### PR TITLE
Initialise sin_zero field

### DIFF
--- a/src/osal/linux/osal_udp.c
+++ b/src/osal/linux/osal_udp.c
@@ -42,6 +42,7 @@ int os_udp_open(os_ipaddr_t addr, os_ipport_t port)
          .sin_family = AF_INET,
          .sin_addr.s_addr = htonl(addr),
          .sin_port = htons(port),
+         .sin_zero = { 0 },
       };
       ret = bind(id, (struct sockaddr *)&local, sizeof(local));
       if(ret != 0)
@@ -71,6 +72,7 @@ int os_udp_sendto(uint32_t id,
       .sin_family = AF_INET,
       .sin_addr.s_addr = htonl(dst_addr),
       .sin_port = htons(dst_port),
+      .sin_zero = { 0 },
    };
    len = sendto(id, data, size, 0, (struct sockaddr *)&remote, sizeof(remote));
 


### PR DESCRIPTION
Initialise the sin_zero field to avoid compiler warnings on some
architectures. Also, not setting sin_zero may cause undefined
behaviour on some architectures.

Fix #2.

Change-Id: I72b5667c59f480ab948a50695e34792dadb8e84f