### PR TITLE
OSAL improvements

### DIFF
--- a/src/osal/linux/osal.c
+++ b/src/osal/linux/osal.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <signal.h>
+#include <limits.h>
 
 #include <pthread.h>
 
@@ -32,22 +33,13 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <sys/syscall.h>
+
 /* Priority of timer callback thread (if USE_SCHED_FIFO is set) */
-#define TIMER_PRIO        30
+#define TIMER_PRIO        5
 
 #define USECS_PER_SEC     (1 * 1000 * 1000)
 #define NSECS_PER_SEC     (1 * 1000 * 1000 * 1000)
-
-int os_snprintf(char * str, size_t size, const char * fmt, ...)
-{
-   int ret;
-   va_list list;
-
-   va_start (list, fmt);
-   ret = snprintf (str, size, fmt, list);
-   va_end (list);
-   return ret;
-}
 
 void os_log (int type, const char * fmt, ...)
 {
@@ -81,6 +73,7 @@ os_thread_t * os_thread_create (const char * name, int priority,
    pthread_attr_t attr;
 
    pthread_attr_init (&attr);
+   pthread_attr_setstacksize (&attr, PTHREAD_STACK_MIN + stacksize);
 
 #if defined (USE_SCHED_FIFO)
    CC_STATIC_ASSERT (_POSIX_THREAD_PRIORITY_SCHEDULING > 0);
@@ -89,8 +82,6 @@ os_thread_t * os_thread_create (const char * name, int priority,
    pthread_attr_setschedpolicy (&attr, SCHED_FIFO);
    pthread_attr_setschedparam (&attr, &param);
 #endif
-
-   /* Note that the default stacksize is used */
 
    result = pthread_create (thread, &attr, (void *)entry, arg);
    if (result != 0)
@@ -139,11 +130,14 @@ void os_mutex_destroy (os_mutex_t * _mutex)
 os_sem_t * os_sem_create (size_t count)
 {
    os_sem_t * sem;
+   pthread_mutexattr_t attr;
 
    sem = (os_sem_t *)malloc (sizeof(*sem));
 
    pthread_cond_init (&sem->cond, NULL);
-   pthread_mutex_init (&sem->mutex, NULL);
+   pthread_mutexattr_init (&attr);
+   pthread_mutexattr_setprotocol (&attr, PTHREAD_PRIO_INHERIT);
+   pthread_mutex_init (&sem->mutex, &attr);
    sem->count = count;
 
    return sem;
@@ -209,9 +203,10 @@ void os_usleep (uint32_t usec)
 {
    struct timespec ts;
    struct timespec remain;
+
    ts.tv_sec = usec / USECS_PER_SEC;
    ts.tv_nsec = (usec % USECS_PER_SEC) * 1000;
-   while (nanosleep (&ts, &remain) == -1)
+   while (clock_nanosleep (CLOCK_MONOTONIC, 0, &ts, &remain) == -1)
    {
       ts = remain;
    }
@@ -228,11 +223,14 @@ uint32_t os_get_current_time_us (void)
 os_event_t * os_event_create (void)
 {
    os_event_t * event;
+   pthread_mutexattr_t attr;
 
    event = (os_event_t *)malloc (sizeof(*event));
 
    pthread_cond_init (&event->cond, NULL);
-   pthread_mutex_init (&event->mutex, NULL);
+   pthread_mutexattr_init (&attr);
+   pthread_mutexattr_setprotocol (&attr, PTHREAD_PRIO_INHERIT);
+   pthread_mutex_init (&event->mutex, &attr);
    event->flags = 0;
 
    return event;
@@ -305,11 +303,14 @@ void os_event_destroy (os_event_t * event)
 os_mbox_t * os_mbox_create (size_t size)
 {
    os_mbox_t * mbox;
+   pthread_mutexattr_t attr;
 
    mbox = (os_mbox_t *)malloc (sizeof(*mbox) + size * sizeof(void *));
 
    pthread_cond_init (&mbox->cond, NULL);
-   pthread_mutex_init (&mbox->mutex, NULL);
+   pthread_mutexattr_init (&attr);
+   pthread_mutexattr_setprotocol (&attr, PTHREAD_PRIO_INHERIT);
+   pthread_mutex_init (&mbox->mutex, &attr);
 
    mbox->r     = 0;
    mbox->w     = 0;
@@ -422,12 +423,32 @@ void os_mbox_destroy (os_mbox_t * mbox)
    free (mbox);
 }
 
-static void os_timer_callback (union sigval sv)
+static void os_timer_thread (void * arg)
 {
-   os_timer_t * timer = sv.sival_ptr;
+   os_timer_t * timer = arg;
+   sigset_t sigset;
+   siginfo_t si;
+   struct timespec tmo;
 
-   if (timer->fn)
-      timer->fn (timer, timer->arg);
+   timer->thread_id = (pid_t)syscall (SYS_gettid);
+
+   /* Add SIGALRM */
+   sigemptyset (&sigset);
+   sigprocmask (SIG_BLOCK, &sigset, NULL);
+   sigaddset(&sigset, SIGALRM);
+
+   tmo.tv_sec = 0;
+   tmo.tv_nsec = 500 * 1000 * 1000;
+
+   while (!timer->exit)
+   {
+      int sig = sigtimedwait (&sigset, &si, &tmo);
+      if (sig == SIGALRM)
+      {
+         if (timer->fn)
+            timer->fn (timer, timer->arg);
+      }
+   }
 }
 
 os_timer_t * os_timer_create (uint32_t us, void (*fn) (os_timer_t *, void * arg),
@@ -435,29 +456,40 @@ os_timer_t * os_timer_create (uint32_t us, void (*fn) (os_timer_t *, void * arg)
 {
    os_timer_t * timer;
    struct sigevent sev;
-   pthread_attr_t attr;
+   sigset_t sigset;
+
+   /* Block SIGALRM in calling thread */
+   sigemptyset (&sigset);
+   sigaddset (&sigset, SIGALRM);
+   sigprocmask (SIG_BLOCK, &sigset, NULL);
 
    timer = (os_timer_t *)malloc (sizeof(*timer));
 
-   timer->fn = fn;
-   timer->arg = arg;
-   timer->us = us;
-   timer->oneshot = oneshot;
+   timer->exit      = false;
+   timer->thread_id = 0;
+   timer->fn        = fn;
+   timer->arg       = arg;
+   timer->us        = us;
+   timer->oneshot   = oneshot;
 
-   pthread_attr_init (&attr);
+   /* Create timer thread */
+   timer->thread = os_thread_create ("os_timer", TIMER_PRIO, 1024,
+                                     os_timer_thread,timer);
+   if (timer->thread == NULL)
+      return NULL;
 
-#if defined (USE_SCHED_FIFO)
-   struct sched_param param = { .sched_priority = TIMER_PRIO };
-   pthread_attr_setinheritsched (&attr, PTHREAD_EXPLICIT_SCHED);
-   pthread_attr_setschedpolicy (&attr, SCHED_FIFO);
-   pthread_attr_setschedparam (&attr, &param);
-#endif
+   /* Wait until timer thread sets its (kernel) thread id */
+   do
+   {
+      sched_yield();
+   } while (timer->thread_id == 0);
 
    /* Create timer */
-   sev.sigev_notify = SIGEV_THREAD;
+   sev.sigev_notify = SIGEV_THREAD_ID;
    sev.sigev_value.sival_ptr = timer;
-   sev.sigev_notify_function = os_timer_callback;
-   sev.sigev_notify_attributes = &attr;
+   sev._sigev_un._tid = timer->thread_id;
+   sev.sigev_signo = SIGALRM;
+   sev.sigev_notify_attributes = NULL;
 
    if (timer_create (CLOCK_MONOTONIC, &sev, &timer->timerid) == -1)
       return NULL;
@@ -496,6 +528,8 @@ void os_timer_stop (os_timer_t * timer)
 
 void os_timer_destroy (os_timer_t * timer)
 {
+   timer->exit = true;
+   pthread_join (*timer->thread, NULL);
    timer_delete (timer->timerid);
    free (timer);
 }

--- a/src/osal/linux/osal_sys.h
+++ b/src/osal/linux/osal_sys.h
@@ -21,14 +21,12 @@ extern "C"
 {
 #endif
 
-#include <cc.h>
 #include <pthread.h>
 #include <time.h>
 #include <netinet/in.h>
 
 #define OS_THREAD
 #define OS_MUTEX
-#define OS_CHANNEL
 #define OS_SEM
 #define OS_EVENT
 #define OS_MBOX
@@ -36,28 +34,24 @@ extern "C"
 
 #define OS_BUF_MAX_SIZE 1522
 
-typedef struct
-{
-   int handle;
-   void (*callback) (void * arg);
-   void * arg;
-} os_channel_t;
+typedef pthread_t os_thread_t;
+typedef pthread_mutex_t os_mutex_t;
 
-struct os_sem
+typedef struct os_sem
 {
    pthread_cond_t cond;
    pthread_mutex_t mutex;
    size_t count;
-};
+} os_sem_t;
 
-struct os_event
+typedef struct os_event
 {
    pthread_cond_t cond;
    pthread_mutex_t mutex;
    uint32_t flags;
-};
+} os_event_t;
 
-struct os_mbox
+typedef struct os_mbox
 {
    pthread_cond_t cond;
    pthread_mutex_t mutex;
@@ -66,30 +60,25 @@ struct os_mbox
    size_t count;
    size_t size;
    void * msg[];
-};
+} os_mbox_t;
 
-struct os_timer
+typedef struct os_timer
 {
    timer_t timerid;
+   os_thread_t * thread;
+   pid_t thread_id;
+   bool exit;
    void(*fn) (struct os_timer *, void * arg);
    void * arg;
    uint32_t us;
    bool oneshot;
-};
+} os_timer_t;
 
-struct os_buf
+typedef struct os_buf
 {
    void * payload;
    uint16_t len;
-};
-
-typedef pthread_mutex_t os_mutex_t;
-typedef pthread_t os_thread_t;
-typedef struct os_sem os_sem_t;
-typedef struct os_event os_event_t;
-typedef struct os_mbox os_mbox_t;
-typedef struct os_timer os_timer_t;
-typedef struct os_buf os_buf_t;
+} os_buf_t;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Use (the linux-specific and fairly undocumented) SIGEV_THREAD_ID to
avoid creating a thread whenever a timer fires.

Set PRIO_INHERIT on all mutexes.

Use clock_nanosleep and CLOCK_MONOTONIC for usleep().

Set stacksize on threads.
