### PR TITLE
Fix error code values sent by p-net

### DIFF
--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -2768,7 +2768,7 @@ static int pf_cmdev_exp_submodule_configure(
                   pf_set_error(p_stat, PNET_ERROR_CODE_CONNECT, PNET_ERROR_DECODE_PNIO, PNET_ERROR_CODE_1_CONN_FAULTY_EXP_BLOCK_REQ, 15);
                   ret = -1;
                }
-               else if (p_exp_sub->data_descriptor[data_ix].length_iops != 1)
+               else if (p_exp_sub->data_descriptor[data_ix].length_iocs != 1)
                {
                   pf_set_error(p_stat, PNET_ERROR_CODE_CONNECT, PNET_ERROR_DECODE_PNIO, PNET_ERROR_CODE_1_CONN_FAULTY_EXP_BLOCK_REQ, 16);
                   ret = -1;

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -1742,7 +1742,7 @@ static int pf_cmrpc_perform_one_write(
 
    if (pf_ar_find_by_uuid(net, &p_write_request->ar_uuid, &p_ar) != 0)
    {
-      pf_set_error(p_stat, PNET_ERROR_CODE_READ, PNET_ERROR_DECODE_PNIO, PNET_ERROR_CODE_1_CMRPC, PNET_ERROR_CODE_2_CMRPC_AR_UUID_UNKNOWN);
+      pf_set_error(p_stat, PNET_ERROR_CODE_WRITE, PNET_ERROR_DECODE_PNIO, PNET_ERROR_CODE_1_CMRPC, PNET_ERROR_CODE_2_CMRPC_AR_UUID_UNKNOWN);
    }
    else if ((p_write_request->api != 0) &&
             (pf_cmdev_get_api(net, p_write_request->api, &p_api) != 0))


### PR DESCRIPTION
The check of the UUID in incoming write request (in pf_cmrpc.c) is
corrected to Profinet 2.4 section 5.2.7 and 5.2.40.10.2

Check of IOCS field length (in pf_cmdev.c) is corrected to
Profinet 2.4 section 5.2.4.2.5

Closes #50