### PR TITLE
Release session after implicit read, and implement ping 

### DIFF
--- a/src/device/pf_block_reader.h
+++ b/src/device/pf_block_reader.h
@@ -46,6 +46,12 @@ uint16_t pf_get_uint16(
 
 /**
  * Extract a NDR header from a buffer.
+ *
+ * This is the first part of the payload of the incoming DCE/RPC message
+ * (which is sent via UDP).
+ *
+ * Reads args_maximum, args_length, maximum_count, offset and actual_count.
+ *
  * @param p_info           In:   The parser state.
  * @param p_pos            InOut:Position in the buffer.
  * @param p_ndr            Out:  Destination buffer.
@@ -183,7 +189,7 @@ void pf_get_ir_info_request(
 
 /**
  * Extract a DCE RPC header from a raw UDP data buffer.
- * @param p_info           In:   The parser information.
+ * @param p_info           InOut:The parser information. Sets p_info->is_big_endian
  * @param p_pos            InOut:The current parsing position.
  * @param p_rpc            Out:  Destination struture.
  */

--- a/src/osal/linux/set_network_parameters
+++ b/src/osal/linux/set_network_parameters
@@ -56,9 +56,13 @@ if ! ip link set dev $INTERFACE up; then
    exit 1
 fi
 
-if ! ip route add default via $DEFAULT_GATEWAY; then
-   echo "Failed to set default gateway"
-   exit 1
+if [ "${DEFAULT_GATEWAY}" != "0.0.0.0" ]; then
+   if ! ip route add default via $DEFAULT_GATEWAY; then
+      echo "Failed to set default gateway"
+      exit 1
+   fi
+else
+   echo "No valid default gateway given. Skipping."
 fi
 
 if ! hostname $HOSTNAME; then


### PR DESCRIPTION
When doing a remote change of IP-address or name, a session is
created. Close the session immediately after an implicit read,
as there is no info wheter the session ever will be used again.

There might also be incoming RPC ping requests when changing
the IP-address. Handle those.

Improve logging and documentation.

Also the Linux script for changing the IP address etc should be
able to handle invalid (not set) default gatway.

Closes #54