### PR TITLE
Defines for LLDP settings

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1038,6 +1038,33 @@ typedef struct pnet_ethaddr
   uint8_t addr[6];
 } pnet_ethaddr_t;
 
+/* LLDP Autonegotiation */
+#define PNET_LLDP_AUTONEG_SUPPORTED                            (1u << 0)
+#define PNET_LLDP_AUTONEG_ENABLED                              (1u << 1)
+
+/* LLDP Autonegotiation capabilities (not exhaustive) */
+#define PNET_LLDP_AUTONEG_CAP_1000BaseT_FULL_DUPLEX            (1ul << 0)
+#define PNET_LLDP_AUTONEG_CAP_1000BaseT_HALF_DUPLEX            (1ul << 1)
+#define PNET_LLDP_AUTONEG_CAP_1000BaseX_FULL_DUPLEX            (1ul << 2)
+#define PNET_LLDP_AUTONEG_CAP_1000BaseX_HALF_DUPLEX            (1ul << 3)
+#define PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX            (1ul << 10)
+#define PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX            (1ul << 11)
+#define PNET_LLDP_AUTONEG_CAP_10BaseT_FULL_DUPLEX              (1ul << 13)
+#define PNET_LLDP_AUTONEG_CAP_10BaseT_HALF_DUPLEX              (1ul << 14)
+#define PNET_LLDP_AUTONEG_CAP_UNKNOWN                          (1ul << 15)
+
+/* LLDP MAU type (not exhaustive). See Profinet 2.4, section 5.2.13.12 */
+#define PNET_MAU_RADIO                                         0x0000
+#define PNET_MAU_COPPER_10BaseT                                0x0005
+#define PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX                  0x000F
+#define PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX                  0x0010
+#define PNET_MAU_COPPER_1000BaseT_HALF_DUPLEX                  0x001D
+#define PNET_MAU_COPPER_1000BaseT_FULL_DUPLEX                  0x001E
+#define PNET_MAU_FIBER_100BaseFX_HALF_DUPLEX                   0x0011
+#define PNET_MAU_FIBER_100BaseFX_FULL_DUPLEX                   0x0012
+#define PNET_MAU_FIBER_1000BaseX_HALF_DUPLEX                   0x0015
+#define PNET_MAU_FIBER_1000BaseX_FULL_DUPLEX                   0x0016
+
 /**
  * LLDP information used by the Profinet stack.
  */

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -690,9 +690,11 @@ int app_adjust_stack_configuration(
    stack_config->lldp_cfg.ttl = 20;                /* seconds */
    stack_config->lldp_cfg.rtclass_2_status = 0;
    stack_config->lldp_cfg.rtclass_3_status = 0;
-   stack_config->lldp_cfg.cap_aneg = 3;            /* Supported (0x01) + enabled (0x02) */
-   stack_config->lldp_cfg.cap_phy = 0x0C00;        /* 100BASE-TX half and full duplex mode capable */
-   stack_config->lldp_cfg.mau_type = 0x0010;       /* Default (copper): 100BaseTXFD */
+   stack_config->lldp_cfg.cap_aneg = PNET_LLDP_AUTONEG_SUPPORTED |
+                                     PNET_LLDP_AUTONEG_ENABLED;
+   stack_config->lldp_cfg.cap_phy = PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
+                                    PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX;
+   stack_config->lldp_cfg.mau_type = PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
 
    /* Network configuration */
    stack_config->send_hello = 1;


### PR DESCRIPTION
Add defines for the different LLDP settings, to help end users.

Note that there are a few lower case letters in the defines to increase readability. However it is still obvious that they are defines.