### PR TITLE
Implement fragmented DCE RPC responses

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -101,6 +101,7 @@ extern "C"
 
 #define PNET_MAX_MAN_SPECIFIC_FAST_STARTUP_DATA_LENGTH         0     /**< or 512 (bytes) */
 
+#define PNET_MAX_SESSION_BUFFER_SIZE                           4500  /**< Max fragmented RPC request/response length */
 /**
  * # GSDML
  * The following values are application-specific and should match what

--- a/src/common/pf_cpm.h
+++ b/src/common/pf_cpm.h
@@ -101,7 +101,7 @@ int pf_cpm_get_iocs(
 /**
  * Retrieve the specified sub-slot data and IOPS received from the controller.
  * User must supply a buffer large enough to hold the received data.
- * Maximum buffer size is 1500 bytes.
+ * Maximum buffer size is PF_FRAME_BUFFER_SIZE (1500) bytes.
  * User must supply a buffer large enough to hold the received IOPS.
  * Maximum buffer size is 256 bytes.
  *

--- a/src/device/pf_block_reader.c
+++ b/src/device/pf_block_reader.c
@@ -127,13 +127,7 @@ uint16_t pf_get_uint16(
    return res;
 }
 
-/**
- * @internal
- * Return a uint16_t from a buffer.
- * @param p_info           In:   The parser state.
- * @param p_pos            InOut:Position in the buffer.
- */
-static uint32_t pf_get_uint32(
+uint32_t pf_get_uint32(
    pf_get_info_t           *p_info,
    uint16_t                *p_pos)
 {
@@ -627,6 +621,7 @@ void pf_get_dce_rpc_header(
 
    p_rpc->version = pf_get_byte(p_info, p_pos);
    p_rpc->packet_type = pf_get_byte(p_info, p_pos) & 0x1f;  /* Only 5 LSB according to spec */
+
    /* flags */
    temp_uint8 = pf_get_byte(p_info, p_pos);
    p_rpc->flags.last_fragment = pf_get_bits(temp_uint8, PF_RPC_F_LAST_FRAGMENT, 1);
@@ -635,15 +630,20 @@ void pf_get_dce_rpc_header(
    p_rpc->flags.maybe = pf_get_bits(temp_uint8, PF_RPC_F_MAYBE, 1);
    p_rpc->flags.idempotent = pf_get_bits(temp_uint8, PF_RPC_F_IDEMPOTENT, 1);
    p_rpc->flags.broadcast = pf_get_bits(temp_uint8, PF_RPC_F_BROADCAST, 1);
+
    /* flags2 */
    temp_uint8 = pf_get_byte(p_info, p_pos);
    p_rpc->flags2.cancel_pending = pf_get_bits(temp_uint8, PF_RPC_F2_CANCEL_PENDING, 1);
+
    /* Data repr */
    temp_uint8 = pf_get_byte(p_info, p_pos);
    p_rpc->is_big_endian = (pf_get_bits(temp_uint8, 4, 4) == 0);
    p_info->is_big_endian = p_rpc->is_big_endian;
+
    /* Float repr  - Assume IEEE */
    temp_uint8 = pf_get_byte(p_info, p_pos);
+   p_rpc->float_repr = 0;
+
    /* Reserved */
    p_rpc->reserved = pf_get_byte(p_info, p_pos);
 

--- a/src/device/pf_block_reader.h
+++ b/src/device/pf_block_reader.h
@@ -45,6 +45,16 @@ uint16_t pf_get_uint16(
    uint16_t                *p_pos);
 
 /**
+ * @internal
+ * Return a uint32_t from a buffer.
+ * @param p_info           In:   The parser state.
+ * @param p_pos            InOut:Position in the buffer.
+ */
+uint32_t pf_get_uint32(
+   pf_get_info_t           *p_info,
+   uint16_t                *p_pos);
+
+/**
  * Extract a NDR header from a buffer.
  *
  * This is the first part of the payload of the incoming DCE/RPC message

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -1191,7 +1191,8 @@ int pf_cmdev_cm_abort(
    }
    else
    {
-      LOG_ERROR(PNET_LOG, "CMDEV(%d): pf_cmdev_cm_abort_req: p_ar is NULL\n", __LINE__);
+      /* p_ar may be NULL when handling controller induced aborts */
+      LOG_INFO(PNET_LOG, "CMDEV(%d): pf_cmdev_cm_abort_req: p_ar is NULL\n", __LINE__);
    }
 
    /* cm_abort_cnf */

--- a/src/device/pf_cmdev.h
+++ b/src/device/pf_cmdev.h
@@ -160,7 +160,7 @@ int pf_cmdev_pull_module(
    uint16_t                slot_nbr);
 
 /**
- * Abort request from the application.
+ * Abort request from the application or from RPC.
  * @param net              InOut: The p-net stack instance
  * @param p_ar             In:   The AR instance.
  * @return  0  if operation succeeded.

--- a/src/device/pf_cmrdr.c
+++ b/src/device/pf_cmrdr.c
@@ -51,7 +51,7 @@ int pf_cmrdr_rm_read_ind(
    uint16_t                start_pos = 0;
    uint8_t                 iocs[255];              /* Max possible array size */
    uint8_t                 iops[255];              /* Max possible array size */
-   uint8_t                 subslot_data[1500];     /* Max possible array size */
+   uint8_t                 subslot_data[PF_FRAME_BUFFER_SIZE];     /* Max possible array size */
    uint8_t                 iocs_len = 0;
    uint8_t                 iops_len = 0;
    uint16_t                data_len = 0;


### PR DESCRIPTION
This allows larger responses, which is required when using more slots.

Closes #34
Closes #42