### PR TITLE
Turn off more of the start-up printouts when not verbose

### DIFF
--- a/sample_app/main_linux.c
+++ b/sample_app/main_linux.c
@@ -386,7 +386,10 @@ void pn_main (void * arg)
          os_event_clr(p_appdata->main_events, EVENT_READY_FOR_DATA); /* Re-arm */
 
          /* Send appl ready to profinet stack. */
-         printf("Application will signal that it is ready for data.\n");
+         if (p_appdata->arguments.verbosity > 0)
+         {
+            printf("Application will signal that it is ready for data.\n");
+         }
          ret = pnet_application_ready(net, p_appdata->main_arep);
          if (ret != 0)
          {

--- a/sample_app/main_rtk.c
+++ b/sample_app/main_rtk.c
@@ -243,7 +243,10 @@ int main(void)
       if (flags & EVENT_READY_FOR_DATA)
       {
          os_event_clr(appdata.main_events, EVENT_READY_FOR_DATA); /* Re-arm */
-         printf("Application will signal that it is ready for data.\n");
+         if (appdata.arguments.verbosity > 0)
+         {
+            printf("Application will signal that it is ready for data.\n");
+         }
          ret = pnet_application_ready(g_net, appdata.main_arep);
          if (ret != 0)
          {

--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -140,6 +140,22 @@ typedef struct app_data_and_stack_obj
 int app_adjust_stack_configuration(
    pnet_cfg_t              *stack_config);
 
+/**
+ * Return a string representation of the given event.
+ * @param event            In:   The event.
+ * @return  A string representing the event.
+ */
+const char* event_value_to_string(
+   pnet_event_values_t event);
+
+/**
+ * Return a string representation of the submodule data direction.
+ * @param direction        In:   The direction.
+ * @return  A string representing the direction.
+ */
+const char* submodule_direction_to_string(
+   pnet_submodule_dir_t direction);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fine tune the print-outs in the sample app, to ease understanding of the startup.

Implement helper functions for user-facing enums.
Use the pattern for enum-to-string conversion found for many non-user facing enums.

