### PR TITLE
Fix potential NULL pointers

### DIFF
--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -915,11 +915,12 @@ static int pf_alarm_apms_a_data_req(
             }
             else if (p_fixed->pdu_type.type == PF_RTA_PDU_TYPE_ERR)
             {
+               CC_ASSERT(p_pnio_status != NULL);
                pf_put_pnet_status(true, p_pnio_status, PF_FRAME_BUFFER_SIZE, p_buf, &pos);
             }
             else
             {
-               /* NACK or ACk does not take any var part. */
+               /* NACK or ACK does not take any var part. */
             }
 
             /* Finally insert the correct VarPartLen */
@@ -979,7 +980,7 @@ static int pf_alarm_apms_a_data_req(
  * @param payload_usi      In:   May be 0.
  * @param payload_len      In:   Payload length. Mandatory id payload_usi != 0.
  * @param p_payload        In:   Mandatory if payload_len > 0.
- * @param p_pnio_status    Out:  Mandatory. Detailed error information.
+ * @param p_pnio_status    Out:  Optional. Detailed error information.
  * @return
  */
 static int pf_alarm_apms_apms_a_data_req(
@@ -999,8 +1000,6 @@ static int pf_alarm_apms_apms_a_data_req(
 
    if (p_apmx->apms_state != PF_APMS_STATE_OPEN)
    {
-      p_pnio_status->error_code_1 = PNET_ERROR_CODE_1_APMS;
-      p_pnio_status->error_code_2 = PNET_ERROR_CODE_2_APMS_INVALID_STATE;
       pf_alarm_alpmi_apms_a_data_cnf(net, p_apmx, -1);
       pf_alarm_alpmr_apms_a_data_cnf(net, p_apmx, -1);
    }
@@ -1748,7 +1747,6 @@ int pf_alarm_alpmr_alarm_ack(
  * @param payload_usi      In:   The USI of the payload.
  * @param payload_len      In:   The length of the payload (is usi < 0x8000).
  * @param p_payload        In:   The payload data (if usi < 0x8000).
- * @param p_result         Out:  Detailed error information (may be NULL).
  * @return  0  if operation succeeded.
  *          -1 if an error occurred (or waiting for ACK from controller: re-try later).
  */
@@ -1766,8 +1764,7 @@ static int pf_alarm_send_alarm(
    uint32_t                submodule_ident,
    uint16_t                payload_usi,
    uint16_t                payload_len,
-   uint8_t                 *p_payload,
-   pnet_result_t           *p_result)
+   uint8_t                 *p_payload)
 {
    int                     ret = -1;
    pf_alarm_data_t         alarm_data;
@@ -1799,7 +1796,7 @@ static int pf_alarm_send_alarm(
             &alarm_data,
             maint_status,
             payload_usi, payload_len, p_payload,
-            (p_result != NULL) ? &p_result->pnio_status : NULL);
+            NULL);
 
          p_alpmx->alpmi_state = PF_ALPMI_STATE_W_ACK;
       }
@@ -1834,8 +1831,7 @@ int pf_alarm_send_process(
       api_id, slot_nbr, subslot_nbr,
       NULL,       /* p_diag_item */
       0, 0,       /* module_ident, submodule_ident */
-      payload_usi, payload_len, p_payload,
-      NULL);      /* p_result */
+      payload_usi, payload_len, p_payload);
 }
 
 int pf_alarm_send_diagnosis(
@@ -1856,8 +1852,7 @@ int pf_alarm_send_diagnosis(
          api_id, slot_nbr, subslot_nbr,
          p_diag_item,
          0, 0,       /* module_ident, submodule_ident */
-         p_diag_item->usi, sizeof(*p_diag_item), (uint8_t *)p_diag_item,
-         NULL);      /* p_result */
+         p_diag_item->usi, sizeof(*p_diag_item), (uint8_t *)p_diag_item);
    }
 
    return ret;
@@ -1894,8 +1889,7 @@ int pf_alarm_send_pull(
       api_id, slot_nbr, subslot_nbr,
       NULL,       /* p_diag_item */
       0, 0,       /* module_ident, submodule_ident */
-      0, 0, NULL, /* payload_usi, payload_len, p_payload, */
-      NULL);      /* p_result */
+      0, 0, NULL); /* payload_usi, payload_len, p_payload */
 
    return 0;
 }
@@ -1916,8 +1910,7 @@ int pf_alarm_send_plug(
       api_id, slot_nbr, subslot_nbr,
       NULL,       /* p_diag_item */
       module_ident, submodule_ident,
-      0, 0, NULL, /* payload_usi, payload_len, p_payload, */
-      NULL);      /* p_result */
+      0, 0, NULL); /* payload_usi, payload_len, p_payload */
 
    return 0;
 }
@@ -1938,8 +1931,8 @@ int pf_alarm_send_plug_wrong(
       api_id, slot_nbr, subslot_nbr,
       NULL,       /* p_diag_item */
       module_ident, submodule_ident,
-      0, 0, NULL, /* payload_usi, payload_len, p_payload, */
-      NULL);      /* p_result */
+      0, 0, NULL); /* payload_usi, payload_len, p_payload */
+
 
    return 0;
 }

--- a/src/device/pf_cmsm.c
+++ b/src/device/pf_cmsm.c
@@ -96,7 +96,7 @@ static void pf_cmsm_set_state(
    pf_ar_t                 *p_ar,
    pf_cmsm_state_values_t  state)
 {
-   assert(p_ar != NULL);
+   CC_ASSERT(p_ar != NULL);
 
    if (state != p_ar->cmsm_state)
    {
@@ -121,7 +121,7 @@ static void pf_cmsm_timeout(
    void                    *arg,
    uint32_t                current_time)
 {
-   assert(arg != NULL);
+   CC_ASSERT(arg != NULL);
    pf_ar_t                 *p_ar = (pf_ar_t *)arg;
 
    p_ar->cmsm_timer = UINT32_MAX;

--- a/src/osal/linux/osal.c
+++ b/src/osal/linux/osal.c
@@ -71,6 +71,11 @@ os_thread_t * os_thread_create (const char * name, int priority,
 {
    int result;
    pthread_t * thread = malloc (sizeof(*thread));
+   if (thread == NULL)
+   {
+      return NULL;
+   }
+
    pthread_attr_t attr;
 
    pthread_attr_init (&attr);
@@ -86,7 +91,10 @@ os_thread_t * os_thread_create (const char * name, int priority,
 
    result = pthread_create (thread, &attr, (void *)entry, arg);
    if (result != 0)
+   {
+      free(thread);
       return NULL;
+   }
 
    pthread_setname_np (*thread, name);
    return thread;
@@ -96,6 +104,11 @@ os_mutex_t * os_mutex_create (void)
 {
    int result;
    pthread_mutex_t * mutex = malloc (sizeof(*mutex));
+   if (mutex == NULL)
+   {
+      return NULL;
+   }
+
    pthread_mutexattr_t attr;
 
    CC_STATIC_ASSERT (_POSIX_THREAD_PRIO_INHERIT > 0);
@@ -104,7 +117,10 @@ os_mutex_t * os_mutex_create (void)
 
    result = pthread_mutex_init (mutex, &attr);
    if (result != 0)
+   {
+      free(mutex);
       return NULL;
+   }
 
    return mutex;
 }
@@ -134,6 +150,10 @@ os_sem_t * os_sem_create (size_t count)
    pthread_mutexattr_t attr;
 
    sem = (os_sem_t *)malloc (sizeof(*sem));
+   if (sem == NULL)
+   {
+      return NULL;
+   }
 
    pthread_cond_init (&sem->cond, NULL);
    pthread_mutexattr_init (&attr);
@@ -227,6 +247,10 @@ os_event_t * os_event_create (void)
    pthread_mutexattr_t attr;
 
    event = (os_event_t *)malloc (sizeof(*event));
+   if (event == NULL)
+   {
+      return NULL;
+   }
 
    pthread_cond_init (&event->cond, NULL);
    pthread_mutexattr_init (&attr);
@@ -307,6 +331,10 @@ os_mbox_t * os_mbox_create (size_t size)
    pthread_mutexattr_t attr;
 
    mbox = (os_mbox_t *)malloc (sizeof(*mbox) + size * sizeof(void *));
+   if (mbox == NULL)
+   {
+      return NULL;
+   }
 
    pthread_cond_init (&mbox->cond, NULL);
    pthread_mutexattr_init (&attr);
@@ -465,6 +493,10 @@ os_timer_t * os_timer_create (uint32_t us, void (*fn) (os_timer_t *, void * arg)
    sigprocmask (SIG_BLOCK, &sigset, NULL);
 
    timer = (os_timer_t *)malloc (sizeof(*timer));
+   if (timer == NULL)
+   {
+      return NULL;
+   }
 
    timer->exit      = false;
    timer->thread_id = 0;
@@ -477,7 +509,10 @@ os_timer_t * os_timer_create (uint32_t us, void (*fn) (os_timer_t *, void * arg)
    timer->thread = os_thread_create ("os_timer", TIMER_PRIO, 1024,
                                      os_timer_thread,timer);
    if (timer->thread == NULL)
+   {
+      free(timer);
       return NULL;
+   }
 
    /* Wait until timer thread sets its (kernel) thread id */
    do
@@ -493,7 +528,10 @@ os_timer_t * os_timer_create (uint32_t us, void (*fn) (os_timer_t *, void * arg)
    sev.sigev_notify_attributes = NULL;
 
    if (timer_create (CLOCK_MONOTONIC, &sev, &timer->timerid) == -1)
+   {
+      free(timer);
       return NULL;
+   }
 
    return timer;
 }


### PR DESCRIPTION
Handle malloc failure and resulting memory leak and/or NULL pointer
dereferencing in src/osal/linux/osal.c

Handle possible NULL pointer dereferencing in pf_alarm.c

Found with clang-scan.