### PR TITLE
Implement fragmented request for CControl

### DIFF
--- a/src/device/pf_cmrpc.h
+++ b/src/device/pf_cmrpc.h
@@ -102,6 +102,9 @@ int pf_cmrpc_cmdev_state_ind(
 /**
  * Send a DCE RPC request to the controller.
  * The only request handled is the APPL_RDY request.
+ *
+ * Opens a new UDP socket for the session.
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_ar             In:   The AR instance.
  * @return  0  if operation succeeded.

--- a/src/osal.h
+++ b/src/osal.h
@@ -94,9 +94,6 @@ enum os_eth_type {
   OS_ETHTYPE_LLDP      = 0x88CCU,
 };
 
-#define OS_PF_RPC_SERVER_PORT    0x8894 /* PROFInet Context Manager */
-#define OS_PF_SNMP_SERVER_PORT   161 /* snmp */
-
 /* 255.255.255.255 */
 #ifndef OS_IPADDR_NONE
 #define OS_IPADDR_NONE         ((uint32_t)0xffffffffUL)
@@ -184,7 +181,6 @@ os_eth_handle_t* os_eth_init(
    os_eth_callback_t       *callback,
    void                    *arg);
 
-int os_udp_socket(void);
 int os_udp_open(os_ipaddr_t addr, os_ipport_t port);
 int os_udp_sendto(uint32_t id,
       os_ipaddr_t dst_addr,
@@ -192,8 +188,8 @@ int os_udp_sendto(uint32_t id,
       const uint8_t * data,
       int size);
 int os_udp_recvfrom(uint32_t id,
-      os_ipaddr_t *dst_addr,
-      os_ipport_t *dst_port,
+      os_ipaddr_t *src_addr,
+      os_ipport_t *src_port,
       uint8_t * data,
       int size);
 void os_udp_close(uint32_t id);

--- a/src/osal/linux/osal_udp.c
+++ b/src/osal/linux/osal_udp.c
@@ -18,10 +18,6 @@
 #include <stdio.h>
 #include <unistd.h>
 
-int os_udp_socket(void)
-{
-   return socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
-}
 
 int os_udp_open(os_ipaddr_t addr, os_ipport_t port)
 {
@@ -80,8 +76,8 @@ int os_udp_sendto(uint32_t id,
 }
 
 int os_udp_recvfrom(uint32_t id,
-      os_ipaddr_t *dst_addr,
-      os_ipport_t *dst_port,
+      os_ipaddr_t *src_addr,
+      os_ipport_t *src_port,
       uint8_t * data,
       int size)
 {
@@ -93,8 +89,8 @@ int os_udp_recvfrom(uint32_t id,
    len = recvfrom(id, data, size, MSG_DONTWAIT, (struct sockaddr *)&remote, &addr_len);
    if(len > 0)
    {
-      *dst_addr = ntohl(remote.sin_addr.s_addr);
-      *dst_port = ntohs(remote.sin_port);
+      *src_addr = ntohl(remote.sin_addr.s_addr);
+      *src_port = ntohs(remote.sin_port);
    }
 
    return len;

--- a/src/osal/rt-kernel/osal_udp.c
+++ b/src/osal/rt-kernel/osal_udp.c
@@ -16,10 +16,6 @@
 #include <string.h>
 #include "pf_includes.h"
 
-int os_udp_socket(void)
-{
-   return socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
-}
 
 int os_udp_open(os_ipaddr_t addr, os_ipport_t port)
 {
@@ -76,8 +72,8 @@ int os_udp_sendto(uint32_t id,
 }
 
 int os_udp_recvfrom(uint32_t id,
-      os_ipaddr_t *dst_addr,
-      os_ipport_t *dst_port,
+      os_ipaddr_t *src_addr,
+      os_ipport_t *src_port,
       uint8_t * data,
       int size)
 {
@@ -89,8 +85,8 @@ int os_udp_recvfrom(uint32_t id,
    len = recvfrom(id, data, size, MSG_DONTWAIT, (struct sockaddr *)&remote, &addr_len);
    if(len > 0)
    {
-      *dst_addr = ntohl(remote.sin_addr.s_addr);
-      *dst_port = ntohs(remote.sin_port);
+      *src_addr = ntohl(remote.sin_addr.s_addr);
+      *src_port = ntohs(remote.sin_port);
    }
 
    return len;

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -54,6 +54,9 @@ static inline uint32_t atomic_fetch_sub(atomic_int *p, uint32_t v)
 }
 #endif
 
+#define PF_RPC_SERVER_PORT                0x8894   /* PROFInet Context Manager */
+#define PF_RPC_CCONTROL_EPHEMERAL_PORT    0xc001
+
 #define PF_FRAME_BUFFER_SIZE              1500
 
 /** This should be smaller than PF_FRAME_BUFFER_SIZE with the maximum size of
@@ -1517,14 +1520,14 @@ typedef struct pf_session_info
    uint16_t                ix;
    bool                    in_use;
    bool                    release_in_progress;
-   bool                    kill_session;  /* E.g. on error or when done */
+   bool                    kill_session;           /* On error or when done. This will kill the session at the end of handling the incoming RPC frame. */
    uint32_t                socket;
    os_eth_handle_t         *eth_handle;
    struct pf_ar            *p_ar;
-   bool                    from_me;
+   bool                    from_me;                /* True if the session originates from the device. */
    pf_uuid_t               activity_uuid;
    uint32_t                ip_addr;
-   os_ipport_t             port;
+   os_ipport_t             port;                   /* Source port on incoming message, destination port on outgoing message */
    uint32_t                sequence_nmb_send;      /* rm_ccontrol_req */
 
    /*
@@ -1540,7 +1543,7 @@ typedef struct pf_session_info
 
    uint8_t                 out_buffer[PNET_MAX_SESSION_BUFFER_SIZE];       /* Response buffer */
    uint16_t                out_buf_len;
-   uint16_t                out_buf_sent_len;
+   uint16_t                out_buf_sent_len;                               /* Number of bytes sent so far */
    uint16_t                out_fragment_nbr;
 
    pf_get_info_t           get_info;

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -78,13 +78,6 @@ int mock_os_eth_send(
    return p_buf->len;
 }
 
-
-int mock_os_udp_socket(void)
-{
-   int ret = 1;
-   return ret;
-}
-
 int mock_os_udp_open(
    os_ipaddr_t             addr,
    os_ipport_t             port)

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -56,7 +56,6 @@ os_eth_handle_t* mock_os_eth_init(
    void *arg);
 int mock_os_eth_send(os_eth_handle_t *handle, os_buf_t * buf);
 void mock_os_cpy_mac_addr(uint8_t * mac_addr);
-int mock_os_udp_socket(void);
 int mock_os_udp_open(os_ipaddr_t addr, os_ipport_t port);
 int mock_os_udp_sendto(uint32_t id,
       os_ipaddr_t dst_addr,


### PR DESCRIPTION
Move Profinet port definitions from osal.h

Remove the redundant function os_udp_socket() from OSAL.

Correct argument names to os_udp_recvfrom()