### PR TITLE
Plug DAP module during initialization

### DIFF
--- a/sample_app/main_linux.c
+++ b/sample_app/main_linux.c
@@ -662,6 +662,8 @@ int main(int argc, char *argv[])
    appdata_and_stack.appdata = &appdata;
    appdata_and_stack.net = net;
 
+   app_plug_dap(net);
+
    /* Initialize timer and Profinet stack */
    appdata.main_events = os_event_create();
    appdata.main_timer  = os_timer_create(TICK_INTERVAL_US, main_timer_tick, (void*)&appdata, false);

--- a/sample_app/main_rtk.c
+++ b/sample_app/main_rtk.c
@@ -158,9 +158,11 @@ static int _cmd_pnio_run(
    g_net = pnet_init(gp_appdata->arguments.eth_interface, TICK_INTERVAL_US, &pnet_default_cfg);
    if (g_net != NULL)
    {
+      app_plug_dap(g_net);
+
       if (gp_appdata->arguments.verbosity > 0)
       {
-         printf("Station name:        %s\n", gp_appdata->arguments.station_name);
+         printf("\nStation name:        %s\n", gp_appdata->arguments.station_name);
          printf("Initialized p-net application.\n\n");
          printf("Waiting for connect request from IO-controller\n");
       }

--- a/sample_app/main_rtk.c
+++ b/sample_app/main_rtk.c
@@ -120,8 +120,6 @@ static int _cmd_pnio_run(
       int                  argc,
       char                 *argv[])
 {
-   uint16_t                ix;
-
    if (g_net != NULL)
    {
       printf("Already initialized p-net application.\n");
@@ -238,7 +236,6 @@ int main(void)
    bool           button1_pressed = false;
    bool           button2_pressed = false;
    bool           button2_pressed_previous = false;
-   bool           led_state = false;
    bool           received_led_state = false;
    uint32_t       tick_ctr_buttons = 0;
    uint32_t       tick_ctr_update_data = 0;

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -646,6 +646,18 @@ static int app_alarm_ack_cnf(
    return 0;
 }
 
+void app_plug_dap(pnet_t *net)
+{
+   /* Use existing callback functions to plug the (sub-)modules */
+   app_exp_module_ind(net, NULL, APP_API , PNET_SLOT_DAP_IDENT, PNET_MOD_DAP_IDENT);
+
+   app_exp_submodule_ind(net, NULL, APP_API, PNET_SLOT_DAP_IDENT, PNET_SUBMOD_DAP_IDENT,
+         PNET_MOD_DAP_IDENT, PNET_SUBMOD_DAP_IDENT);
+   app_exp_submodule_ind(net, NULL, APP_API, PNET_SLOT_DAP_IDENT, PNET_SUBMOD_DAP_INTERFACE_1_IDENT,
+         PNET_MOD_DAP_IDENT, PNET_SUBMOD_DAP_INTERFACE_1_IDENT);
+   app_exp_submodule_ind(net, NULL, APP_API, PNET_SLOT_DAP_IDENT, PNET_SUBMOD_DAP_INTERFACE_1_PORT_0_IDENT,
+         PNET_MOD_DAP_IDENT, PNET_SUBMOD_DAP_INTERFACE_1_PORT_0_IDENT);
+}
 
 /************ Configuration of product ID, software version etc **************/
 

--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -144,6 +144,17 @@ typedef struct app_data_and_stack_obj
 int app_adjust_stack_configuration(
    pnet_cfg_t              *stack_config);
 
+
+/**
+ * Plug DAP (sub-)modules. This operation shall be called after p-net 
+ * stack initialization
+ *
+ * @param net     In: p-net stack instance
+ * @return  None
+*/
+void app_plug_dap(pnet_t *net);
+
+
 /**
  * Return a string representation of the given event.
  * @param event            In:   The event.

--- a/src/device/pf_cmdev.h
+++ b/src/device/pf_cmdev.h
@@ -58,7 +58,7 @@ typedef int (*pf_ftn_subslot_t)(
       pf_subslot_t         *p_subslot);
 
 /**
- * Initialize the cmdev component. Plugs the DAP (sub-)modules.
+ * Initialize the cmdev component.
  * @param net              InOut: The p-net stack instance
  */
 void pf_cmdev_init(


### PR DESCRIPTION
This update does not implement correct behavior for the im0_filter_data request but the read result is accepted by the automated RT-tester so test does not stop on im0_filter_data. Related tests still not pass for other reasons.

Modules still defined and plugged by sample application.  Possibly the DAP module shall not be defined by the sample application but this may have other implications.
