### PR TITLE
Fix behavior-related issues

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -78,7 +78,7 @@ extern "C"
  * Please note that some defines have minimum requirements.
  * These values are used as is by the stack. No validation is performed.
  */
-#define PNET_MAX_AR                                            1     /**< Number of connections. Must be > 0. */
+#define PNET_MAX_AR                                            2     /**< Number of connections. Must be > 0. "Automated RT Tester" uses 2 */
 #define PNET_MAX_API                                           1     /**< Number of Application Processes. Must be > 0. */
 #define PNET_MAX_CR                                            2     /**< Per AR. 1 input and 1 output. */
 #define PNET_MAX_MODULES                                       5     /**< Per API. Should be > 1 to allow at least one I/O module. */
@@ -381,6 +381,12 @@ extern "C"
 #define PNET_ERROR_CODE_2_ABORT_DCP_STATION_NAME_CHANGED       0x1f
 #define PNET_ERROR_CODE_2_ABORT_DCP_RESET_TO_FACTORY           0x20
 #define PNET_ERROR_CODE_2_ABORT_PDEV_CHECK_FAILED              0x24
+
+/**
+ * # List of error_code_2 values, for
+ * PNET_ERROR_CODE_1_DCTRL_FAULTY_CONNECT (not exhaustive).
+ */
+#define PNET_ERROR_CODE_2_DCTRL_FAULTY_CONNECT_CONTROLCOMMAND  0x08
 
 /**
  * The events are sent from CMDEV to the application using the state_cb call-back function.

--- a/src/common/pf_ppm.c
+++ b/src/common/pf_ppm.c
@@ -460,6 +460,7 @@ int pf_ppm_set_data_and_iops(
       case PF_PPM_STATE_RUN:
          if ((data_len == p_iodata->data_length) && (iops_len == p_iodata->iops_length))
          {
+            CC_ASSERT(net->ppm_buf_lock != NULL);
             os_mutex_lock(net->ppm_buf_lock);
             if (data_len > 0)
             {
@@ -519,6 +520,7 @@ int pf_ppm_set_iocs(
       case PF_PPM_STATE_RUN:
          if (iocs_len == p_iodata->iocs_length)
          {
+            CC_ASSERT(net->ppm_buf_lock != NULL);
             os_mutex_lock(net->ppm_buf_lock);
             memcpy(&p_iocr->ppm.buffer_data[p_iodata->iocs_offset], p_iocs, iocs_len);
             os_mutex_unlock(net->ppm_buf_lock);
@@ -577,6 +579,7 @@ int pf_ppm_get_data_and_iops(
       case PF_PPM_STATE_RUN:
          if ((*p_data_len >= p_iodata->data_length) && (*p_iops_len >= p_iodata->iops_length))
          {
+            CC_ASSERT(net->ppm_buf_lock != NULL);
             os_mutex_lock(net->ppm_buf_lock);
             memcpy(p_data, &p_iocr->ppm.buffer_data[p_iodata->data_offset], p_iodata->data_length);
             memcpy(p_iops, &p_iocr->ppm.buffer_data[p_iodata->iops_offset], p_iodata->iops_length);
@@ -643,6 +646,7 @@ int pf_ppm_get_iocs(
       case PF_PPM_STATE_RUN:
          if (*p_iocs_len >= p_iodata->iocs_length)
          {
+            CC_ASSERT(net->ppm_buf_lock != NULL);
             os_mutex_lock(net->ppm_buf_lock);
             memcpy(p_iocs, &p_iocr->ppm.buffer_data[p_iodata->iocs_offset], p_iodata->iocs_length);
             os_mutex_unlock(net->ppm_buf_lock);

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -2553,6 +2553,9 @@ static int pf_cmdev_check_iocr_param(
  *
  * This function configures an expected sub-module.
  * Perform final checks of parameters and let the application plug the sub-module if needed.
+ *
+ * Triggers user call-back \a pnet_exp_submodule_ind()
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_exp_api        In:   The expected API instance.
  * @param p_exp_mod        In:   The expected sub-module instance.
@@ -2803,6 +2806,9 @@ static int pf_cmdev_exp_submodule_configure(
  *
  * This function configures an expected module.
  * Perform final checks of parameters and let the application plug the module if needed.
+ *
+ * Triggers the user call-back \a pnet_exp_module_ind() and \a pnet_exp_submodule_ind().
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_exp_api        In:   The expected API instance.
  * @param p_exp_mod        In:   The expected sub-module instance.
@@ -2929,6 +2935,9 @@ static int pf_cmdev_exp_modules_configure(
  *
  * This function configures an expected API.
  * Perform final checks of parameters and let the application plug the (sub-)modules when needed.
+ *
+ * Triggers the user call-back \a pnet_exp_module_ind() and \a pnet_exp_submodule_ind().
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_ar             In:   The AR instance.
  * @param p_stat           Out:  Detailed error information.
@@ -3086,6 +3095,9 @@ static int pf_cmdev_check_ar_rpc(
  * Check the AR for errors.
  *
  * This function implements the APDUCheck function in the Profinet spec.
+ *
+ * Triggers the user call-back \a pnet_exp_module_ind() and \a pnet_exp_submodule_ind().
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_ar             In:   The AR instance.
  * @param p_stat           Out:  Detailed error information.

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -467,6 +467,8 @@ int pf_fspm_state_ind(
 {
    int ret = 0;
 
+   CC_ASSERT(p_ar != NULL);
+
    switch (event)
    {
    case    PNET_EVENT_ABORT:     LOG_INFO(PNET_LOG, "CMDEV event ABORT\n"); break;


### PR DESCRIPTION
Kill sessions for unknown UUIDs

Use 2 AR by default, as Automated RT Tester needs 2.

Use correct error code when invalid control command for DControl is received.

Close AR if duplicate UUID is received.

Closes #94