### PR TITLE
Fix alarm parsing bug

### DIFF
--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -438,7 +438,7 @@ static int pf_alarm_alpmr_apmr_a_data_ind(
       /* Only DATA: AlarmNotifications are sent to this function */
       ret = pf_fspm_aplmr_alarm_ind(net, p_apmx->p_ar,
          p_alarm_data->api_id, p_alarm_data->slot_nbr, p_alarm_data->subslot_nbr,
-         data_usi, data_len, p_data);
+         data_len, data_usi, p_data);
 
       /* App must now send an ACK or a NACK */
       p_apmx->p_alpmx->alpmr_state = PF_ALPMR_STATE_W_USER_ACK;

--- a/src/device/pf_block_reader.c
+++ b/src/device/pf_block_reader.c
@@ -761,15 +761,14 @@ void pf_get_alarm_data(
    p_alarm_data->subslot_nbr = pf_get_uint16(p_info, p_pos);
    p_alarm_data->module_ident = pf_get_uint32(p_info, p_pos);
    p_alarm_data->submodule_ident = pf_get_uint32(p_info, p_pos);
-   p_alarm_data->alarm_type = pf_get_uint16(p_info, p_pos);
 
    /* AlarmSpecifier */
    temp_u16 = pf_get_uint16(p_info, p_pos);
    p_alarm_data->sequence_number = pf_get_bits(temp_u16, 0, 11);
-   p_alarm_data->alarm_specifier.channel_diagnosis = pf_get_bits(temp_u16, 1, 11);
-   p_alarm_data->alarm_specifier.manufacturer_diagnosis = pf_get_bits(temp_u16, 1, 12);
-   p_alarm_data->alarm_specifier.submodule_diagnosis = pf_get_bits(temp_u16, 1, 13);
-   p_alarm_data->alarm_specifier.ar_diagnosis = pf_get_bits(temp_u16, 1, 15);
+   p_alarm_data->alarm_specifier.channel_diagnosis = pf_get_bits(temp_u16, 11, 1);
+   p_alarm_data->alarm_specifier.manufacturer_diagnosis = pf_get_bits(temp_u16, 12, 1);
+   p_alarm_data->alarm_specifier.submodule_diagnosis = pf_get_bits(temp_u16, 13, 1);
+   p_alarm_data->alarm_specifier.ar_diagnosis = pf_get_bits(temp_u16, 15, 1);
 }
 
 void pf_get_alarm_ack(
@@ -783,15 +782,14 @@ void pf_get_alarm_ack(
    p_alarm_data->api_id = pf_get_uint32(p_info, p_pos);
    p_alarm_data->slot_nbr = pf_get_uint16(p_info, p_pos);
    p_alarm_data->subslot_nbr = pf_get_uint16(p_info, p_pos);
-   p_alarm_data->alarm_type = pf_get_uint16(p_info, p_pos);
 
    /* AlarmSpecifier */
    temp_u16 = pf_get_uint16(p_info, p_pos);
    p_alarm_data->sequence_number = pf_get_bits(temp_u16, 0, 11);
-   p_alarm_data->alarm_specifier.channel_diagnosis = pf_get_bits(temp_u16, 1, 11);
-   p_alarm_data->alarm_specifier.manufacturer_diagnosis = pf_get_bits(temp_u16, 1, 12);
-   p_alarm_data->alarm_specifier.submodule_diagnosis = pf_get_bits(temp_u16, 1, 13);
-   p_alarm_data->alarm_specifier.ar_diagnosis = pf_get_bits(temp_u16, 1, 15);
+   p_alarm_data->alarm_specifier.channel_diagnosis = pf_get_bits(temp_u16, 11, 1);
+   p_alarm_data->alarm_specifier.manufacturer_diagnosis = pf_get_bits(temp_u16, 12, 1);
+   p_alarm_data->alarm_specifier.submodule_diagnosis = pf_get_bits(temp_u16, 13, 1);
+   p_alarm_data->alarm_specifier.ar_diagnosis = pf_get_bits(temp_u16, 15, 1);
 }
 
 void pf_get_pnio_status(


### PR DESCRIPTION
Remove duplicate parsing of alarmtype field.
Use correct argument order in functions.

Closes #149