### PR TITLE
Check that alarm mbox is available before writing to it

### DIFF
--- a/src/common/pf_eth.c
+++ b/src/common/pf_eth.c
@@ -104,7 +104,7 @@ int pf_eth_recv (void * arg, os_buf_t * p_buf)
          ret = net->eth_id_map[ix].frame_handler (
             net,
             frame_id,
-            p_buf,
+            p_buf, /* This cannot be NULL, as seen above */
             frame_pos,
             net->eth_id_map[ix].p_arg);
       }

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -1527,6 +1527,7 @@ typedef struct pf_apmx
    /* Latest sent alarm */
    os_buf_t * p_rta;
 
+   bool high_priority; /* True for high priority APMX. For printouts. */
    uint16_t vlan_prio; /* 5 or 6 */
    uint16_t block_type_alarm_notify;
    uint16_t block_type_alarm_ack;


### PR DESCRIPTION
Reduce code duplication by using same code for low- and high-
priority alarm frame handlers.