### PR TITLE
Fix outgoing alarm frame structure

### DIFF
--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -2574,13 +2574,13 @@ static void pf_put_diag_item (
          res_len,
          p_bytes,
          p_pos);
-      pf_put_uint16 (
+      pf_put_uint32 (
          is_big_endian,
          p_item->fmt.std.ext_ch_add_value,
          res_len,
          p_bytes,
          p_pos);
-      pf_put_uint16 (
+      pf_put_uint32 (
          is_big_endian,
          p_item->fmt.std.qual_ch_qualifier,
          res_len,
@@ -3156,6 +3156,7 @@ void pf_put_alarm_block (
       case PF_USI_CHANNEL_DIAGNOSIS:
       case PF_USI_EXTENDED_CHANNEL_DIAGNOSIS:
       case PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS:
+         /* Insert a maintainance item before the diagnosis item */
          if (maint_status != 0)
          {
             pf_put_uint16 (

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -425,8 +425,8 @@ int pnet_alarm_send_process_alarm (
    uint32_t api,
    uint16_t slot,
    uint16_t subslot,
-   uint16_t payload_len,
    uint16_t payload_usi,
+   uint16_t payload_len,
    uint8_t * p_payload)
 {
    int ret = -1;


### PR DESCRIPTION
Change field sizes to uint32 instead of uint16, and correct
argument order to function for building frame.