### PR TITLE
Add product name to configuration. Add getters for chassis ID

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1215,14 +1215,22 @@ typedef struct pnet_lldp_peer_to_peer_boundary
 } pnet_lldp_peer_to_peer_boundary_t;
 
 /**
+ * Chassis ID
+ */
+typedef struct pf_lldp_chassis_id
+{
+   char string[PNET_LLDP_CHASSIS_ID_MAX_LEN + 1]; /**< Terminated string */
+   uint8_t subtype;
+   size_t len;
+} pf_lldp_chassis_id_t;
+
+/**
  * LLDP Peer information used by the Profinet stack.
  */
 typedef struct pnet_lldp_peer_info
 {
    /* LLDP TLVs */
-   uint8_t chassis_id_subtype;
-   char chassis_id[PNET_LLDP_CHASSIS_ID_MAX_LEN + 1];
-   size_t chassis_id_len;
+   pf_lldp_chassis_id_t chassis_id;
    uint8_t port_id_subtype;
    char port_id[PNET_LLDP_PORT_ID_MAX_LEN + 1];
    size_t port_id_len;

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1295,6 +1295,16 @@ typedef struct pnet_cfg
    char device_vendor[20 + 1];                       /**< Terminated string */
    char manufacturer_specific_string[240 + 1];       /**< Terminated string */
 
+   /**
+    * Product name
+    *
+    * This is known as DeviceVendorValue and DeviceType in the Profinet
+    * specification. It constitutes the first part of SystemIdentification
+    * (sysDescr in SNMP). It may also be used to construct the Chassis ID.
+    * See IEC CDV 61158-6-10 ch. 4.10.3.3.1.
+    */
+   char product_name[25 + 1]; /**< Terminated string */
+
    /* Timing */
    uint16_t min_device_interval; /** Smallest allowed data exchange interval, in
                                     units of 31.25 us. Used for triggering error

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -1285,6 +1285,7 @@ int app_adjust_stack_configuration (pnet_cfg_t * stack_config)
    stack_config->oem_device_id.device_id_lo = 0x01;
    strcpy (stack_config->device_vendor, "rt-labs");
    strcpy (stack_config->manufacturer_specific_string, "PNET demo");
+   strcpy (stack_config->product_name, "rt-labs PNET demo");
 
    /* Timing */
    stack_config->min_device_interval = 32; /* Corresponds to 1 ms */

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -26,6 +26,49 @@
 extern "C" {
 #endif
 
+#define PF_LLDP_SUBTYPE_MAC              4
+#define PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED 7
+
+/**
+ * Check if information about peer device has been received
+ *
+ * The info is received in an LLDP packet and relevant
+ * info is stored by LLDP stack.
+ *
+ * @param net              In:    The p-net stack instance
+ * @param timestamp_10ms   Out:   Time when the LLDP packet with the info
+ *                                was first received, in units of
+ *                                10 milliseconds with system startup
+ *                                as the zero point (as in SNMP sysUpTime).
+ *                                Note that if an LLDP packet with identical
+ *                                info is received, the timestamp is not
+ *                                updated.
+ */
+bool pf_lldp_is_peer_info_received (pnet_t * net, uint32_t * timestamp_10ms);
+
+/**
+ * Get Chassis ID of local device.
+ *
+ * @param net              In:    The p-net stack instance
+ * @param p_chassis_id     Out:   Chassis ID of local device.
+ */
+void pf_lldp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id);
+
+/**
+ * Get Chassis ID of peer device.
+ *
+ * The peer Chassis ID is received in LLDP frames. If no LLDP frame has been
+ * received, the returned Chassis ID is empty.
+ *
+ * Thread-safety is ensured by means of a mutex.
+ *
+ * @param net              In:    The p-net stack instance
+ * @param p_chassis_id     Out:   Chassis ID of peer device.
+ */
+void pf_lldp_get_peer_chassis_id (
+   pnet_t * net,
+   pf_lldp_chassis_id_t * p_chassis_id);
+
 /**
  * Initialize the LLDP component.
  *

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3467,6 +3467,7 @@ void pf_put_pdport_data_real (
    uint16_t temp_u16 = 0;
    uint8_t numPeers = net->lldp_peer_info.ttl ? 1 : 0;
    uint8_t temp_u8 = 0;
+   pf_lldp_chassis_id_t chassis_id;
 
    /* Block header first */
    pf_put_block_header (
@@ -3526,19 +3527,17 @@ void pf_put_pdport_data_real (
          p_bytes,
          p_pos);
 
+      /* Get ChassisId of peer device */
+      pf_lldp_get_peer_chassis_id (net, &chassis_id);
+
       /* Length ChassisID */
-      pf_put_byte (net->lldp_peer_info.chassis_id_len, res_len, p_bytes, p_pos);
+      pf_put_byte (chassis_id.len, res_len, p_bytes, p_pos);
 
       /* ChassisID */
-      pf_put_mem (
-         net->lldp_peer_info.chassis_id,
-         net->lldp_peer_info.chassis_id_len,
-         res_len,
-         p_bytes,
-         p_pos);
+      pf_put_mem (chassis_id.string, chassis_id.len, res_len, p_bytes, p_pos);
 
       /* 1 bytes padding if needed*/
-      if (net->lldp_peer_info.chassis_id_len % 2 != 0)
+      if (chassis_id.len % 2 != 0)
       {
          pf_put_byte (temp_u8, res_len, p_bytes, p_pos);
       }
@@ -3738,6 +3737,7 @@ void pf_put_pdinterface_data_real (
    uint16_t block_pos = *p_pos;
    uint16_t block_len = 0;
    uint16_t temp_u16 = 0;
+   pf_lldp_chassis_id_t chassis_id;
 
    /* Block header first */
    pf_put_block_header (
@@ -3750,39 +3750,14 @@ void pf_put_pdinterface_data_real (
       p_bytes,
       p_pos);
 
+   /* Get owner ChassisId */
+   pf_lldp_get_chassis_id (net, &chassis_id);
+
    /* Owner ChassisID Length */
-   if ((uint8_t)strlen (net->fspm_cfg.lldp_cfg.chassis_id) > 0)
-   {
-      pf_put_byte (
-         (uint8_t)strlen (net->fspm_cfg.lldp_cfg.chassis_id),
-         res_len,
-         p_bytes,
-         p_pos);
+   pf_put_byte ((uint8_t)chassis_id.len, res_len, p_bytes, p_pos);
 
-      /* Owner ChassisID*/
-      pf_put_mem (
-         &net->fspm_cfg.lldp_cfg.chassis_id,
-         strlen (net->fspm_cfg.lldp_cfg.chassis_id),
-         res_len,
-         p_bytes,
-         p_pos);
-   }
-   else
-   {
-      pf_put_byte (
-         (uint8_t)strlen (net->cmina_current_dcp_ase.station_name),
-         res_len,
-         p_bytes,
-         p_pos);
-
-      /* Owner ChassisID*/
-      pf_put_mem (
-         &net->cmina_current_dcp_ase.station_name,
-         strlen (net->cmina_current_dcp_ase.station_name),
-         res_len,
-         p_bytes,
-         p_pos);
-   }
+   /* Owner ChassisID*/
+   pf_put_mem (chassis_id.string, chassis_id.len, res_len, p_bytes, p_pos);
 
    /* Two bytes padding */
    pf_put_uint16 (is_big_endian, temp_u16, res_len, p_bytes, p_pos);

--- a/src/osal.h
+++ b/src/osal.h
@@ -128,6 +128,20 @@ typedef struct os_ethaddr
 } os_ethaddr_t;
 
 /**
+ * Get system uptime.
+ *
+ * This is the sysUpTime, as used by SNMP:
+ * "The time (in hundredths of a second) since the network
+ *  management portion of the system was last re-initialized."
+ * - IETF RFC 3418 (SNMP MIB-2).
+ *
+ * Starts at 0, with wrap-around after ~497 days.
+ *
+ * @return System uptime, in units of 10 milliseconds.
+ */
+uint32_t os_get_system_uptime_10ms (void);
+
+/**
  * Load a binary file.
  *
  * Can load the data into two buffers.

--- a/src/osal/linux/osal.c
+++ b/src/osal/linux/osal.c
@@ -352,6 +352,15 @@ void os_usleep (uint32_t usec)
    }
 }
 
+uint32_t os_get_system_uptime_10ms (void)
+{
+   uint32_t uptime;
+
+   /* TODO: Implement this */
+   uptime = 0;
+   return uptime;
+}
+
 uint32_t os_get_current_time_us (void)
 {
    struct timespec ts;

--- a/src/osal/rt-kernel/osal.c
+++ b/src/osal/rt-kernel/osal.c
@@ -21,6 +21,8 @@
 #include <drivers/net.h>
 #include <gpio.h>
 #include <lwip/netif.h>
+#include <lwip/snmp.h>
+#include <lwip/sys.h>
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -264,6 +266,14 @@ void os_mutex_destroy (os_mutex_t * mutex)
 void os_usleep (uint32_t us)
 {
    task_delay (tick_from_ms (us / 1000));
+}
+
+uint32_t os_get_system_uptime_10ms (void)
+{
+   uint32_t uptime;
+
+   MIB2_COPY_SYSUPTIME_TO (&uptime);
+   return uptime;
 }
 
 uint32_t os_get_current_time_us (void)

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2230,7 +2230,34 @@ struct pnet
                                                    and discarded packets */
    uint32_t lldp_timeout; /* Scheduler handle for periodic LLDP sending */
 
+   /* LLDP mutex
+    *
+    * This mutex protects information about the peer device.
+    */
+   os_mutex_t * lldp_mutex;
+
+   /* Timestamp for when LLDP packet with new content was received.
+    *
+    * Units are the same as sysUptime in SNMP.
+    * Protected by LLDP mutex.
+    */
+   uint32_t lldp_timestamp_for_last_peer_change;
+
+   /* Is information about peer device received?
+    *
+    * Information is received in LLDP packets.
+    * Protected by LLDP mutex.
+    */
+   bool lldp_is_peer_info_received;
+
+   /* LLDP peer information
+    *
+    * The information may be changed anytime an incoming LLDP packet arrives.
+    *
+    * Protected by LLDP mutex.
+    */
    pnet_lldp_peer_info_t lldp_peer_info;
+
    uint32_t lldp_rx_timeout; /* Scheduler handle for LLDP timeout */
 
    pf_port_t port[PNET_MAX_PORT];

--- a/test/test_lldp.cpp
+++ b/test/test_lldp.cpp
@@ -136,3 +136,42 @@ TEST_F (LldpTest, LldpGenerateAliasName)
    EXPECT_EQ (strcmp (alias, port_id_test_sample_1), 0);
    memset (alias, 0, sizeof (alias));
 }
+
+TEST_F (LldpTest, LldpGetChassisId)
+{
+   pf_lldp_chassis_id_t chassis_id;
+
+   memset (&chassis_id, 0, sizeof (chassis_id));
+
+   /* Currently, the MAC address is used as Chassis ID */
+   pf_lldp_get_chassis_id (net, &chassis_id);
+   EXPECT_EQ (chassis_id.subtype, PF_LLDP_SUBTYPE_MAC);
+   EXPECT_EQ (chassis_id.len, 6u);
+
+   /* TODO: Add test case for locally assigned Chassis ID */
+}
+
+TEST_F (LldpTest, LldpGetPeerChassisId)
+{
+   pf_lldp_chassis_id_t chassis_id;
+
+   memset (&chassis_id, 0, sizeof (chassis_id));
+
+   /* Nothing received */
+   pf_lldp_get_peer_chassis_id (net, &chassis_id);
+   EXPECT_EQ (chassis_id.len, 0u);
+
+   /* TODO: Add test case for scenario where LLDP packet has been received */
+}
+
+TEST_F (LldpTest, LldpIsPeerInfoReceived)
+{
+   bool is_received;
+   uint32_t last_chage;
+
+   /* Nothing received */
+   is_received = pf_lldp_is_peer_info_received (net, &last_chage);
+   EXPECT_EQ (is_received, false);
+
+   /* TODO: Add test case for scenario where LLDP packet has been received */
+}

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -490,6 +490,7 @@ void PnetIntegrationTestBase::cfg_init()
    strcpy (pnet_default_cfg.station_name, "");
    strcpy (pnet_default_cfg.device_vendor, "rt-labs");
    strcpy (pnet_default_cfg.manufacturer_specific_string, "PNET demo");
+   strcpy (pnet_default_cfg.product_name, "PNET unit tests");
 
    strcpy (pnet_default_cfg.lldp_cfg.port_id, "port-001");
    pnet_default_cfg.lldp_cfg.ttl = 20; /* seconds */


### PR DESCRIPTION
Currently not used. Will be used by SNMP later on.