### PR TITLE
Add reset of dpportcheck state variable on new AR.

### DIFF
--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -1746,6 +1746,7 @@ static int pf_cmrpc_rm_connect_ind (
    else
    {
       net->port[0].adjust.active = false;
+      net->port[0].check.active = false;
       pf_lldp_tx_restart (net, true);
    }
 


### PR DESCRIPTION
This fixes test case Different Access Ways Port 2 Port.