### PR TITLE
Correct return value from pnet_init()

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1320,11 +1320,11 @@ typedef struct pnet_cfg
  *
  * This function must be called to initialize the Profinet stack.
  *
- * @param netif            In:   Name of the network interface.
- * @param tick_us          In:   Periodic interval in us. Specify the interval
- *                               between calls to pnet_handle_periodic().
- * @param p_cfg            In:   Profinet configuration. These values are used
- * at first startup and at factory reset.
+ * @param netif            In:    Name of the network interface.
+ * @param tick_us          In:    Periodic interval in us. Specify the interval
+ *                                between calls to pnet_handle_periodic().
+ * @param p_cfg            In:    Profinet configuration. These values are used
+ *                                at first startup and at factory reset.
  * @return a handle to the stack instance, or NULL if an error occurred.
  */
 PNET_EXPORT pnet_t * pnet_init (

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -23,7 +23,7 @@
 #include "pf_includes.h"
 #include "pf_block_reader.h"
 
-pnet_t * pnet_init_only (
+int pnet_init_only (
    pnet_t * net,
    const char * netif,
    uint32_t tick_us,
@@ -38,7 +38,7 @@ pnet_t * pnet_init_only (
          "Too long interface name. Given: %s  Max len: %d\n",
          netif,
          PNET_MAX_INTERFACE_NAME_LENGTH);
-      return NULL;
+      return -1;
    }
    strcpy (net->interface_name, netif);
 
@@ -54,7 +54,7 @@ pnet_t * pnet_init_only (
    /* initialize configuration */
    if (pf_fspm_init (net, p_cfg) != 0)
    {
-      return NULL;
+      return -1;
    }
 
    /* Initialize everything (and the DCP protocol) */
@@ -62,8 +62,7 @@ pnet_t * pnet_init_only (
    net->eth_handle = os_eth_init (netif, pf_eth_recv, (void *)net);
    if (net->eth_handle == NULL)
    {
-      free (net);
-      return NULL;
+      return -1;
    }
 
    pf_eth_init (net);
@@ -79,7 +78,7 @@ pnet_t * pnet_init_only (
 
    pf_cmrpc_init (net);
 
-   return net;
+   return 0;
 }
 
 pnet_t * pnet_init (
@@ -87,7 +86,7 @@ pnet_t * pnet_init (
    uint32_t tick_us,
    const pnet_cfg_t * p_cfg)
 {
-   pnet_t * net;
+   pnet_t * net = NULL;
 
    net = os_malloc (sizeof (*net));
    if (net == NULL)
@@ -95,7 +94,12 @@ pnet_t * pnet_init (
       return NULL;
    }
 
-   pnet_init_only (net, netif, tick_us, p_cfg);
+   if (pnet_init_only (net, netif, tick_us, p_cfg) != 0)
+   {
+      free (net);
+      return NULL;
+   }
+
    return net;
 }
 

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -781,7 +781,7 @@ typedef struct pf_eth_frame_id_map
 typedef struct pf_cmina_dcp_ase
 {
    char station_name[PNET_STATION_NAME_MAX_LEN + 1]; /* Terminated */
-   char device_vendor[20 + 1];                          /* Terminated */
+   char device_vendor[20 + 1];                       /* Terminated */
    uint8_t device_role;        /* Only value "1" supported */
    uint16_t device_initiative; /* 1: Should send hello. 0: No sending of hello
                                 */
@@ -2238,9 +2238,18 @@ struct pnet
 
 /**
  * @internal
- * Initialise a pnet_t structure. For testing purposes.
+ * Initialise a pnet_t structure into already allocated memory.
+ *
+ * @param net              InOut: The p-net stack instance to be initialised.
+ * @param netif            In:    Name of the network interface.
+ * @param tick_us          In:    Periodic interval in us. Specify the interval
+ *                                between calls to pnet_handle_periodic().
+ * @param p_cfg            In:    Profinet configuration. These values are used
+ *                                at first startup and at factory reset.
+ * @return  0  on success.
+ *          -1 if an error occurred.
  */
-pnet_t * pnet_init_only (
+int pnet_init_only (
    pnet_t * net,
    const char * netif,
    uint32_t tick_us,


### PR DESCRIPTION
Without this fix the error checking during startup does not work.
This leads to later segfault if the initialisation failed, but
the application not it notified.