### PR TITLE
Fix non-initialized warning for osal.c

### DIFF
--- a/src/osal/rt-kernel/osal.c
+++ b/src/osal/rt-kernel/osal.c
@@ -270,7 +270,7 @@ void os_usleep (uint32_t us)
 
 uint32_t os_get_system_uptime_10ms (void)
 {
-   uint32_t uptime;
+   uint32_t uptime = 0;
 
    MIB2_COPY_SYSUPTIME_TO (&uptime);
    return uptime;


### PR DESCRIPTION
Without this fix the compiler says:
error: uptime is used uninitialized in this function [-Werror=uninitialized]