### PR TITLE
snmp: Implement internal API (stubs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option (PNET_OPTION_AR_VENDOR_BLOCKS "" ON)
 option (PNET_OPTION_RS "" ON)
 option (PNET_OPTION_MC_CR "" ON)
 option (PNET_OPTION_SRL "" OFF)
+option (PNET_OPTION_SNMP "" OFF)
 
 # TODO: this should be handled in cc.h
 option (PNET_USE_ATOMICS "Enable use of atomic operations (stdatomic.h)" OFF)
@@ -105,6 +106,9 @@ set_property(CACHE PF_ETH_LOG PROPERTY STRINGS ${LOG_STATE_VALUES})
 
 set(PF_LLDP_LOG ON CACHE STRING "pf_lldp log")
 set_property(CACHE PF_LLDP_LOG PROPERTY STRINGS ${LOG_STATE_VALUES})
+
+set(PF_SNMP_LOG ON CACHE STRING "pf_snmp log")
+set_property(CACHE PF_SNMP_LOG PROPERTY STRINGS ${LOG_STATE_VALUES})
 
 set(PF_CPM_LOG ON CACHE STRING "pf_cpm log")
 set_property(CACHE PF_CPM_LOG PROPERTY STRINGS ${LOG_STATE_VALUES})

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -39,6 +39,10 @@ extern "C" {
 #include <stdint.h>
 #include <stdio.h>
 
+#define PNET_PRODUCT_NAME_MAX_LEN  25
+#define PNET_ORDER_ID_MAX_LEN      20
+#define PNET_SERIAL_NUMBER_MAX_LEN 16
+
 #define PNET_MAX_FILE_FULLPATH_LEN                                             \
    (PNET_MAX_DIRECTORYPATH_LENGTH + PNET_MAX_FILENAME_LENGTH) /** Including    \
                                                                  separator and \
@@ -351,6 +355,7 @@ extern "C" {
 
 #define PNET_FILENAME_IP                                                       \
    "pnet_data_ip.bin" /* Max length PNET_MAX_FILENAME_LENGTH */
+#define PNET_FILENAME_SYSCONTACT  "pnet_data_syscontact.bin"
 #define PNET_FILENAME_IM          "pnet_data_im.bin"
 #define PNET_FILENAME_DIAGNOSTICS "pnet_data_diagnostics.bin"
 #define PNET_FILENAME_LOGBOOK     "pnet_data_logbook.bin"
@@ -1018,8 +1023,9 @@ typedef struct pnet_im_0
 {
    uint8_t im_vendor_id_hi;
    uint8_t im_vendor_id_lo;
-   char im_order_id[20 + 1];      /**< Terminated string */
-   char im_serial_number[16 + 1]; /**< Terminated string */
+   char im_order_id[PNET_ORDER_ID_MAX_LEN + 1]; /**< Terminated string */
+   char im_serial_number[PNET_SERIAL_NUMBER_MAX_LEN + 1]; /**< Terminated string
+                                                           */
    uint16_t im_hardware_revision;
    char im_sw_revision_prefix;
    uint8_t im_sw_revision_functional_enhancement;
@@ -1324,7 +1330,7 @@ typedef struct pnet_cfg
     * (sysDescr in SNMP). It may also be used to construct the Chassis ID.
     * See IEC CDV 61158-6-10 ch. 4.10.3.3.1.
     */
-   char product_name[25 + 1]; /**< Terminated string */
+   char product_name[PNET_PRODUCT_NAME_MAX_LEN + 1]; /**< Terminated string */
 
    /* Timing */
    uint16_t min_device_interval; /** Smallest allowed data exchange interval, in

--- a/options.h.in
+++ b/options.h.in
@@ -51,6 +51,10 @@
 #cmakedefine01 PNET_OPTION_SRL
 #endif
 
+#if !defined (PNET_OPTION_SNMP)
+#cmakedefine01 PNET_OPTION_SNMP
+#endif
+
 /**
  * Disable use of atomic operations (stdatomic.h).
  * If the compiler supports it then set this define to 1.
@@ -186,6 +190,10 @@
 
 #ifndef PF_LLDP_LOG
 #define PF_LLDP_LOG             (LOG_STATE_@PF_LLDP_LOG@)
+#endif
+
+#ifndef PF_SNMP_LOG
+#define PF_SNMP_LOG             (LOG_STATE_@PF_SNMP_LOG@)
 #endif
 
 #ifndef PF_CPM_LOG

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources (profinet PRIVATE
   common/pf_eth.c
   common/pf_file.c
   common/pf_lldp.c
+  common/pf_snmp.c
   common/pf_udp.c
   common/pf_alarm.h
   common/pf_cpm.h
@@ -70,5 +71,6 @@ target_sources (profinet PRIVATE
   common/pf_scheduler.h
   common/pf_eth.h
   common/pf_lldp.h
+  common/pf_snmp.h
   common/pf_udp.h
   )

--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -1,0 +1,441 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2020 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#ifdef UNIT_TEST
+#endif
+
+/**
+ * @file
+ * @brief Helper functions for use by platform-dependent SNMP server (agent).
+ *
+ */
+
+#include "pf_includes.h"
+#include <string.h>
+
+#define STRINGIFY(s)   STRINGIFIED (s)
+#define STRINGIFIED(s) #s
+
+void pf_snmp_get_system_name (pnet_t * net, pf_snmp_system_name_t * name)
+{
+   int error;
+
+   CC_STATIC_ASSERT (sizeof (name->string) >= OS_HOST_NAME_MAX);
+
+   error = os_get_hostname (name->string);
+   if (error)
+   {
+      name->string[0] = '\0';
+   }
+   name->string[sizeof (name->string) - 1] = '\0';
+}
+
+int pf_snmp_set_system_name (pnet_t * net, const pf_snmp_system_name_t * name)
+{
+   /* TODO: Set new hostname permanently. Perhaps call os_set_ip_suite()? */
+   return -1;
+}
+
+void pf_snmp_get_system_contact (
+   pnet_t * net,
+   pf_snmp_system_contact_t * contact)
+{
+   const char * directory = net->fspm_cfg.file_directory;
+   int error;
+
+   error = pf_file_load (
+      directory,
+      PNET_FILENAME_SYSCONTACT,
+      contact,
+      sizeof (*contact));
+   if (error)
+   {
+      contact->string[0] = '\0';
+      LOG_INFO (
+         PF_SNMP_LOG,
+         "SNMP(%d): Could not yet read sysContact from nvm.\n",
+         __LINE__);
+   }
+   else
+   {
+      LOG_INFO (
+         PF_SNMP_LOG,
+         "SNMP(%d): Did read sysContact from nvm.\n",
+         __LINE__);
+   }
+   contact->string[sizeof (contact->string) - 1] = '\0';
+}
+
+int pf_snmp_set_system_contact (
+   pnet_t * net,
+   const pf_snmp_system_contact_t * contact)
+{
+   const char * directory = net->fspm_cfg.file_directory;
+   pf_snmp_system_contact_t temporary_buffer;
+   int res;
+
+   res = pf_file_save_if_modified (
+      directory,
+      PNET_FILENAME_SYSCONTACT,
+      (void *)contact, /* TODO: Remove cast after adding 'const' to parameter
+                        */
+      &temporary_buffer,
+      sizeof (*contact));
+   switch (res)
+   {
+   case 2:
+      LOG_INFO (
+         PF_SNMP_LOG,
+         "SNMP(%d): First nvm saving of sysContact. "
+         "sysContact: %s\n",
+         __LINE__,
+         contact->string);
+      break;
+   case 1:
+      LOG_INFO (
+         PF_SNMP_LOG,
+         "SNMP(%d): Updating nvm stored sysContact. "
+         "sysContact: %s\n",
+         __LINE__,
+         contact->string);
+      break;
+   case 0:
+      LOG_INFO (
+         PF_SNMP_LOG,
+         "SNMP(%d): No storing of nvm sysContact (no changes). "
+         "sysContact: %s\n",
+         __LINE__,
+         contact->string);
+      break;
+   default:
+      /* Fall-through */
+   case -1:
+      LOG_ERROR (
+         PF_SNMP_LOG,
+         "SNMP(%d): Failed to store nvm sysContact.\n",
+         __LINE__);
+      break;
+   }
+
+   return res == -1 ? -1 : 0;
+}
+
+void pf_snmp_get_system_location (
+   pnet_t * net,
+   pf_snmp_system_location_t * location)
+{
+   snprintf (
+      location->string,
+      sizeof (location->string),
+      "%s",
+      net->fspm_cfg.im_1_data.im_tag_location);
+}
+
+int pf_snmp_set_system_location (
+   pnet_t * net,
+   const pf_snmp_system_location_t * location)
+{
+   /* TODO: Write to I&M1 */
+   return -1;
+}
+
+void pf_snmp_get_system_description (
+   pnet_t * net,
+   pf_snmp_system_description_t * description)
+{
+   /* Encode as per Profinet specification:
+    * DeviceType, Blank, OrderID, Blank, IM_Serial_Number, Blank, HWRevision,
+    * Blank, SWRevisionPrefix, SWRevision.
+    *
+    * See IEC CDV 61158-6-10 (PN-AL-Protocol) ch. 5.1.2 "APDU abstract syntax",
+    * field "SystemIdentification".
+    */
+   snprintf (
+      description->string,
+      sizeof (description->string),
+      /* clang-format off */
+      "%-" STRINGIFY (PNET_PRODUCT_NAME_MAX_LEN) "s "
+      "%-" STRINGIFY (PNET_ORDER_ID_MAX_LEN) "s "
+      "%-" STRINGIFY (PNET_SERIAL_NUMBER_MAX_LEN) "s "
+      "%5u "
+      "%c%3u%3u%3u",
+      /* clang-format on */
+      net->fspm_cfg.product_name,
+      net->fspm_cfg.im_0_data.im_order_id,
+      net->fspm_cfg.im_0_data.im_serial_number,
+      net->fspm_cfg.im_0_data.im_hardware_revision,
+      net->fspm_cfg.im_0_data.im_sw_revision_prefix,
+      net->fspm_cfg.im_0_data.im_sw_revision_functional_enhancement,
+      net->fspm_cfg.im_0_data.im_sw_revision_bug_fix,
+      net->fspm_cfg.im_0_data.im_sw_revision_internal_change);
+}
+
+void pf_snmp_get_port_list (pnet_t * net, pf_lldp_port_list_t * p_list)
+{
+   /* TODO: Implement support for multiple ports */
+   memset (p_list, 0, sizeof (*p_list));
+   p_list->ports[0] = BIT (8 - 1);
+}
+
+int pf_snmp_get_first_port (const pf_lldp_port_list_t * p_list)
+{
+   /* TODO: Implement support for multiple ports */
+   return 1;
+}
+
+int pf_snmp_get_next_port (const pf_lldp_port_list_t * p_list, int loc_port_num)
+{
+   /* TODO: Implement support for multiple ports */
+   return 0;
+}
+
+int pf_snmp_get_peer_timestamp (
+   pnet_t * net,
+   int loc_port_num,
+   uint32_t * timestamp_10ms)
+{
+   /* TODO: Implement support for multiple ports */
+   return pf_lldp_is_peer_info_received (net, timestamp_10ms) ? 0 : -1;
+}
+
+void pf_snmp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id)
+{
+   /* TODO: Implement this */
+   memset (p_chassis_id, 0, sizeof (*p_chassis_id));
+   p_chassis_id->subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
+   snprintf (
+      p_chassis_id->string,
+      sizeof (p_chassis_id->string),
+      "my chassis-id");
+   p_chassis_id->len = strlen (p_chassis_id->string);
+}
+
+int pf_snmp_get_peer_chassis_id (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_chassis_id_t * p_chassis_id)
+{
+   uint32_t timestamp_10ms;
+
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_chassis_id, 0, sizeof (*p_chassis_id));
+   p_chassis_id->subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
+   snprintf (
+      p_chassis_id->string,
+      sizeof (p_chassis_id->string),
+      "peer chassis-id");
+   p_chassis_id->len = strlen (p_chassis_id->string);
+
+   return pf_lldp_is_peer_info_received (net, &timestamp_10ms) ? 0 : -1;
+}
+
+void pf_snmp_get_port_id (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_port_id_t * p_port_id)
+{
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_port_id, 0, sizeof (*p_port_id));
+   p_port_id->subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
+   snprintf (p_port_id->string, sizeof (p_port_id->string), "my port-id");
+   p_port_id->len = strlen (p_port_id->string);
+}
+
+int pf_snmp_get_peer_port_id (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_port_id_t * p_port_id)
+{
+   uint32_t timestamp_10ms;
+
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_port_id, 0, sizeof (*p_port_id));
+   p_port_id->subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
+   snprintf (p_port_id->string, sizeof (p_port_id->string), "peer port-id");
+   p_port_id->len = strlen (p_port_id->string);
+
+   return pf_lldp_is_peer_info_received (net, &timestamp_10ms) ? 0 : -1;
+}
+
+void pf_snmp_get_port_description (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_port_description_t * p_port_descr)
+{
+   /* TODO: Implement support for multiple ports */
+   CC_ASSERT (loc_port_num == 1);
+   snprintf (
+      p_port_descr->string,
+      sizeof (p_port_descr->string),
+      "%s",
+      net->interface_name);
+   p_port_descr->len = strlen (p_port_descr->string);
+}
+
+int pf_snmp_get_peer_port_description (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_port_description_t * p_port_desc)
+{
+   uint32_t timestamp_10ms;
+
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_port_desc, 0, sizeof (*p_port_desc));
+   snprintf (
+      p_port_desc->string,
+      sizeof (p_port_desc->string),
+      "peer port descr");
+   p_port_desc->len = strlen (p_port_desc->string);
+
+   return pf_lldp_is_peer_info_received (net, &timestamp_10ms) ? 0 : -1;
+}
+
+void pf_snmp_get_management_address (
+   pnet_t * net,
+   pf_lldp_management_address_t * p_man_address)
+{
+   /* TODO: Implement this */
+   memset (p_man_address, 0, sizeof (*p_man_address));
+   p_man_address->subtype = 1;
+   memset (p_man_address, 42, 4);
+   p_man_address->len = 4;
+}
+
+int pf_snmp_get_peer_management_address (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_management_address_t * p_man_address)
+{
+   uint32_t timestamp_10ms;
+
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_man_address, 0, sizeof (*p_man_address));
+   p_man_address->subtype = 1;
+   memset (p_man_address, 42, 4);
+   p_man_address->len = 4;
+
+   return pf_lldp_is_peer_info_received (net, &timestamp_10ms) ? 0 : -1;
+}
+
+void pf_snmp_get_management_port_index (
+   pnet_t * net,
+   pf_lldp_management_port_index_t * p_man_port_index)
+{
+   /* TODO: Implement this */
+   memset (p_man_port_index, 0, sizeof (*p_man_port_index));
+   p_man_port_index->subtype = 2;
+   p_man_port_index->index = 1;
+}
+
+int pf_snmp_get_peer_management_port_index (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_management_port_index_t * p_man_port_index)
+{
+   uint32_t timestamp_10ms;
+
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_man_port_index, 0, sizeof (*p_man_port_index));
+   p_man_port_index->subtype = 2;
+   p_man_port_index->index = 1;
+
+   return pf_lldp_is_peer_info_received (net, &timestamp_10ms) ? 0 : -1;
+}
+
+void pf_snmp_get_station_name (
+   pnet_t * net,
+   pf_lldp_station_name_t * p_station_name)
+{
+   /* TODO: Implement this */
+   memset (p_station_name, 0, sizeof (*p_station_name));
+   snprintf (
+      p_station_name->string,
+      sizeof (p_station_name->string),
+      "my station-name");
+   p_station_name->len = strlen (p_station_name->string);
+}
+
+int pf_snmp_get_peer_station_name (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_station_name_t * p_station_name)
+{
+   uint32_t timestamp_10ms;
+
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_station_name, 0, sizeof (*p_station_name));
+   snprintf (
+      p_station_name->string,
+      sizeof (p_station_name->string),
+      "peer station-name");
+   p_station_name->len = strlen (p_station_name->string);
+
+   return pf_lldp_is_peer_info_received (net, &timestamp_10ms) ? 0 : -1;
+}
+
+void pf_snmp_get_signal_delays (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_signal_delay_t * p_delays)
+{
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_delays, 0, sizeof (*p_delays));
+}
+
+int pf_snmp_get_peer_signal_delays (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_signal_delay_t * p_delays)
+{
+   uint32_t timestamp_10ms;
+
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_delays, 0, sizeof (*p_delays));
+
+   return pf_lldp_is_peer_info_received (net, &timestamp_10ms) ? 0 : -1;
+}
+
+void pf_snmp_get_link_status (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_link_status_t * p_link_status)
+{
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_link_status, 0, sizeof (*p_link_status));
+}
+
+int pf_snmp_get_peer_link_status (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_link_status_t * p_link_status)
+{
+   uint32_t timestamp_10ms;
+
+   /* TODO: Implement this */
+   CC_ASSERT (loc_port_num == 1);
+   memset (p_link_status, 0, sizeof (*p_link_status));
+
+   return pf_lldp_is_peer_info_received (net, &timestamp_10ms) ? 0 : -1;
+}

--- a/src/common/pf_snmp.h
+++ b/src/common/pf_snmp.h
@@ -35,6 +35,13 @@
  * entities, where a network entity may be a Profinet Device/Controller/
  * Supervisor or an LLDP-aware network switch.
  *
+ * The SNMP variables are declared in the following MIBs:
+ * - MIB-II. See IETF RFC 3418 (SNMP MIB).
+ * - LLDP-MIB. See IEEE 802.1AB-2005 (LLDPv1).
+ * - LLDP-EXT-DOT3-MIB. See IEEE 802.1AB-2005 (LLDPv1).
+ * - LLDP-EXT-PNO-MIB. See IEC CDV 61158-6-10 (PN-AL-Protocol).
+ * The Profinet guideline PN-Topology describes usage of SNMP (see ch. 6.2).
+ *
  * Getter functions for the following variables for the local device, interface
  * and ports are provided:
  * - sysName
@@ -407,7 +414,6 @@ void pf_snmp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id);
  *
  * The remote Chassis ID is contained in an LLDP packet sent from a port
  * on the remote device to a local port with no intermediate switches.
- * If no LLDP packet has been received, the returned Chassis ID is empty.
  *
  * See IEEE 802.1AB-2005 (LLDPv1) ch. 12.2. Relevant fields:
  * - lldpRemChassisId,
@@ -454,7 +460,6 @@ void pf_snmp_get_port_id (
  *
  * The remote Port ID is contained in an LLDP packet sent from a port
  * on the remote device to the local port with no intermediate switches.
- * If no LLDP packet has been received, the returned Port ID is empty.
  *
  * Note that the remote device may have multiple ports. Only the remote
  * port connected to the local port is relevant here.
@@ -501,6 +506,9 @@ void pf_snmp_get_port_description (
 /**
  * Get port description for remote port.
  *
+ * The remote Port description is contained in an LLDP packet sent from a port
+ * on the remote device to the local port with no intermediate switches.
+ *
  * See IEEE 802.1AB-2005 (LLDPv1) ch. 12.2. Relevant fields:
  * - lldpRemPortDesc,
  * - lldpRemLocalPortNum.
@@ -524,15 +532,23 @@ int pf_snmp_get_peer_port_description (
  * Get Management Address for local interface.
  *
  * The management address should usually be the IP address for the local
- * interface the local port belongs to. It could also be the MAC address of
+ * interface the local ports belong to. It could also be the MAC address of
  * the local interface in case no IP address has been assigned.
  *
  * Note that the local device may have multiple interfaces (such as a
  * loopback interface). Only the local interface used by the p-net stack
  * is relevant here.
  *
+ * Note that when constructing the response to the request for the variable
+ * lldpLocManAddr, the lldpLocManAddr is to be encoded as an variable length
+ * OCTET STRING, where the first element is the number of octets.
+ * If lldpLocManAddr is the IPv4 address 192.168.10.9, it should be encoded as
+ * 4.192.168.10.9 and lldpLocManAddrLen would be 5.
+ * See PN-Topology ch. 6.3.1.
+ *
  * See IEEE 802.1AB-2005 ch. 12.2. Relevant fields:
  * - lldpLocManAddr,
+ * - lldpLocManAddrLen,
  * - lldpLocManAddrSubtype.
  *
  * @param net              In:    The p-net stack instance.
@@ -557,8 +573,15 @@ void pf_snmp_get_management_address (
  * Note that the remote device may have multiple interfaces. Only the remote
  * interface connected to the local port is relevant here.
  *
+ * Note that when constructing the response to the request for the variable
+ * lldpLocManAddr, the lldpLocManAddr is to be encoded as an variable length
+ * OCTET STRING, where the first element is the number of octets.
+ * If lldpLocManAddr is the IPv4 address 192.168.10.9, it should be encoded as
+ * 4.192.168.10.9 and lldpLocManAddrLen would be 5.
+ *
  * See IEEE 802.1AB-2005 (LLDPv1) ch. 12.2. Relevant fields:
  * - lldpRemManAddr,
+ * - lldpRemManAddrLen,
  * - lldpRemManAddrSubtype,
  * - lldpRemLocalPortNum.
  *
@@ -604,8 +627,7 @@ void pf_snmp_get_management_port_index (
  * Get ManAddrIfId for remote interface connected to local port.
  *
  * The ManAddrIfId of remote device is contained in an LLDP packet sent from a
- * port on the remote device to the local port with no intermediate switches. If
- * no LLDP packet has been received, the returned ManAddrIfIdSubtype is zero.
+ * port on the remote device to the local port with no intermediate switches.
  *
  * Note that the remote device may have multiple interfaces. Only the remote
  * interface connected to the local port is relevant here.
@@ -659,7 +681,6 @@ void pf_snmp_get_station_name (
  * The remote station name (NameOfStation) is the name of the remote interface
  * and is contained in an LLDP packet sent from a port
  * on the remote device to the local port with no intermediate switches.
- * If no LLDP packet has been received, the returned station name is empty.
  *
  * The station name is usually a string, but may also be the MAC address of
  * the remote interface in case no string has been assigned.

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -319,6 +319,7 @@ int pf_cmina_set_default_cfg (pnet_t * net, uint16_t reset_mode)
          pf_file_clear (p_file_directory, PNET_FILENAME_IP);
          pf_file_clear (p_file_directory, PNET_FILENAME_DIAGNOSTICS);
          pf_file_clear (p_file_directory, PNET_FILENAME_LOGBOOK);
+         pf_file_clear (p_file_directory, PNET_FILENAME_SYSCONTACT);
       }
 
       if (reset_mode > 0)
@@ -1245,6 +1246,7 @@ int pf_cmina_remove_all_data_files (const char * file_directory)
    pf_file_clear (file_directory, PNET_FILENAME_IP);
    pf_file_clear (file_directory, PNET_FILENAME_DIAGNOSTICS);
    pf_file_clear (file_directory, PNET_FILENAME_LOGBOOK);
+   pf_file_clear (file_directory, PNET_FILENAME_SYSCONTACT);
 
    return 0;
 }

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -73,6 +73,15 @@ int pnet_init_only (
    pf_dcp_init (net);  /* Start DCP */
    pf_lldp_init (net); /* Send the LLDP frame */
 
+   /* Configure SNMP server if enabled */
+#if PNET_OPTION_SNMP == 1
+   if (os_snmp_init (net) != 0)
+   {
+      LOG_ERROR (PNET_LOG, "Failed to configure SNMP\n");
+      return -1;
+   }
+#endif
+
    pf_cmdev_exit (net); /* Prepare for re-init */
    pf_cmdev_init (net);
 

--- a/src/pf_includes.h
+++ b/src/pf_includes.h
@@ -41,6 +41,7 @@ extern "C" {
 #include "pf_eth.h"
 #include "pf_file.h"
 #include "pf_lldp.h"
+#include "pf_snmp.h"
 #include "pf_ppm.h"
 #include "pf_ptcp.h"
 #include "pf_scheduler.h"

--- a/src/pnal.h
+++ b/src/pnal.h
@@ -78,6 +78,14 @@ typedef struct os_ethaddr
 } os_ethaddr_t;
 
 /**
+ * The p-net stack instance.
+ *
+ * This is needed for SNMP in order to access various stack variables,
+ * such as the location  of the device and LLDP variables.
+ */
+typedef struct pnet pnet_t;
+
+/**
  * Get system uptime.
  *
  * This is the sysUpTime, as used by SNMP:
@@ -224,6 +232,19 @@ int os_udp_recvfrom (
  * @param id               In:    Socket ID
  */
 void os_udp_close (uint32_t id);
+
+/**
+ * Configure SNMP server.
+ *
+ * This function configures a platform-specific SNMP server as to
+ * enable a connected SNMP client to read variables from the p-net stack,
+ * as well as to write some variables to it.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @return  0 if the operation succeeded.
+ *         -1 if an error occurred.
+ */
+int os_snmp_init (pnet_t * net);
 
 /**
  * Get network parameters (IP address, netmask etc)


### PR DESCRIPTION
A new file pf_snmp.c is added where each function
from header file pf_snmp.h is implemented, mostly
as stub functions returning fake data (see TODO
comments).

A cmake option to enable SNMP is added.
By default, it is set to OFF.

When enabled, the platform-specific function
os_snmp_init() is called at startup.
As no platform currently implements this function,
a link error is then generated.