### PR TITLE
Remove const from buffer pointer in os_eth_send()

### DIFF
--- a/src/common/pf_eth.c
+++ b/src/common/pf_eth.c
@@ -41,7 +41,7 @@ int pf_eth_init (pnet_t * net)
    return ret;
 }
 
-int pf_eth_send (pnet_t * net, os_eth_handle_t * handle, const os_buf_t * buf)
+int pf_eth_send (pnet_t * net, os_eth_handle_t * handle, os_buf_t * buf)
 {
    int sent_len = 0;
 

--- a/src/common/pf_eth.h
+++ b/src/common/pf_eth.h
@@ -38,7 +38,7 @@ int pf_eth_init (pnet_t * net);
  * @param buf              In:    Buffer with data to be sent
  * @return  The number of bytes sent, or -1 if an error occurred.
  */
-int pf_eth_send (pnet_t * net, os_eth_handle_t * handle, const os_buf_t * buf);
+int pf_eth_send (pnet_t * net, os_eth_handle_t * handle, os_buf_t * buf);
 
 /**
  * Add a frame_id entry to the frame id filter map.

--- a/src/pnal.h
+++ b/src/pnal.h
@@ -138,6 +138,12 @@ int os_save_file (
  */
 void os_clear_file (const char * fullpath);
 
+
+/* os_buf_t should at least contain:
+ *  void * payload;
+ *  uint16_t len;
+ */
+
 os_buf_t * os_buf_alloc (uint16_t length);
 void os_buf_free (os_buf_t * p);
 uint8_t os_buf_header (os_buf_t * p, int16_t header_size_increment);
@@ -149,7 +155,7 @@ uint8_t os_buf_header (os_buf_t * p, int16_t header_size_increment);
  * @param buf           In: Buffer with data to be sent
  * @return  The number of bytes sent, or -1 if an error occurred.
  */
-int os_eth_send (os_eth_handle_t * handle, const os_buf_t * buf);
+int os_eth_send (os_eth_handle_t * handle, os_buf_t * buf);
 
 /**
  * Initialize receiving of raw Ethernet frames (in separate thread)

--- a/src/ports/linux/pnal_eth.c
+++ b/src/ports/linux/pnal_eth.c
@@ -134,7 +134,7 @@ os_eth_handle_t * os_eth_init (
    }
 }
 
-int os_eth_send (os_eth_handle_t * handle, const os_buf_t * buf)
+int os_eth_send (os_eth_handle_t * handle, os_buf_t * buf)
 {
    int ret = send (handle->socket, buf->payload, buf->len, 0);
 

--- a/src/ports/rt-kernel/pnal_eth.c
+++ b/src/ports/rt-kernel/pnal_eth.c
@@ -25,6 +25,7 @@
 static struct netif * interface[MAX_NUMBER_OF_IF];
 static int nic_index = 0;
 
+
 os_eth_handle_t * os_eth_init (
    const char * if_name,
    os_eth_callback_t * callback,
@@ -76,7 +77,7 @@ os_eth_handle_t * os_eth_init (
    }
 }
 
-int os_eth_send (os_eth_handle_t * handle, const os_buf_t * buf)
+int os_eth_send (os_eth_handle_t * handle, os_buf_t * buf)
 {
    int ret = -1;
 

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -73,7 +73,7 @@ int mock_os_set_ip_suite (
    return 0;
 }
 
-int mock_os_eth_send (os_eth_handle_t * handle, const os_buf_t * p_buf)
+int mock_os_eth_send (os_eth_handle_t * handle, os_buf_t * p_buf)
 {
    memcpy (mock_os_data.eth_send_copy, p_buf->payload, p_buf->len);
    mock_os_data.eth_send_len = p_buf->len;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -62,7 +62,7 @@ os_eth_handle_t * mock_os_eth_init (
    const char * if_name,
    os_eth_callback_t * callback,
    void * arg);
-int mock_os_eth_send (os_eth_handle_t * handle, const os_buf_t * buf);
+int mock_os_eth_send (os_eth_handle_t * handle, os_buf_t * buf);
 void mock_os_cpy_mac_addr (uint8_t * mac_addr);
 int mock_os_udp_open (os_ipaddr_t addr, os_ipport_t port);
 int mock_os_udp_sendto (


### PR DESCRIPTION
The send function in LWIP does not accept const buffer pointer