### PR TITLE
Remove LLDP TTL from config

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1188,7 +1188,6 @@ typedef struct pnet_lldp_cfg
    char chassis_id[PNET_LLDP_CHASSIS_ID_MAX_LEN + 1];
    char port_id[PNET_LLDP_PORT_ID_MAX_LEN + 1]; /**< Terminated string */
    pnet_ethaddr_t port_addr;
-   uint16_t ttl; /**< Time to live in seconds */
    uint16_t rtclass_2_status;
    uint16_t rtclass_3_status;
    uint8_t cap_aneg;  /**< Autonegotiation supported and enabled */

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -1289,7 +1289,6 @@ int app_adjust_stack_configuration (pnet_cfg_t * stack_config)
 
    /* LLDP settings */
    strcpy (stack_config->lldp_cfg.port_id, "port-001");
-   stack_config->lldp_cfg.ttl = PNET_LLDP_TTL;
    stack_config->lldp_cfg.rtclass_2_status = 0;
    stack_config->lldp_cfg.rtclass_3_status = 0;
    stack_config->lldp_cfg.cap_aneg = PNET_LLDP_AUTONEG_SUPPORTED |

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -251,17 +251,15 @@ static void pf_lldp_add_port_id_tlv (
 /**
  * @internal
  * Insert the mandatory time-to-live (TTL) TLV into a buffer.
- * @param p_lldp_cfg       In:    LLDP configuration for this port
  * @param p_buf            InOut: The buffer.
  * @param p_pos            InOut: The position in the buffer.
  */
 static void pf_lldp_add_ttl_tlv (
-   const pnet_lldp_cfg_t * p_lldp_cfg,
    uint8_t * p_buf,
    uint16_t * p_pos)
 {
    pf_lldp_add_tlv_header (p_buf, p_pos, LLDP_TYPE_TTL, 2);
-   pf_put_uint16 (true, p_lldp_cfg->ttl, PF_FRAME_BUFFER_SIZE, p_buf, p_pos);
+   pf_put_uint16 (true, PNET_LLDP_TTL, PF_FRAME_BUFFER_SIZE, p_buf, p_pos);
 }
 
 /**
@@ -663,7 +661,7 @@ void pf_lldp_send (pnet_t * net)
          /* Add mandatory parts */
          pf_lldp_add_chassis_id_tlv (&chassis_id, p_buf, &pos);
          pf_lldp_add_port_id_tlv (p_lldp_cfg, p_buf, &pos);
-         pf_lldp_add_ttl_tlv (p_lldp_cfg, p_buf, &pos);
+         pf_lldp_add_ttl_tlv (p_buf, &pos);
 
          /* Add optional parts */
          pf_lldp_add_port_status (p_lldp_cfg, p_buf, &pos);

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -495,7 +495,6 @@ void PnetIntegrationTestBase::cfg_init()
    strcpy (pnet_default_cfg.product_name, "PNET unit tests");
 
    strcpy (pnet_default_cfg.lldp_cfg.port_id, "port-001");
-   pnet_default_cfg.lldp_cfg.ttl = 20; /* seconds */
    pnet_default_cfg.lldp_cfg.rtclass_2_status = 0;
    pnet_default_cfg.lldp_cfg.rtclass_3_status = 0;
    pnet_default_cfg.lldp_cfg.cap_aneg = 3; /* Supported (0x01) + enabled (0x02)


### PR DESCRIPTION
The TTL (time to live) value for outgoing LLDP frames should
always be 20 seconds, according to the Profinet standard.
Do not bother users to always supply this value.