### PR TITLE
Add logbook entries

### DIFF
--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -1105,6 +1105,12 @@ int pf_fspm_cm_connect_ind (
                .connect_cb (net, net->fspm_cfg.cb_arg, p_ar->arep, p_result);
    }
 
+   pf_fspm_create_log_book_entry (
+      net,
+      p_ar->arep,
+      &p_result->pnio_status,
+      PF_LOG_BOOK_AR_CONNECT);
+
    return ret;
 }
 
@@ -1120,6 +1126,12 @@ int pf_fspm_cm_release_ind (
       ret = net->fspm_cfg
                .release_cb (net, net->fspm_cfg.cb_arg, p_ar->arep, p_result);
    }
+
+   pf_fspm_create_log_book_entry (
+      net,
+      p_ar->arep,
+      &p_result->pnio_status,
+      PF_LOG_BOOK_AR_RELEASE);
 
    return ret;
 }
@@ -1141,6 +1153,12 @@ int pf_fspm_cm_dcontrol_ind (
          control_command,
          p_result);
    }
+
+   pf_fspm_create_log_book_entry (
+      net,
+      p_ar->arep,
+      &p_result->pnio_status,
+      PF_LOG_BOOK_DCONTROL);
 
    return ret;
 }

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2195,6 +2195,19 @@ typedef struct pf_log_book_ts
    uint32_t nano_sec;
 } pf_log_book_ts_t;
 
+/*
+ * p-net stack specific log book entry detail values.
+ * Values are not defined by Profinet specification
+ * but device/stack specific.
+ * See PN-AL-protocol (Mar20) 7.3.6 LogBook ASE
+ */
+typedef enum
+{
+   PF_LOG_BOOK_AR_CONNECT = 1,
+   PF_LOG_BOOK_AR_RELEASE,
+   PF_LOG_BOOK_DCONTROL
+} pf_log_book_entry_detail_values_t;
+
 typedef struct pf_log_book_entry
 {
    pf_log_book_ts_t time_ts;


### PR DESCRIPTION
What to store in the logbook is up to the stack/device vendor.
Automated RT-tester requires that at least one logbook entry
is stored. This solves this by adding entries on AR connect and
release.