### PR TITLE
Lower log level message on read of unsupported I&M data

### DIFF
--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -802,7 +802,7 @@ int pf_fspm_cm_read_ind (
          break;
       default:
          /* Nothing if data not available here */
-         LOG_ERROR (
+         LOG_DEBUG (
             PNET_LOG,
             "FSPM(%d): Request to read non-implemented I&M data. Index %u\n",
             __LINE__,


### PR DESCRIPTION
This is not an error and printing these log messages
makes test case Different Access Way Port to Port fail.