### PR TITLE
snmp: Change internal API to use iterator

### DIFF
--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -513,22 +513,26 @@ void pf_lldp_get_port_list (pnet_t * net, pf_lldp_port_list_t * p_list)
    p_list->ports[0] = BIT (8 - 1);
 }
 
-int pf_lldp_get_first_port (const pf_lldp_port_list_t * p_list)
+void pf_lldp_init_port_iterator (pnet_t * net, pf_port_iterator_t * p_iterator)
 {
    /* TODO: Implement support for multiple ports */
-   /* TODO: Move this to some other source file, as the list of local ports is
-    * not part of any LLDP TLV sent in LLDP frames.
-    */
-   return 1;
+   /* TODO: Move this to some other source file */
+   p_iterator->next_port = 1;
 }
 
-int pf_lldp_get_next_port (const pf_lldp_port_list_t * p_list, int loc_port_num)
+int pf_lldp_get_next_port (pf_port_iterator_t * p_iterator)
 {
    /* TODO: Implement support for multiple ports */
-   /* TODO: Move this to some other source file, as the list of local ports is
-    * not part of any LLDP TLV sent in LLDP frames.
-    */
-   return 0;
+   /* TODO: Move this to some other source file */
+   if (p_iterator->next_port == 1)
+   {
+      p_iterator->next_port = 0;
+      return 1;
+   }
+   else
+   {
+      return 0;
+   }
 }
 
 int pf_lldp_get_peer_timestamp (

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -41,26 +41,27 @@ extern "C" {
 void pf_lldp_get_port_list (pnet_t * net, pf_lldp_port_list_t * p_list);
 
 /**
- * Get first port in list of local ports.
+ * Initialise iterator for iterating over local ports.
  *
- * @param p_list           In:    List of local ports.
- * @return Local port index for first port on local interface.
+ * This iterator may be used for iterating over all physical ports
+ * on the local interface. The management port is not included.
+ * See pf_lldp_get_next_port().
+ *
+ * @param net              In:    The p-net stack instance.
+ * @param p_iterator       Out:   Port iterator.
  */
-int pf_lldp_get_first_port (const pf_lldp_port_list_t * p_list);
+void pf_lldp_init_port_iterator (pnet_t * net, pf_port_iterator_t * p_iterator);
 
 /**
- * Get next port in list of local ports.
+ * Get next local port.
  *
  * If no more ports are available, 0 is returned.
  *
- * @param p_list           In:    List of local ports.
- * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. N, where N is the total
- *                                number of local ports used by p-net stack.
- * @return Local port index for next port on local interface.
+ * @param p_iterator       InOut: Port iterator.
+ * @return Local port number for next port on local interface.
  *         If no more ports are available, 0 is returned.
  */
-int pf_lldp_get_next_port (const pf_lldp_port_list_t * p_list, int loc_port_num);
+int pf_lldp_get_next_port (pf_port_iterator_t * p_iterator);
 
 /**
  * Get time when new information about remote device was received.

--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -186,14 +186,14 @@ void pf_snmp_get_port_list (pnet_t * net, pf_lldp_port_list_t * p_list)
    pf_lldp_get_port_list (net, p_list);
 }
 
-int pf_snmp_get_first_port (const pf_lldp_port_list_t * p_list)
+void pf_snmp_init_port_iterator (pnet_t * net, pf_port_iterator_t * p_iterator)
 {
-   return pf_lldp_get_first_port (p_list);
+   pf_lldp_init_port_iterator (net, p_iterator);
 }
 
-int pf_snmp_get_next_port (const pf_lldp_port_list_t * p_list, int loc_port_num)
+int pf_snmp_get_next_port (pf_port_iterator_t * p_iterator)
 {
-   return pf_lldp_get_next_port (p_list, loc_port_num);
+   return pf_lldp_get_next_port (p_iterator);
 }
 
 int pf_snmp_get_peer_timestamp (

--- a/src/common/pf_snmp.h
+++ b/src/common/pf_snmp.h
@@ -327,27 +327,25 @@ int pf_snmp_set_system_location (
  * See IEEE 802.1AB-2005 (LLDPv1) ch. 12.2. Relevant fields:
  * - lldpConfigManAddrPortsTxEnable.
  *
- * See pf_snmp_get_first_port() and pf_snmp_get_next_port().
- *
  * @param net              In:    The p-net stack instance.
  * @param p_list           Out:   List of local ports.
  */
 void pf_snmp_get_port_list (pnet_t * net, pf_lldp_port_list_t * p_list);
 
 /**
- * Get first port in list of local ports.
+ * Initialise iterator for iterating over local ports.
  *
- * See IEEE 802.1AB-2005 (LLDPv1) ch. 12.2. Relevant fields:
- * - lldpLocPortNum,
- * - lldpRemLocalPortNum.
+ * This iterator may be used for iterating over all physical ports
+ * on the local interface. The management port is not included.
+ * See pf_snmp_get_next_port().
  *
- * @param p_list           In:    List of local ports.
- * @return Local port index for first port on local interface.
+ * @param net              In:    The p-net stack instance.
+ * @param p_iterator       Out:   Port iterator.
  */
-int pf_snmp_get_first_port (const pf_lldp_port_list_t * p_list);
+void pf_snmp_init_port_iterator (pnet_t * net, pf_port_iterator_t * p_iterator);
 
 /**
- * Get next port in list of local ports.
+ * Get next local port.
  *
  * If no more ports are available, 0 is returned.
  *
@@ -355,14 +353,11 @@ int pf_snmp_get_first_port (const pf_lldp_port_list_t * p_list);
  * - lldpLocPortNum,
  * - lldpRemLocalPortNum.
  *
- * @param p_list           In:    List of local ports.
- * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. N, where N is the total
- *                                number of local ports used by p-net stack.
- * @return Local port index for next port on local interface.
+ * @param p_iterator       InOut: Port iterator.
+ * @return Local port number for next port on local interface.
  *         If no more ports are available, 0 is returned.
  */
-int pf_snmp_get_next_port (const pf_lldp_port_list_t * p_list, int loc_port_num);
+int pf_snmp_get_next_port (pf_port_iterator_t * p_iterator);
 
 /**
  * Get time when new information about remote device was received.

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2340,7 +2340,7 @@ typedef struct pf_lldp_link_status
  * Port description
  *
  * "The port description field shall contain an alpha-numeric string
- * that indicates the port’s description. If RFC 2863
+ * that indicates the port's description. If RFC 2863
  * is implemented, the ifDescr object should be used for this field."
  * - IEEE 802.1AB (LLDP) ch. 9.5.5.2 "port description".
  *
@@ -2375,6 +2375,17 @@ typedef struct pf_lldp_port_list_t
 {
    uint8_t ports[2];
 } pf_lldp_port_list_t;
+
+/**
+ * Port iterator
+ *
+ * This iterator may be used for iterating over all physical ports
+ * on the local interface. The management port is not included.
+ */
+typedef struct pf_port_iterator
+{
+   int next_port;
+} pf_port_iterator_t;
 
 /**
  * Port ID

--- a/src/ports/rt-kernel/rowindex.c
+++ b/src/ports/rt-kernel/rowindex.c
@@ -107,11 +107,11 @@ static int rowindex_construct_for_remote_interface (
 
 int rowindex_match_with_local_port (const u32_t * row_oid, u8_t row_oid_len)
 {
-   pf_lldp_port_list_t port_list;
+   pf_port_iterator_t port_iterator;
    int port;
 
-   pf_snmp_get_port_list (pnal_snmp.net, &port_list);
-   port = pf_snmp_get_first_port (&port_list);
+   pf_snmp_init_port_iterator (pnal_snmp.net, &port_iterator);
+   port = pf_snmp_get_next_port (&port_iterator);
    while (port != 0)
    {
       struct snmp_obj_id port_oid;
@@ -122,7 +122,7 @@ int rowindex_match_with_local_port (const u32_t * row_oid, u8_t row_oid_len)
          return port;
       }
 
-      port = pf_snmp_get_next_port (&port_list, port);
+      port = pf_snmp_get_next_port (&port_iterator);
    }
 
    return 0;
@@ -132,7 +132,7 @@ int rowindex_update_with_next_local_port (struct snmp_obj_id * row_oid)
 {
    struct snmp_next_oid_state state;
    u32_t next_oid[SNMP_MAX_OBJ_ID_LEN];
-   pf_lldp_port_list_t port_list;
+   pf_port_iterator_t port_iterator;
    int port;
 
    snmp_next_oid_init (
@@ -141,8 +141,8 @@ int rowindex_update_with_next_local_port (struct snmp_obj_id * row_oid)
       row_oid->len,
       next_oid,
       SNMP_MAX_OBJ_ID_LEN);
-   pf_snmp_get_port_list (pnal_snmp.net, &port_list);
-   port = pf_snmp_get_first_port (&port_list);
+   pf_snmp_init_port_iterator (pnal_snmp.net, &port_iterator);
+   port = pf_snmp_get_next_port (&port_iterator);
    while (port != 0)
    {
       struct snmp_obj_id port_oid;
@@ -150,7 +150,7 @@ int rowindex_update_with_next_local_port (struct snmp_obj_id * row_oid)
       rowindex_construct_for_local_port (&port_oid, port);
       snmp_next_oid_check (&state, port_oid.id, port_oid.len, (void *)port);
 
-      port = pf_snmp_get_next_port (&port_list, port);
+      port = pf_snmp_get_next_port (&port_iterator);
    }
 
    if (state.status == SNMP_NEXT_OID_STATUS_SUCCESS)
@@ -216,11 +216,11 @@ snmp_err_t rowindex_update_with_next_local_interface (
 
 int rowindex_match_with_remote_device (const u32_t * row_oid, u8_t row_oid_len)
 {
-   pf_lldp_port_list_t port_list;
+   pf_port_iterator_t port_iterator;
    int port;
 
-   pf_snmp_get_port_list (pnal_snmp.net, &port_list);
-   port = pf_snmp_get_first_port (&port_list);
+   pf_snmp_init_port_iterator (pnal_snmp.net, &port_iterator);
+   port = pf_snmp_get_next_port (&port_iterator);
    while (port != 0)
    {
       struct snmp_obj_id port_oid;
@@ -234,7 +234,7 @@ int rowindex_match_with_remote_device (const u32_t * row_oid, u8_t row_oid_len)
          return port;
       }
 
-      port = pf_snmp_get_next_port (&port_list, port);
+      port = pf_snmp_get_next_port (&port_iterator);
    }
 
    return 0;
@@ -244,7 +244,7 @@ int rowindex_update_with_next_remote_device (struct snmp_obj_id * row_oid)
 {
    struct snmp_next_oid_state state;
    u32_t next_oid[SNMP_MAX_OBJ_ID_LEN];
-   pf_lldp_port_list_t port_list;
+   pf_port_iterator_t port_iterator;
    int port;
 
    snmp_next_oid_init (
@@ -253,8 +253,8 @@ int rowindex_update_with_next_remote_device (struct snmp_obj_id * row_oid)
       row_oid->len,
       next_oid,
       SNMP_MAX_OBJ_ID_LEN);
-   pf_snmp_get_port_list (pnal_snmp.net, &port_list);
-   port = pf_snmp_get_first_port (&port_list);
+   pf_snmp_init_port_iterator (pnal_snmp.net, &port_iterator);
+   port = pf_snmp_get_next_port (&port_iterator);
    while (port != 0)
    {
       int error;
@@ -266,7 +266,7 @@ int rowindex_update_with_next_remote_device (struct snmp_obj_id * row_oid)
          snmp_next_oid_check (&state, port_oid.id, port_oid.len, (void *)port);
       }
 
-      port = pf_snmp_get_next_port (&port_list, port);
+      port = pf_snmp_get_next_port (&port_iterator);
    }
 
    if (state.status == SNMP_NEXT_OID_STATUS_SUCCESS)
@@ -286,11 +286,11 @@ int rowindex_match_with_remote_interface (
    const u32_t * row_oid,
    u8_t row_oid_len)
 {
-   pf_lldp_port_list_t port_list;
+   pf_port_iterator_t port_iterator;
    int port;
 
-   pf_snmp_get_port_list (pnal_snmp.net, &port_list);
-   port = pf_snmp_get_first_port (&port_list);
+   pf_snmp_init_port_iterator (pnal_snmp.net, &port_iterator);
+   port = pf_snmp_get_next_port (&port_iterator);
    while (port != 0)
    {
       int error;
@@ -304,7 +304,7 @@ int rowindex_match_with_remote_interface (
          return port;
       }
 
-      port = pf_snmp_get_next_port (&port_list, port);
+      port = pf_snmp_get_next_port (&port_iterator);
    }
 
    return 0;
@@ -314,7 +314,7 @@ int rowindex_update_with_next_remote_interface (struct snmp_obj_id * row_oid)
 {
    struct snmp_next_oid_state state;
    u32_t next_oid[SNMP_MAX_OBJ_ID_LEN];
-   pf_lldp_port_list_t port_list;
+   pf_port_iterator_t port_iterator;
    int port;
 
    snmp_next_oid_init (
@@ -323,8 +323,8 @@ int rowindex_update_with_next_remote_interface (struct snmp_obj_id * row_oid)
       row_oid->len,
       next_oid,
       SNMP_MAX_OBJ_ID_LEN);
-   pf_snmp_get_port_list (pnal_snmp.net, &port_list);
-   port = pf_snmp_get_first_port (&port_list);
+   pf_snmp_init_port_iterator (pnal_snmp.net, &port_iterator);
+   port = pf_snmp_get_next_port (&port_iterator);
    while (port != 0)
    {
       int error;
@@ -336,7 +336,7 @@ int rowindex_update_with_next_remote_interface (struct snmp_obj_id * row_oid)
          snmp_next_oid_check (&state, port_oid.id, port_oid.len, (void *)port);
       }
 
-      port = pf_snmp_get_next_port (&port_list, port);
+      port = pf_snmp_get_next_port (&port_iterator);
    }
 
    if (state.status == SNMP_NEXT_OID_STATUS_SUCCESS)


### PR DESCRIPTION
This adds an iterator object which may be used
for iterating over local ports. Previously used
functions are removed.

The rt-kernel port was updated to use the
iterator.