### PR TITLE
Functions triggering informative callbacks should be void

### DIFF
--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -498,7 +498,7 @@ static int pf_alarm_alpmi_apmr_a_data_ind (
    case PF_ALPMI_STATE_W_ACK:
       /* This function is only called for DATA = ACK */
       p_apmx->p_alpmx->alpmi_state = PF_ALPMI_STATE_W_ALARM;
-      (void)pf_fspm_alpmi_alarm_cnf (net, p_apmx->p_ar, p_pnio_status);
+      pf_fspm_alpmi_alarm_cnf (net, p_apmx->p_ar, p_pnio_status);
       ret = 0;
       break;
    }
@@ -563,7 +563,7 @@ static void pf_alarm_alpmr_apms_a_data_cnf (
       else
       {
          /* Handle pos cnf */
-         (void)pf_fspm_alpmr_alarm_ack_cnf (
+         pf_fspm_alpmr_alarm_ack_cnf (
             net,
             p_apmx->p_ar,
             res); /* ALPMR:

--- a/src/common/pf_cpm.c
+++ b/src/common/pf_cpm.c
@@ -519,7 +519,7 @@ static int pf_cpm_c_data_ind (
          if (changes != 0)
          {
             /* Notify the application about changes in the data_status */
-            (void)pf_fspm_data_status_changed (
+            pf_fspm_data_status_changed (
                net,
                p_iocr->p_ar,
                p_iocr,

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -4815,7 +4815,7 @@ int pf_cmdev_rm_ccontrol_cnf (
                ret = pf_cmdev_set_state (net, p_ar, PF_CMDEV_STATE_WDATA);
             }
             /* Send result to application */
-            (void)pf_fspm_ccontrol_cnf (net, p_ar, p_ccontrol_result);
+            pf_fspm_ccontrol_cnf (net, p_ar, p_ccontrol_result);
          }
          else
          {
@@ -4831,7 +4831,7 @@ int pf_cmdev_rm_ccontrol_cnf (
             (p_ccontrol_result->add_data_1 << 16) +
                (p_ccontrol_result->add_data_2));
          /* Send result to application */
-         (void)pf_fspm_ccontrol_cnf (net, p_ar, p_ccontrol_result);
+         pf_fspm_ccontrol_cnf (net, p_ar, p_ccontrol_result);
          (void)pf_cmdev_set_state (net, p_ar, PF_CMDEV_STATE_ABORT);
       }
    }

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -330,7 +330,7 @@ int pf_cmina_set_default_cfg (pnet_t * net, uint16_t reset_mode)
       if (reset_mode > 0)
       {
          /* User callback */
-         (void)pf_fspm_reset_ind (net, reset_user_application, reset_mode);
+         pf_fspm_reset_ind (net, reset_user_application, reset_mode);
       }
 
       net->cmina_nonvolatile_dcp_ase.standard_gw_value = 0; /* Means: OwnIP is

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -515,18 +515,16 @@ int pf_fspm_exp_submodule_ind (
    return ret;
 }
 
-int pf_fspm_data_status_changed (
+void pf_fspm_data_status_changed (
    pnet_t * net,
    const pf_ar_t * p_ar,
    const pf_iocr_t * p_iocr,
    uint8_t changes,
    uint8_t data_status)
 {
-   int ret = -1;
-
    if (net->fspm_cfg.new_data_status_cb != NULL)
    {
-      ret = net->fspm_cfg.new_data_status_cb (
+      (void)net->fspm_cfg.new_data_status_cb (
          net,
          net->fspm_cfg.cb_arg,
          p_ar->arep,
@@ -534,24 +532,18 @@ int pf_fspm_data_status_changed (
          changes,
          data_status);
    }
-
-   return ret;
 }
 
-int pf_fspm_ccontrol_cnf (
+void pf_fspm_ccontrol_cnf (
    pnet_t * net,
    const pf_ar_t * p_ar,
    pnet_result_t * p_result)
 {
-   int ret = 0;
-
    if (net->fspm_cfg.ccontrol_cb != NULL)
    {
-      ret = net->fspm_cfg
-               .ccontrol_cb (net, net->fspm_cfg.cb_arg, p_ar->arep, p_result);
+      (void)net->fspm_cfg
+         .ccontrol_cb (net, net->fspm_cfg.cb_arg, p_ar->arep, p_result);
    }
-
-   return ret;
 }
 
 int pf_fspm_cm_read_ind (
@@ -1071,13 +1063,11 @@ int pf_fspm_cm_dcontrol_ind (
    return ret;
 }
 
-int pf_fspm_state_ind (
+void pf_fspm_state_ind (
    pnet_t * net,
    const pf_ar_t * p_ar,
    pnet_event_values_t event)
 {
-   int ret = 0;
-
    CC_ASSERT (p_ar != NULL);
 
    LOG_DEBUG (
@@ -1088,11 +1078,9 @@ int pf_fspm_state_ind (
 
    if (net->fspm_cfg.state_cb != NULL)
    {
-      ret =
+      (void)
          net->fspm_cfg.state_cb (net, net->fspm_cfg.cb_arg, p_ar->arep, event);
    }
-
-   return ret;
 }
 
 int pf_fspm_alpmr_alarm_ind (
@@ -1120,55 +1108,40 @@ int pf_fspm_alpmr_alarm_ind (
    return ret;
 }
 
-int pf_fspm_alpmi_alarm_cnf (
+void pf_fspm_alpmi_alarm_cnf (
    pnet_t * net,
    const pf_ar_t * p_ar,
    const pnet_pnio_status_t * p_pnio_status)
 {
-   int ret = 0;
-
    if (net->fspm_cfg.alarm_cnf_cb != NULL)
    {
-      ret = net->fspm_cfg.alarm_cnf_cb (
-         net,
-         net->fspm_cfg.cb_arg,
-         p_ar->arep,
-         p_pnio_status);
+      (void)net->fspm_cfg
+         .alarm_cnf_cb (net, net->fspm_cfg.cb_arg, p_ar->arep, p_pnio_status);
    }
-
-   return ret;
 }
 
-int pf_fspm_alpmr_alarm_ack_cnf (pnet_t * net, const pf_ar_t * p_ar, int res)
+void pf_fspm_alpmr_alarm_ack_cnf (pnet_t * net, const pf_ar_t * p_ar, int res)
 {
-   int ret = 0;
-
    if (net->fspm_cfg.alarm_ack_cnf_cb != NULL)
    {
-      ret = net->fspm_cfg
-               .alarm_ack_cnf_cb (net, net->fspm_cfg.cb_arg, p_ar->arep, res);
+      (void)net->fspm_cfg
+         .alarm_ack_cnf_cb (net, net->fspm_cfg.cb_arg, p_ar->arep, res);
    }
-
-   return ret;
 }
 
-int pf_fspm_reset_ind (
+void pf_fspm_reset_ind (
    pnet_t * net,
    bool should_reset_application,
    uint16_t reset_mode)
 {
-   int ret = 0;
-
    if (net->fspm_cfg.reset_cb != NULL)
    {
-      ret = net->fspm_cfg.reset_cb (
+      (void)net->fspm_cfg.reset_cb (
          net,
          net->fspm_cfg.cb_arg,
          should_reset_application,
          reset_mode);
    }
-
-   return ret;
 }
 
 int pf_fspm_signal_led_ind (pnet_t * net, bool led_state)

--- a/src/device/pf_fspm.h
+++ b/src/device/pf_fspm.h
@@ -114,14 +114,14 @@ int pf_fspm_cm_read_ind (
 
 /**
  * Response from controller to appl_rdy request.
+ *
  * Triggers the \a pnet_ccontrol_cnf() user callback.
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_ar             In:   The AR instance.
  * @param p_result         Out:  The result information.
- * @return  0  if operation succeeded.
- *          -1 if an error occurred.
  */
-int pf_fspm_ccontrol_cnf (
+void pf_fspm_ccontrol_cnf (
    pnet_t * net,
    const pf_ar_t * p_ar,
    pnet_result_t * p_result);
@@ -176,10 +176,8 @@ int pf_fspm_cm_dcontrol_ind (
  * @param p_ar             In:    The AR instance.
  * @param event            In:    The new CMDEV state. Use PNET_EVENT_xxx, not
  *                                PF_CMDEV_STATE_xxx
- * @return  0  if operation succeeded.
- *          -1 if an error occurred.
  */
-int pf_fspm_state_ind (
+void pf_fspm_state_ind (
    pnet_t * net,
    const pf_ar_t * p_ar,
    pnet_event_values_t event);
@@ -209,7 +207,7 @@ int pf_fspm_alpmr_alarm_ind (
    const uint8_t * p_data);
 
 /**
- * The remote side acknowledges the alarm sent by this side by sending an
+ * The remote side acknowledges the alarm sent by this side, by sending an
  * AlarmAck. Calls user call-back \a pnet_alarm_cnf().
  *
  * ALPMI: ALPMI_Alarm_Notification.cnf(+/-)
@@ -217,10 +215,8 @@ int pf_fspm_alpmr_alarm_ind (
  * @param net              InOut: The p-net stack instance
  * @param p_ar             In:    The AR instance.
  * @param p_pnio_status    In:    Detailed ACK information.
- * @return  0  if operation succeeded.
- *          -1 if an error occurred.
  */
-int pf_fspm_alpmi_alarm_cnf (
+void pf_fspm_alpmi_alarm_cnf (
    pnet_t * net,
    const pf_ar_t * p_ar,
    const pnet_pnio_status_t * p_pnio_status);
@@ -237,10 +233,8 @@ int pf_fspm_alpmi_alarm_cnf (
  *                                   This is cnf(+)
  *                                -1 if ACK was not received.
  *                                   This is cnf(-)
- * @return  0  if operation succeeded.
- *          -1 if an error occurred.
  */
-int pf_fspm_alpmr_alarm_ack_cnf (pnet_t * net, const pf_ar_t * p_ar, int res);
+void pf_fspm_alpmr_alarm_ack_cnf (pnet_t * net, const pf_ar_t * p_ar, int res);
 
 /**
  * Call user call-back \a pnet_exp_module_ind() to indicate to application
@@ -283,15 +277,14 @@ int pf_fspm_exp_submodule_ind (
 /**
  * Notify application that the received data status has changed,
  * via the \a pnet_new_data_status_ind() user callback.
+ *
  * @param net              InOut: The p-net stack instance
- * @param p_ar             In:  The AR instance.
- * @param p_iocr           In:  The IOCR instance.
- * @param changes          In:  The changed bits in the data status.
- * @param data_status      In:  Data status (after the changes)
- * @return  0  if operation succeeded.
- *          -1 if an error occurred.
+ * @param p_ar             In:    The AR instance.
+ * @param p_iocr           In:    The IOCR instance.
+ * @param changes          In:    The changed bits in the data status.
+ * @param data_status      In:    Data status (after the changes)
  */
-int pf_fspm_data_status_changed (
+void pf_fspm_data_status_changed (
    pnet_t * net,
    const pf_ar_t * p_ar,
    const pf_iocr_t * p_iocr,
@@ -305,12 +298,10 @@ int pf_fspm_data_status_changed (
  *
  * @param net                       InOut: The p-net stack instance
  * @param should_reset_application  In:    True if the user should reset the
- * application data.
+ *                                         application data.
  * @param reset_mode                In:    Detailed reset information.
- * @return  0  if operation succeeded.
- *          -1 if an error occurred.
  */
-int pf_fspm_reset_ind (
+void pf_fspm_reset_ind (
    pnet_t * net,
    bool should_reset_application,
    uint16_t reset_mode);


### PR DESCRIPTION
The return values from some informative user callbacks should not affect the stack.
It is more obvious if the functions triggering them are void.

We could possibly change the public API of the relevant callbacks
later to make them void, but for now use the same return
value meaning for all public callbacks.
Documentation on the public API will be improved in a separate
pullrequest.