### PR TITLE
Rework alarm

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -870,9 +870,10 @@ typedef int (*pnet_new_data_status_ind) (
 /**
  * The IO-controller has sent an alarm to the device.
  *
- * This functionality is used for alarms triggered by the IO-controller.
- *
- * It is optional to implement this callback.
+ * When receiving this indication, the application shall
+ * respond with pnet_alarm_send_ack.
+ * pnet_alarm_send_ack may be called in the context of this
+ * callback.
  *
  * @param net              InOut: The p-net stack instance
  * @param arg              InOut: User-defined data (not used by p-net)
@@ -883,7 +884,7 @@ typedef int (*pnet_new_data_status_ind) (
  * @param data_usi         In:    Alarm USI
  * @param p_data           In:    Alarm data
  * @return  0  on success.
- *          -1 if an error occurred.
+ *          Other values are ignored.
  */
 typedef int (*pnet_alarm_ind) (
    pnet_t * net,

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1261,7 +1261,7 @@ typedef struct pnet_lldp_peer_to_peer_boundary
 typedef struct pf_lldp_chassis_id
 {
    char string[PNET_LLDP_CHASSIS_ID_MAX_LEN + 1]; /**< Terminated string */
-   uint8_t subtype;
+   uint8_t subtype; /* PF_LLDP_SUBTYPE_xxx */
    size_t len;
 } pf_lldp_chassis_id_t;
 
@@ -1894,6 +1894,15 @@ typedef enum pnet_diag_ch_prop_dir_values
 #define PNET_DIAG_QUALIFIER_POS_REQUIRED 7
 #define PNET_DIAG_QUALIFIER_POS_ADVICE   3
 
+/** Qualifier 31..27 */
+#define PNET_DIAG_QUALIFIER_MASK_FAULT 0xF8000000
+/** Qualifier 26..17 */
+#define PNET_DIAG_QUALIFIER_MASK_DEMANDED 0x07FE0000
+/** Qualifier 16..7 */
+#define PNET_DIAG_QUALIFIER_MASK_REQUIRED 0x0001FF80
+/** Qualifier 6..3 */
+#define PNET_DIAG_QUALIFIER_MASK_ADVICE 0x00000078
+
 #define PNET_CHANNEL_WHOLE_SUBMODULE 0x8000
 
 typedef struct pnet_diag_source
@@ -1917,7 +1926,6 @@ typedef struct pnet_diag_source
  * Uses the "Qualified channel diagnosis" format on the wire.
  *
  * @param net                 InOut: The p-net stack instance.
- * @param arep                In:    The AREP.
  * @param p_diag_source       In:    Slot, subslot, channel, direction etc.
  * @param ch_bits             In:    Number of bits in the channel.
  * @param severity            In:    Diagnosis severity.
@@ -1939,7 +1947,6 @@ typedef struct pnet_diag_source
  */
 PNET_EXPORT int pnet_diag_std_add (
    pnet_t * net,
-   uint32_t arep,
    const pnet_diag_source_t * p_diag_source,
    pnet_diag_ch_prop_type_values_t ch_bits,
    pnet_diag_ch_prop_maint_values_t severity,
@@ -1955,7 +1962,6 @@ PNET_EXPORT int pnet_diag_std_add (
  * This sends a diagnosis alarm.
  *
  * @param net               InOut: The p-net stack instance.
- * @param arep              In:    The AREP.
  * @param p_diag_source     In:    Slot, subslot, channel, direction etc.
  * @param ch_error_type     In:    The channel error type.
  * @param ext_ch_error_type In:    The extended channel error type
@@ -1970,7 +1976,6 @@ PNET_EXPORT int pnet_diag_std_add (
  */
 PNET_EXPORT int pnet_diag_std_update (
    pnet_t * net,
-   uint32_t arep,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type,
@@ -1984,7 +1989,6 @@ PNET_EXPORT int pnet_diag_std_update (
  * This sends a diagnosis alarm.
  *
  * @param net               InOut: The p-net stack instance.
- * @param arep              In:    The AREP.
  * @param p_diag_source     In:    Slot, subslot, channel, direction etc.
  * @param ch_error_type     In:    The channel error type.
  * @param ext_ch_error_type In:    The extended channel error type
@@ -1995,7 +1999,6 @@ PNET_EXPORT int pnet_diag_std_update (
  */
 PNET_EXPORT int pnet_diag_std_remove (
    pnet_t * net,
-   uint32_t arep,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type);
@@ -2013,7 +2016,6 @@ PNET_EXPORT int pnet_diag_std_remove (
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
- * @param arep             In:    The AREP.
  * @param api              In:    The API.
  * @param slot             In:    The slot.
  * @param subslot          In:    The sub-slot.
@@ -2025,7 +2027,6 @@ PNET_EXPORT int pnet_diag_std_remove (
  */
 PNET_EXPORT int pnet_diag_usi_add (
    pnet_t * net,
-   uint32_t arep,
    uint32_t api,
    uint16_t slot,
    uint16_t subslot,
@@ -2043,7 +2044,6 @@ PNET_EXPORT int pnet_diag_usi_add (
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
- * @param arep             In:    The AREP.
  * @param api              In:    The API.
  * @param slot             In:    The slot.
  * @param subslot          In:    The sub-slot.
@@ -2055,7 +2055,6 @@ PNET_EXPORT int pnet_diag_usi_add (
  */
 PNET_EXPORT int pnet_diag_usi_update (
    pnet_t * net,
-   uint32_t arep,
    uint32_t api,
    uint16_t slot,
    uint16_t subslot,
@@ -2070,7 +2069,6 @@ PNET_EXPORT int pnet_diag_usi_update (
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
- * @param arep             In:    The AREP.
  * @param api              In:    The API.
  * @param slot             In:    The slot.
  * @param subslot          In:    The sub-slot.
@@ -2080,7 +2078,6 @@ PNET_EXPORT int pnet_diag_usi_update (
  */
 PNET_EXPORT int pnet_diag_usi_remove (
    pnet_t * net,
-   uint32_t arep,
    uint32_t api,
    uint16_t slot,
    uint16_t subslot,

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -1522,10 +1522,10 @@ static void app_handle_cyclic_data (
  *  - pnet_alarm_send_process_alarm()
  *  - pnet_diag_std_add()
  *  - pnet_diag_std_update()
- *  - pnet_diag_std_remove()
  *  - pnet_diag_usi_add()
  *  - pnet_diag_usi_update()
  *  - pnet_diag_usi_remove()
+ *  - pnet_diag_std_remove()
  *  - pnet_create_log_book_entry()
  *
  * Uses first input module, if available.
@@ -1640,7 +1640,6 @@ static void app_handle_send_alarm (
          diag_source.ch);
       pnet_diag_std_add (
          net,
-         arep,
          &diag_source,
          APP_DIAG_CHANNEL_NUMBER_OF_BITS,
          PNET_DIAG_CH_PROP_MAINT_QUALIFIED,
@@ -1658,7 +1657,6 @@ static void app_handle_send_alarm (
          diag_source.ch);
       pnet_diag_std_update (
          net,
-         arep,
          &diag_source,
          CHANNEL_ERRORTYPE_NETWORK_COMPONENT_FUNCTION_MISMATCH,
          EXTENDED_CHANNEL_ERRORTYPE_FRAME_DROPPED,
@@ -1674,7 +1672,6 @@ static void app_handle_send_alarm (
          diag_source.ch);
       pnet_diag_std_remove (
          net,
-         arep,
          &diag_source,
          CHANNEL_ERRORTYPE_NETWORK_COMPONENT_FUNCTION_MISMATCH,
          EXTENDED_CHANNEL_ERRORTYPE_FRAME_DROPPED);
@@ -1687,7 +1684,6 @@ static void app_handle_send_alarm (
          p_subslot->subslot_nbr);
       pnet_diag_usi_add (
          net,
-         arep,
          APP_API,
          slot,
          p_subslot->subslot_nbr,
@@ -1702,7 +1698,6 @@ static void app_handle_send_alarm (
          p_subslot->subslot_nbr);
       pnet_diag_usi_add (
          net,
-         arep,
          APP_API,
          slot,
          p_subslot->subslot_nbr,
@@ -1717,7 +1712,6 @@ static void app_handle_send_alarm (
          p_subslot->subslot_nbr);
       pnet_diag_usi_remove (
          net,
-         arep,
          APP_API,
          slot,
          p_subslot->subslot_nbr,

--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -1354,11 +1354,6 @@ static int pf_alarm_apms_a_data_req (
  * @param p_alarm_data     In:    Alarm details (Type, slot, subslot etc).
  * @param maint_status     In:    The Maintenance status used for specific USI
  *                                values (inserted only if not zero).
- * @param payload_usi      In:    The payload USI. Use 0 for no payload.
- * @param payload_len      In:    Payload length. Must be > 0 for manufacturer
- *                                specific payload ("USI format").
- * @param p_payload        In:    Mandatory if payload_usi > 0. May be NULL.
- *                                Custom data or pf_diag_item_t.
  * @param p_pnio_status    In:    Optional. Detailed error information (or NULL)
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
@@ -1368,9 +1363,6 @@ static int pf_alarm_apms_apms_a_data_req (
    pf_apmx_t * p_apmx,
    const pf_alarm_data_t * p_alarm_data,
    uint32_t maint_status,
-   uint16_t payload_usi,
-   uint16_t payload_len,
-   const uint8_t * p_payload,
    const pnet_pnio_status_t * p_pnio_status)
 {
    int ret = -1;
@@ -1404,9 +1396,9 @@ static int pf_alarm_apms_apms_a_data_req (
          &fixed,
          p_alarm_data,
          maint_status,
-         payload_usi,
-         payload_len,
-         p_payload,
+         p_alarm_data->payload.usi,
+         p_alarm_data->payload.len,
+         p_alarm_data->payload.data,
          p_pnio_status);
 
       p_apmx->apms_state = PF_APMS_STATE_WTACK;
@@ -1821,6 +1813,93 @@ static int pf_alarm_apmr_a_data_ind (
 
 /**
  * @internal
+ * Return the alarm specifier and maintenance status for a specific sub-slot,
+ * by looking at all diagnosis items found for that subslot.
+ *
+ * Also includes the "current diag item" in the analysis.
+ *
+ * Describes diagnosis alarms.
+ *
+ * This corresponds to the "BuildSummarizedAlarmSpecifier" and
+ * "BuildSummarizedMaintenanceStatus" functions mentioned in the standard.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param p_ar             In:    The AR instance.
+ * @param api_id           In:    The API identifier.
+ * @param slot_nbr         In:    The slot number.
+ * @param subslot_nbr      In:    The sub-slot number.
+ * @param p_diag_item      In:    The current diag item (may be NULL).
+ * @param p_alarm_spec     Out:   The computed alarm specifier.
+ * @param p_maint_status   Out:   The computed maintenance status.
+ * @return  0  if operation succeeded.
+ *          -1 if an error occurred.
+ */
+static int pf_alarm_get_diag_summary (
+   pnet_t * net,
+   const pf_ar_t * p_ar,
+   uint32_t api_id,
+   uint16_t slot_nbr,
+   uint16_t subslot_nbr,
+   const pf_diag_item_t * p_diag_item,
+   pnet_alarm_spec_t * p_alarm_spec,
+   uint32_t * p_maint_status)
+{
+   pf_device_t * p_dev = NULL;
+   pf_subslot_t * p_subslot = NULL;
+   uint16_t item_ix;
+   pf_diag_item_t * p_item = NULL;
+
+   if (pf_cmdev_get_device (net, &p_dev) == 0)
+   {
+      memset (p_alarm_spec, 0, sizeof (*p_alarm_spec));
+      *p_maint_status = 0;
+
+      /* Consider only alarms on this sub-slot. */
+      if (
+         pf_cmdev_get_subslot_full (
+            net,
+            api_id,
+            slot_nbr,
+            subslot_nbr,
+            &p_subslot) == 0)
+      {
+         /* Collect all diags into maintenanceStatus*/
+
+         /* First handle the "current" (unreported) item. */
+         if (p_diag_item != NULL)
+         {
+            pf_alarm_add_diag_item_to_summary (
+               p_ar,
+               p_subslot,
+               p_diag_item,
+               p_alarm_spec,
+               p_maint_status);
+         }
+
+         /* Now handle all the already reported diag items. */
+         item_ix = p_subslot->diag_list;
+         pf_cmdev_get_diag_item (net, item_ix, &p_item);
+         while (p_item != NULL)
+         {
+            /* Collect all diags into maintenanceStatus*/
+            pf_alarm_add_diag_item_to_summary (
+               p_ar,
+               p_subslot,
+               p_item,
+               p_alarm_spec,
+               p_maint_status);
+
+            item_ix = p_item->next;
+            pf_cmdev_get_diag_item (net, item_ix, &p_item);
+         }
+      }
+   }
+
+   return 0;
+}
+
+/**
+ * @internal
  * Handle the reception of Alarm messages for one AR instance.
  *
  * When called this function reads max 1 alarm message from its input queue
@@ -2036,6 +2115,177 @@ static int pf_alarm_apmr_periodic (pnet_t * net, pf_ar_t * p_ar)
    return ret;
 }
 
+/**
+ * Send alarm
+ * - Update diag summary
+ * - Update sequence numbers
+ * - Hand over to alarm to APMS instance
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param p_ar             InOut: The AR instance.
+ * @param p_apmx           InOut: The APMX instance.
+ * @param alarm_data       In: Alarm
+ */
+static int pf_alarm_send_internal (
+   pnet_t * net,
+   pf_ar_t * p_ar,
+   pf_apmx_t * p_apmx,
+   pf_alarm_data_t * alarm_data)
+{
+   int ret = -1;
+   uint32_t maint_status = 0;
+
+   CC_ASSERT (net->global_alarm_enable == true);
+   CC_ASSERT (p_ar->alarm_enable == true);
+   CC_ASSERT (p_apmx->p_alpmx->alpmi_state == PF_ALPMI_STATE_W_ALARM);
+
+   (void)pf_alarm_get_diag_summary (
+      net,
+      p_ar,
+      alarm_data->api_id,
+      alarm_data->slot_nbr,
+      alarm_data->subslot_nbr,
+      NULL,
+      &alarm_data->alarm_specifier,
+      &maint_status);
+
+   /* Calculate sequence numbers */
+   alarm_data->sequence_number = p_apmx->p_alpmx->sequence_number;
+   p_apmx->p_alpmx->prev_sequence_number = p_apmx->p_alpmx->sequence_number;
+   p_apmx->p_alpmx->sequence_number++;
+   p_apmx->p_alpmx->sequence_number %= 0x0800;
+
+   /* Create and send an DATA RTA-PDU */
+   ret = pf_alarm_apms_apms_a_data_req (
+      net,
+      p_apmx,
+      alarm_data,
+      maint_status,
+      NULL);
+
+   if (ret == 0)
+   {
+      p_apmx->p_alpmx->alpmi_state = PF_ALPMI_STATE_W_ACK;
+   }
+   else
+   {
+      LOG_ERROR (PF_ALARM_LOG, "Alarm(%d): Failed to send alarm\n", __LINE__);
+   }
+
+   return ret;
+}
+
+/**
+ * Reset queues for outgoing alarms
+ * @param net              InOut: The p-net stack instance
+ * @param p_ar             InOut: The AR instance.
+ * @return 0 is always returned
+ */
+static int pf_alarm_reset_send_queues (pnet_t * net, pf_ar_t * p_ar)
+{
+   memset (p_ar->alarm_send_q, 0, sizeof (p_ar->alarm_send_q));
+   return 0;
+}
+
+/**
+ * Add an alarm to the send queue
+ * @param q               InOut: Alarm send queue
+ * @param p_alarm_data    InOut: Alarm
+ * @return 0  is returned if an alarm is put into the queue
+ *         -1 is returned if queue is full
+ */
+static int pf_alarm_add_send_queue (
+   pf_alarm_queue_t * q,
+   pf_alarm_data_t * p_alarm_data)
+{
+   int ret = -1;
+
+   if (q->count < PNET_MAX_ALARMS)
+   {
+      memcpy (&q->items[q->write_index], p_alarm_data, sizeof (*p_alarm_data));
+      q->write_index++;
+      q->write_index %= PNET_MAX_ALARMS;
+      q->count++;
+      ret = 0;
+   }
+   else
+   {
+      LOG_ERROR (
+         PF_ALARM_LOG,
+         "Alarm(%d): Send queue is full, alarm dropped.\n",
+         __LINE__);
+   }
+
+   return ret;
+}
+
+/**
+ * Fetch an alarm from the send queue
+ * @param q               InOut: Alarm send queue
+ * @param p_alarm_data    InOut: Alarm
+ * @return 0  is returned if an alarm is fetched from the queue
+ *         -1 is returned if queue is empty
+ */
+static int pf_alarm_fetch_send_queue (
+   pf_alarm_queue_t * q,
+   pf_alarm_data_t * p_alarm_data)
+{
+   int ret = -1;
+   if (q->count > 0)
+   {
+      memcpy (p_alarm_data, &q->items[q->read_index], sizeof (*p_alarm_data));
+      q->read_index++;
+      q->read_index %= PNET_MAX_ALARMS;
+      q->count--;
+      ret = 0;
+   }
+   return ret;
+}
+
+/**
+ * @internal
+ * Handle outgoing alarm messages for one AR instance.
+ *
+ * When called this function checks the ALMPI state for high and
+ * low priority alarms. If state is PF_ALPMI_STATE_W_ALARM and a alarm
+ * is found in the send queue this alarm is sent.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param p_ar             InOut: The AR instance.
+ * @return  0  if operation succeeded.
+ *          -1 if an error occurred.
+ */
+static void pf_alarm_almpi_periodic (pnet_t * net, pf_ar_t * p_ar)
+{
+   int res = 0;
+   int16_t prio;
+   pf_apmx_t * p_apmx;
+   pf_alarm_queue_t * q;
+   pf_alarm_data_t alarm_data;
+
+   if (p_ar->alarm_enable == true)
+   {
+      for (prio = 1; prio >= 0; prio--)
+      {
+         p_apmx = &p_ar->apmx[prio];
+         q = &p_ar->alarm_send_q[prio];
+         if (p_apmx->p_alpmx->alpmi_state == PF_ALPMI_STATE_W_ALARM)
+         {
+            res = pf_alarm_fetch_send_queue (q, &alarm_data);
+            if (res == 0)
+            {
+               pf_alarm_send_internal (net, p_ar, p_apmx, &alarm_data);
+               /*
+                * If a high prio alarm is found don't check low low prio
+                * alarms until next call of this operation.
+                */
+               break;
+            }
+         }
+      }
+   }
+}
+
 /* ===== Common alarm functions ===== */
 void pf_alarm_enable (pf_ar_t * p_ar)
 {
@@ -2056,7 +2306,6 @@ bool pf_alarm_pending (const pf_ar_t * p_ar)
 int pf_alarm_activate (pnet_t * net, pf_ar_t * p_ar)
 {
    int ret = 0; /* Assume all goes well */
-
    if (pf_alarm_alpmx_activate (p_ar) != 0)
    {
       ret = -1;
@@ -2066,6 +2315,8 @@ int pf_alarm_activate (pnet_t * net, pf_ar_t * p_ar)
    {
       ret = -1;
    }
+
+   pf_alarm_reset_send_queues (net, p_ar);
 
    return ret;
 }
@@ -2235,93 +2486,6 @@ void pf_alarm_add_diag_item_to_summary (
    }
 }
 
-/**
- * @internal
- * Return the alarm specifier and maintenance status for a specific sub-slot,
- * by looking at all diagnosis items found for that subslot.
- *
- * Also includes the "current diag item" in the analysis.
- *
- * Describes diagnosis alarms.
- *
- * This corresponds to the "BuildSummarizedAlarmSpecifier" and
- * "BuildSummarizedMaintenanceStatus" functions mentioned in the standard.
- *
- * @param net              InOut: The p-net stack instance
- * @param p_ar             In:    The AR instance.
- * @param api_id           In:    The API identifier.
- * @param slot_nbr         In:    The slot number.
- * @param subslot_nbr      In:    The sub-slot number.
- * @param p_diag_item      In:    The current diag item (may be NULL).
- * @param p_alarm_spec     Out:   The computed alarm specifier.
- * @param p_maint_status   Out:   The computed maintenance status.
- * @return  0  if operation succeeded.
- *          -1 if an error occurred.
- */
-static int pf_alarm_get_diag_summary (
-   pnet_t * net,
-   const pf_ar_t * p_ar,
-   uint32_t api_id,
-   uint16_t slot_nbr,
-   uint16_t subslot_nbr,
-   const pf_diag_item_t * p_diag_item,
-   pnet_alarm_spec_t * p_alarm_spec,
-   uint32_t * p_maint_status)
-{
-   pf_device_t * p_dev = NULL;
-   pf_subslot_t * p_subslot = NULL;
-   uint16_t item_ix;
-   pf_diag_item_t * p_item = NULL;
-
-   if (pf_cmdev_get_device (net, &p_dev) == 0)
-   {
-      memset (p_alarm_spec, 0, sizeof (*p_alarm_spec));
-      *p_maint_status = 0;
-
-      /* Consider only alarms on this sub-slot. */
-      if (
-         pf_cmdev_get_subslot_full (
-            net,
-            api_id,
-            slot_nbr,
-            subslot_nbr,
-            &p_subslot) == 0)
-      {
-         /* Collect all diags into maintenanceStatus*/
-
-         /* First handle the "current" (unreported) item. */
-         if (p_diag_item != NULL)
-         {
-            pf_alarm_add_diag_item_to_summary (
-               p_ar,
-               p_subslot,
-               p_diag_item,
-               p_alarm_spec,
-               p_maint_status);
-         }
-
-         /* Now handle all the already reported diag items. */
-         item_ix = p_subslot->diag_list;
-         pf_cmdev_get_diag_item (net, item_ix, &p_item);
-         while (p_item != NULL)
-         {
-            /* Collect all diags into maintenanceStatus*/
-            pf_alarm_add_diag_item_to_summary (
-               p_ar,
-               p_subslot,
-               p_item,
-               p_alarm_spec,
-               p_maint_status);
-
-            item_ix = p_item->next;
-            pf_cmdev_get_diag_item (net, item_ix, &p_item);
-         }
-      }
-   }
-
-   return 0;
-}
-
 int pf_alarm_periodic (pnet_t * net)
 {
    uint16_t ix;
@@ -2335,6 +2499,7 @@ int pf_alarm_periodic (pnet_t * net)
          if ((p_ar != NULL) && (p_ar->in_use == true))
          {
             (void)pf_alarm_apmr_periodic (net, p_ar);
+            (void)pf_alarm_almpi_periodic (net, p_ar);
          }
       }
    }
@@ -2376,9 +2541,6 @@ int pf_alarm_alpmr_alarm_ack (
          p_apmx,
          &alarm_data,
          0,
-         0,
-         0,
-         NULL, /* No payload */
          p_pnio_status);
 
       p_alpmx->alpmr_state = PF_ALPMR_STATE_W_TACK;
@@ -2433,8 +2595,10 @@ int pf_alarm_alpmr_alarm_ack (
  *                                a diagnosis alarm. Otherwise NULL.
  *                                Custom data or pf_diag_item_t.
  * @return  0  if operation succeeded.
- *          -1 if an error occurred (or waiting for ACK from controller: re-try
- *             later).
+ *          -1 if an error occurred. Errors include:
+ *             Payload oversize (process alarms only)
+ *             Alarms not enabled for AR
+ *             Queue for outgoing alarms is full
  */
 static int pf_alarm_send_alarm (
    pnet_t * net,
@@ -2453,68 +2617,27 @@ static int pf_alarm_send_alarm (
 {
    int ret = -1;
    pf_alarm_data_t alarm_data;
-   uint32_t maint_status = 0;
-   pf_apmx_t * p_apmx = &p_ar->apmx[high_prio ? 1 : 0];
-   pf_alpmx_t * p_alpmx = &p_ar->alpmx[high_prio ? 1 : 0];
 
-   if ((net->global_alarm_enable == true) &&
-       (p_ar->alarm_enable == true))
+   if (
+      net->global_alarm_enable == true && p_ar->alarm_enable == true &&
+      payload_len <= sizeof (alarm_data.payload.data))
    {
-      if (p_alpmx->alpmi_state == PF_ALPMI_STATE_W_ALARM)
-      {
-         /* Prepare data */
-         memset (&alarm_data, 0, sizeof (alarm_data));
-         alarm_data.alarm_type = alarm_type;
-         alarm_data.api_id = api_id;
-         alarm_data.slot_nbr = slot_nbr;
-         alarm_data.subslot_nbr = subslot_nbr;
-         alarm_data.module_ident = module_ident;
-         alarm_data.submodule_ident = submodule_ident;
+      /* Prepare data */
+      memset (&alarm_data, 0, sizeof (alarm_data));
+      alarm_data.alarm_type = alarm_type;
+      alarm_data.api_id = api_id;
+      alarm_data.slot_nbr = slot_nbr;
+      alarm_data.subslot_nbr = subslot_nbr;
+      alarm_data.module_ident = module_ident;
+      alarm_data.submodule_ident = submodule_ident;
 
-         /* Check if there is any (other) diagnosis for this subslot */
-         (void)pf_alarm_get_diag_summary (
-            net,
-            p_ar,
-            api_id,
-            slot_nbr,
-            subslot_nbr,
-            p_diag_item,
-            &alarm_data.alarm_specifier,
-            &maint_status);
+      alarm_data.payload.usi = payload_usi;
+      alarm_data.payload.len = payload_len;
+      memcpy (alarm_data.payload.data, p_payload, payload_len);
 
-         /* Calculate sequence numbers */
-         alarm_data.sequence_number = p_alpmx->sequence_number;
-         p_alpmx->prev_sequence_number = p_alpmx->sequence_number;
-         p_alpmx->sequence_number++;
-         p_alpmx->sequence_number %= 0x0800;
-
-         /* Create and send an DATA RTA-PDU */
-         ret = pf_alarm_apms_apms_a_data_req (
-            net,
-            p_apmx,
-            &alarm_data,
-            maint_status,
-            payload_usi,
-            payload_len,
-            p_payload,
-            NULL);
-
-         p_alpmx->alpmi_state = PF_ALPMI_STATE_W_ACK;
-      }
-      else
-      {
-         /* The standard says that ALPMI_Alarm_Notification.cnf(-) should be
-          * sent back to application */
-         LOG_INFO (
-            PF_ALARM_LOG,
-            "Alarm(%d): Skipped sending the alarm, as the ALPMI state is %s.\n",
-            __LINE__,
-            pf_alarm_alpmi_state_to_string (p_alpmx->alpmi_state));
-      }
-   }
-   else
-   {
-      ret = 0; /* ToDo: Is this right? */
+      return pf_alarm_add_send_queue (
+         &p_ar->alarm_send_q[high_prio ? 1 : 0],
+         &alarm_data);
    }
 
    return ret;
@@ -2586,7 +2709,6 @@ int pf_alarm_send_diagnosis (
 
    if (p_diag_item != NULL)
    {
-
       /* Calculate alarm type */
       if (p_diag_item->usi >= PF_USI_CHANNEL_DIAGNOSIS)
       {
@@ -2627,7 +2749,7 @@ int pf_alarm_send_diagnosis (
          module_ident,
          submodule_ident,
          p_diag_item->usi,
-         0, /* Not using manufacturer specific payload */
+         sizeof (*p_diag_item),
          (uint8_t *)p_diag_item);
    }
    else

--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -619,16 +619,20 @@ static int pf_alarm_alpmr_apmr_a_data_ind (
       alarm_arg.alarm_specifier = p_alarm_data->alarm_specifier;
       alarm_arg.sequence_number = p_alarm_data->sequence_number;
 
-      ret = pf_fspm_alpmr_alarm_ind (
+      p_apmx->p_alpmx->alpmr_state = PF_ALPMR_STATE_W_USER_ACK;
+
+      /*
+       * Indicate alarm to app. App must respond to callback
+       * using pnet_alarm_send_ack()
+       */
+      (void)pf_fspm_alpmr_alarm_ind (
          net,
          p_apmx->p_ar,
          &alarm_arg,
          data_len,
          data_usi,
          p_data);
-
-      /* App must now send an ACK or a NACK */
-      p_apmx->p_alpmx->alpmr_state = PF_ALPMR_STATE_W_USER_ACK;
+      ret = 0;
       break;
    case PF_ALPMR_STATE_W_USER_ACK:
       /* ToDo: "Combine data for the RTA error request */

--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -844,7 +844,7 @@ static void pf_alarm_apms_timeout (
          p_apmx->apms_state = PF_APMS_STATE_OPEN;
 
          p_apmx->p_ar->err_cls = PNET_ERROR_CODE_1_APMS;
-         p_apmx->p_ar->err_code = PNET_ERROR_CODE_2_APMS_TIMEOUT;
+         p_apmx->p_ar->err_code = PNET_ERROR_CODE_2_ABORT_AR_ALARM_SEND_CNF_NEG;
          pf_alarm_error_ind (
             net,
             p_apmx,
@@ -2086,55 +2086,148 @@ int pf_alarm_close (pnet_t * net, pf_ar_t * p_ar)
 
 /**
  * @internal
- * Return the alarm specifier and maintenance status for a diagnosis item.
+ * Update the alarm specifier and maintenance status from a diagnosis item.
  *
- * Add one diag item to the alarm digest.
+ * Add one diag item to the alarm summary (this function is typically executed
+ * several times on different diagnosis items to update the same alarm
+ * specifier and maintenance status values).
+ *
+ * Looks at:
+ *   p_diag_item->usi
+ *   p_diag_item->fmt.std.ch_properties
+ *   p_diag_item->fmt.std.qual_ch_qualifier
+ *
  * @param p_ar             In:    The AR instance.
  * @param p_subslot        In:    The subslot instance.
  * @param p_diag_item      In:    The diag item.
- * @param p_alarm_spec     Out:   The computed alarm specifier. Describes
- *                                diagnosis alarms.
- * @param p_maint_status   Out:   The computed maintenance status.
+ * @param p_alarm_spec     InOut: The updated alarm specifier.
+ *                                Describes diagnosis alarms.
+ * @param p_maint_status   InOut: The updated maintenance status.
+ *                                Describes diagnosis alarms.
  */
-static void pf_alarm_add_item_to_digest (
-   pf_ar_t * p_ar,
+void pf_alarm_add_diag_item_to_summary (
+   const pf_ar_t * p_ar,
    const pf_subslot_t * p_subslot,
    const pf_diag_item_t * p_diag_item,
    pnet_alarm_spec_t * p_alarm_spec,
    uint32_t * p_maint_status)
 {
+   bool is_fault = false;
+   bool is_maintenance_demanded = false;
+   bool is_maintenance_required = false;
+   bool is_appears = false;
+   bool is_same_ar = false;
+   uint32_t severity_qualifier = 0;
+
+   /* Is the diagnosis on the same AR? */
+   if (p_subslot->p_ar == p_ar)
+   {
+      is_same_ar = true;
+   }
+
    if (p_diag_item->usi < PF_USI_CHANNEL_DIAGNOSIS)
    {
+      /* Diagnosis in manufacturer specific format (always FAULT) */
+
       p_alarm_spec->manufacturer_diagnosis = true;
+      p_alarm_spec->submodule_diagnosis = true;
+      if (is_same_ar == true)
+      {
+         p_alarm_spec->ar_diagnosis = true;
+      }
    }
    else
    {
-      *p_maint_status |= p_diag_item->fmt.std.qual_ch_qualifier;
+      /* Diagnosis in standard format */
+
+      severity_qualifier =
+         (p_diag_item->fmt.std.qual_ch_qualifier & ~0x00000007);
+
+      /* Severity "Maintenance required" */
       if (
          PNET_DIAG_CH_PROP_MAINT_GET (p_diag_item->fmt.std.ch_properties) ==
          PNET_DIAG_CH_PROP_MAINT_REQUIRED)
       {
-         *p_maint_status |= BIT (0); /* Set MaintenanceRequired bit */
+         is_maintenance_required = true;
       }
+      else if (
+         PNET_DIAG_CH_PROP_MAINT_GET (p_diag_item->fmt.std.ch_properties) ==
+         PNET_DIAG_CH_PROP_MAINT_QUALIFIED)
+      {
+         if ((severity_qualifier & PNET_DIAG_QUALIFIER_MASK_REQUIRED) > 0)
+         {
+            is_maintenance_required = true;
+         }
+      }
+
+      /* Severity "Maintenance demanded"  */
       if (
          PNET_DIAG_CH_PROP_MAINT_GET (p_diag_item->fmt.std.ch_properties) ==
          PNET_DIAG_CH_PROP_MAINT_DEMANDED)
       {
-         *p_maint_status |= BIT (1); /* Set MaintenanceDemanded bit */
+         is_maintenance_demanded = true;
+      }
+      else if (
+         PNET_DIAG_CH_PROP_MAINT_GET (p_diag_item->fmt.std.ch_properties) ==
+         PNET_DIAG_CH_PROP_MAINT_QUALIFIED)
+      {
+         if ((severity_qualifier & PNET_DIAG_QUALIFIER_MASK_DEMANDED) > 0)
+         {
+            is_maintenance_demanded = true;
+         }
       }
 
+      /* Severity "Fault" */
       if (
          PNET_DIAG_CH_PROP_MAINT_GET (p_diag_item->fmt.std.ch_properties) ==
          PNET_DIAG_CH_PROP_MAINT_FAULT)
       {
-         p_alarm_spec->submodule_diagnosis = true;
-         if (p_subslot->p_ar == p_ar)
+         is_fault = true;
+      }
+      else if (
+         PNET_DIAG_CH_PROP_MAINT_GET (p_diag_item->fmt.std.ch_properties) ==
+         PNET_DIAG_CH_PROP_MAINT_QUALIFIED)
+      {
+         if ((severity_qualifier & PNET_DIAG_QUALIFIER_MASK_FAULT) > 0)
          {
-            /* We found a FAULT that belongs to a specific AR */
-            p_alarm_spec->ar_diagnosis = true;
+            is_fault = true;
          }
       }
-      p_alarm_spec->channel_diagnosis = true;
+
+      /* Is the diagnosis appearing */
+      if (
+         PNET_DIAG_CH_PROP_SPEC_GET (p_diag_item->fmt.std.ch_properties) ==
+         PNET_DIAG_CH_PROP_SPEC_APPEARS)
+      {
+         is_appears = true;
+      }
+
+      /* Maintenance qualifier bits */
+      *p_maint_status |= severity_qualifier;
+
+      /* MaintenanceRequired and MaintenanceDemanded bits */
+      if (is_maintenance_required == true)
+      {
+         *p_maint_status |= BIT (0);
+      }
+      if (is_maintenance_demanded == true)
+      {
+         *p_maint_status |= BIT (1);
+      }
+
+      /* Alarm specifiers for diagnosis in standard format */
+      if (is_appears == true)
+      {
+         p_alarm_spec->channel_diagnosis = true;
+      }
+      if (is_appears == true && is_fault == true)
+      {
+         p_alarm_spec->submodule_diagnosis = true;
+      }
+      if (is_appears == true && is_fault == true && is_same_ar == true)
+      {
+         p_alarm_spec->ar_diagnosis = true;
+      }
    }
 }
 
@@ -2143,7 +2236,12 @@ static void pf_alarm_add_item_to_digest (
  * Return the alarm specifier and maintenance status for a specific sub-slot,
  * by looking at all diagnosis items found for that subslot.
  *
+ * Also includes the "current diag item" in the analysis.
+ *
  * Describes diagnosis alarms.
+ *
+ * This corresponds to the "BuildSummarizedAlarmSpecifier" and
+ * "BuildSummarizedMaintenanceStatus" functions mentioned in the standard.
  *
  * @param net              InOut: The p-net stack instance
  * @param p_ar             In:    The AR instance.
@@ -2156,9 +2254,9 @@ static void pf_alarm_add_item_to_digest (
  * @return  0  if operation succeeded.
  *          -1 if an error occurred.
  */
-static int pf_alarm_get_diag_digest (
+static int pf_alarm_get_diag_summary (
    pnet_t * net,
-   pf_ar_t * p_ar,
+   const pf_ar_t * p_ar,
    uint32_t api_id,
    uint16_t slot_nbr,
    uint16_t subslot_nbr,
@@ -2190,7 +2288,7 @@ static int pf_alarm_get_diag_digest (
          /* First handle the "current" (unreported) item. */
          if (p_diag_item != NULL)
          {
-            pf_alarm_add_item_to_digest (
+            pf_alarm_add_diag_item_to_summary (
                p_ar,
                p_subslot,
                p_diag_item,
@@ -2204,7 +2302,7 @@ static int pf_alarm_get_diag_digest (
          while (p_item != NULL)
          {
             /* Collect all diags into maintenanceStatus*/
-            pf_alarm_add_item_to_digest (
+            pf_alarm_add_diag_item_to_summary (
                p_ar,
                p_subslot,
                p_item,
@@ -2327,7 +2425,8 @@ int pf_alarm_alpmr_alarm_ack (
  * @param payload_len      In:    Payload length. Must be > 0 for manufacturer
  *                                specific payload ("USI format", which is
  *                                the payload_usi range 0x0001..0x7fff).
- * @param p_payload        In:    Mandatory if payload_usi > 0. May be NULL.
+ * @param p_payload        In:    Mandatory if payload_len > 0, or if sending
+ *                                a diagnosis alarm. Otherwise NULL.
  *                                Custom data or pf_diag_item_t.
  * @return  0  if operation succeeded.
  *          -1 if an error occurred (or waiting for ACK from controller: re-try
@@ -2366,7 +2465,9 @@ static int pf_alarm_send_alarm (
          alarm_data.subslot_nbr = subslot_nbr;
          alarm_data.module_ident = module_ident;
          alarm_data.submodule_ident = submodule_ident;
-         (void)pf_alarm_get_diag_digest (
+
+         /* Check if there is any (other) diagnosis for this subslot */
+         (void)pf_alarm_get_diag_summary (
             net,
             p_ar,
             api_id,
@@ -2436,6 +2537,19 @@ int pf_alarm_send_process (
       payload_len,
       payload_usi);
 
+   if (payload_usi >= PF_USI_CHANNEL_DIAGNOSIS)
+   {
+      LOG_ERROR (
+         PNET_LOG,
+         "DIAG(%d): Wrong USI given for process alarm: %u Slot: %u "
+         "Subslot %u\n",
+         __LINE__,
+         payload_usi,
+         slot_nbr,
+         subslot_nbr);
+      return -1;
+   }
+
    return pf_alarm_send_alarm (
       net,
       p_ar,
@@ -2461,24 +2575,62 @@ int pf_alarm_send_diagnosis (
    const pf_diag_item_t * p_diag_item)
 {
    int ret = -1;
+   pf_alarm_type_values_t alarm_type = PF_ALARM_TYPE_DIAGNOSIS;
+   uint32_t module_ident = PNET_MOD_DAP_IDENT;
+   uint32_t submodule_ident = PNET_SUBMOD_DAP_INTERFACE_1_PORT_0_IDENT;
 
-   LOG_INFO (PF_ALARM_LOG, "Alarm(%d): Sending diagnosis alarm\n", __LINE__);
    if (p_diag_item != NULL)
    {
+
+      /* Calculate alarm type */
+      if (p_diag_item->usi >= PF_USI_CHANNEL_DIAGNOSIS)
+      {
+         switch (p_diag_item->fmt.std.ch_error_type)
+         {
+         case PF_WRT_ERROR_REMOTE_MISMATCH:
+            alarm_type = PF_ALARM_TYPE_PORT_DATA_CHANGE;
+            break;
+         default:
+            break;
+         }
+      }
+
+      // TODO Calculate module_ident, submodule_ident
+      // The ModuleIdentNumber of the portsubmodule which is connected to device
+      // ‘b’ The SubModuleIdentNumber of the portsubmodule which is connected to
+      // device ‘b’
+
+      LOG_INFO (
+         PF_ALARM_LOG,
+         "Alarm(%d): Sending diagnosis alarm (type 0x%04X) Slot: %u  Subslot: "
+         "0x%04X  USI: 0x%04X\n",
+         __LINE__,
+         alarm_type,
+         slot_nbr,
+         subslot_nbr,
+         p_diag_item->usi);
+
       ret = pf_alarm_send_alarm (
          net,
          p_ar,
-         PF_ALARM_TYPE_DIAGNOSIS,
+         alarm_type,
          false, /* Low prio */
          api_id,
          slot_nbr,
          subslot_nbr,
          p_diag_item,
-         0,
-         0, /* module_ident, submodule_ident */
+         module_ident,
+         submodule_ident,
          p_diag_item->usi,
-         sizeof (*p_diag_item),
+         0, /* Not using manufacturer specific payload */
          (uint8_t *)p_diag_item);
+   }
+   else
+   {
+      LOG_ERROR (
+         PF_ALARM_LOG,
+         "Alarm(%d): The diagnosis item is NULL\n",
+         __LINE__);
    }
 
    return ret;
@@ -2491,23 +2643,20 @@ int pf_alarm_send_pull (
    uint16_t slot_nbr,
    uint16_t subslot_nbr)
 {
-   uint16_t alarm_type;
+   uint16_t alarm_type = PF_ALARM_TYPE_PULL;
 
-   LOG_INFO (PF_ALARM_LOG, "Alarm(%d): Sending pull alarm\n", __LINE__);
+   LOG_INFO (
+      PF_ALARM_LOG,
+      "Alarm(%d): Sending pull alarm. Slot: %u  Subslot: 0x%04X\n",
+      __LINE__,
+      slot_nbr,
+      subslot_nbr);
    if (subslot_nbr == 0)
    {
       if (p_ar->ar_param.ar_properties.pull_module_alarm_allowed == true)
       {
          alarm_type = PF_ALARM_TYPE_PULL_MODULE;
       }
-      else
-      {
-         alarm_type = PF_ALARM_TYPE_PULL;
-      }
-   }
-   else
-   {
-      alarm_type = PF_ALARM_TYPE_PULL;
    }
 
    (void)pf_alarm_send_alarm (

--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -2453,7 +2453,8 @@ static int pf_alarm_send_alarm (
    pf_apmx_t * p_apmx = &p_ar->apmx[high_prio ? 1 : 0];
    pf_alpmx_t * p_alpmx = &p_ar->alpmx[high_prio ? 1 : 0];
 
-   if (net->global_alarm_enable == true)
+   if ((net->global_alarm_enable == true) &&
+       (p_ar->alarm_enable == true))
    {
       if (p_alpmx->alpmi_state == PF_ALPMI_STATE_W_ALARM)
       {

--- a/src/common/pf_alarm.h
+++ b/src/common/pf_alarm.h
@@ -258,6 +258,15 @@ int pf_alarm_alpmr_alarm_ack (
  */
 void pf_alarm_show (const pf_ar_t * p_ar);
 
+/************ Internal functions, made available for unit testing ************/
+
+void pf_alarm_add_diag_item_to_summary (
+   const pf_ar_t * p_ar,
+   const pf_subslot_t * p_subslot,
+   const pf_diag_item_t * p_diag_item,
+   pnet_alarm_spec_t * p_alarm_spec,
+   uint32_t * p_maint_status);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -4243,19 +4243,8 @@ static int pf_cmdev_check_apdu (
    return ret;
 }
 
-/**
- * @internal
- * Generate module diffs, when needed, for the specified AR.
- * @param net              InOut: The p-net stack instance
- * @param p_ar             InOut: The AR instance.
- * @param p_stat           Out:   Detailed result of the operation.
- * @return  0  if no diff was detected.
- *          -1 if a diff was detected.
- */
-static int pf_cmdev_generate_submodule_diff (
-   pnet_t * net,
-   pf_ar_t * p_ar,
-   pnet_result_t * p_stat)
+
+int pf_cmdev_generate_submodule_diff (pnet_t * net, pf_ar_t * p_ar)
 {
    int ret = 0;
    uint16_t exp_api_ix;
@@ -4272,8 +4261,9 @@ static int pf_cmdev_generate_submodule_diff (
    bool has_api_diff = false;
    bool has_mod_diff = false;
    bool has_sub_diff = false;
+   pf_submodule_state_t * p_submodule_state;
 
-   /* Generate a diff if needed */
+   /* Generate a diff including all expected (sub)modules */
    for (exp_api_ix = 0; exp_api_ix < p_ar->nbr_exp_apis; exp_api_ix++)
    {
       p_ar->api_diffs[nbr_api_diffs].api = p_ar->exp_apis[exp_api_ix].api;
@@ -4386,6 +4376,34 @@ static int pf_cmdev_generate_submodule_diff (
                            .module_diffs[nbr_mod_diffs]
                            .submodule_diffs[nbr_sub_diffs]
                            .submodule_state.ident_info = PF_SUBMOD_PLUG_WRONG;
+                        has_sub_diff = true;
+                     }
+
+                     /* Check submodule diagnosis state and update diff. */
+                     p_submodule_state = &p_ar->api_diffs[nbr_api_diffs]
+                                             .module_diffs[nbr_mod_diffs]
+                                             .submodule_diffs[nbr_sub_diffs]
+                                             .submodule_state;
+
+                     if (
+                        (p_cfg_subslot->submodule_state.fault == true) ||
+                        (p_cfg_subslot->submodule_state.maintenance_demanded ==
+                         true) ||
+                        (p_cfg_subslot->submodule_state.maintenance_required ==
+                         true))
+                     {
+                        p_ar->api_diffs[nbr_api_diffs]
+                           .module_diffs[nbr_mod_diffs]
+                           .submodule_diffs[nbr_sub_diffs]
+                           .submodule_ident_number =
+                           p_cfg_subslot->submodule_ident_number;
+
+                        p_submodule_state->fault =
+                           p_cfg_subslot->submodule_state.fault;
+                        p_submodule_state->maintenance_demanded =
+                           p_cfg_subslot->submodule_state.maintenance_demanded;
+                        p_submodule_state->maintenance_required =
+                           p_cfg_subslot->submodule_state.maintenance_required;
                         has_sub_diff = true;
                      }
                   }
@@ -4639,7 +4657,7 @@ int pf_cmdev_rm_connect_ind (
    /* RM_Connect.ind */
    if (
       (pf_cmdev_check_apdu (net, p_ar, p_connect_result) == 0) &&
-      (pf_cmdev_generate_submodule_diff (net, p_ar, p_connect_result) == 0))
+      (pf_cmdev_generate_submodule_diff (net, p_ar) == 0))
    {
       /* Start building the response to the connect request. */
       memcpy (

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -4866,6 +4866,12 @@ int pf_cmdev_rm_ccontrol_cnf (
           */
          if (p_control_io->control_command == BIT (PF_CONTROL_COMMAND_BIT_DONE))
          {
+            /*
+             * Alarm transmitter enabled on APPLRDY CNF.
+             * PN-AL-protocol (Mar20) Figure A.7
+             */
+            pf_alarm_enable (p_ar);
+
             if (p_ar->ready_4_data == true)
             {
                (void)pf_cmdev_state_ind (net, p_ar, PNET_EVENT_DATA);

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -178,7 +178,7 @@ int pf_cmdev_get_api (pnet_t * net, uint32_t api_id, pf_api_t ** pp_api)
  * @internal
  * Get an slot instance of an API.
  * @param p_api            InOut: The API instance.
- * @param slot_nbr         In:    The slot number.
+ * @param slot_nbr         In:    The slot number (must be in_use)
  * @param pp_slot          Out:   The slot instance.
  * @return  0  if operation succeeded.
  *          -1 if an error occurred.
@@ -221,7 +221,7 @@ static int pf_cmdev_get_slot (
  * @internal
  * Get an sub-slot instance of a slot instance.
  * @param p_slot           InOut: The slot instance.
- * @param subslot_nbr      In:    The sub-slot number.
+ * @param subslot_nbr      In:    The sub-slot number (must be in_use).
  * @param pp_subslot       Out:   The sub-slot instance.
  * @return  0  if operation succeeded.
  *          -1 if an error occurred.
@@ -1183,7 +1183,7 @@ static int pf_cmdev_cfg_slot_show (pf_slot_t * p_slot)
 static int pf_cmdev_cfg_subslot_show (pf_subslot_t * p_subslot)
 {
    printf ("      >>>SUBSLOT<<<\n");
-   printf ("      subslot_nbr     = %u\n", (unsigned)p_subslot->subslot_nbr);
+   printf ("      subslot_nbr     = 0x%04X\n", (unsigned)p_subslot->subslot_nbr);
    printf ("      in_use          = %u\n", (unsigned)p_subslot->in_use);
    printf (
       "      plug_state      = %s\n",
@@ -1191,16 +1191,25 @@ static int pf_cmdev_cfg_subslot_show (pf_subslot_t * p_subslot)
          p_subslot->submodule_state.ident_info));
    printf ("      AR              = %p\n", p_subslot->p_ar);
    printf (
-      "      submod_ident    = %u\n",
+      "      submod_ident    = 0x%08X\n",
       (unsigned)p_subslot->submodule_ident_number);
    printf (
-      "      exp_sub_ident   = %u\n",
+      "      exp_sub_ident   = 0x%08X\n",
       (unsigned)p_subslot->exp_submodule_ident_number);
    printf (
       "      direction       = %s\n",
       pf_cmdev_direction_to_string (p_subslot->direction));
    printf ("      length_input    = %u\n", (unsigned)p_subslot->length_input);
    printf ("      length_output   = %u\n", (unsigned)p_subslot->length_output);
+   printf ("      diag list start = ");
+   if (p_subslot->diag_list == PF_DIAG_IX_NULL)
+   {
+      printf ("PF_DIAG_IX_NULL (no diagnosis items)\n");
+   }
+   else
+   {
+      printf ("%u\n", (unsigned)p_subslot->diag_list);
+   }
 
    return 0;
 }
@@ -1220,6 +1229,7 @@ void pf_cmdev_diag_show (const pnet_t * net)
 {
    uint16_t ix = 0;
    uint16_t total = 0;
+   const pf_diag_item_t * p_diag;
 
    printf ("DIAGNOSIS\n");
    printf (
@@ -1237,15 +1247,28 @@ void pf_cmdev_diag_show (const pnet_t * net)
 
    for (ix = 0; ix < NELEMENTS (net->cmdev_device.diag_items); ix++)
    {
-      if (net->cmdev_device.diag_items[ix].in_use == true)
+      p_diag = &net->cmdev_device.diag_items[ix];
+      if (p_diag->in_use == true)
       {
-         printf ("[%u] USI: 0x%04X", ix, net->cmdev_device.diag_items[ix].usi);
-         if (net->cmdev_device.diag_items[ix].usi >= 0x8000)
+         printf ("[%3u] USI: 0x%04X ", ix, p_diag->usi);
+         if (p_diag->next == UINT16_MAX)
+         {
+            printf (" [Last]  ");
+         }
+         else
+         {
+            printf ("Next: %3u", p_diag->next);
+         }
+
+         if (p_diag->usi >= PF_USI_CHANNEL_DIAGNOSIS)
          {
             printf (
-               "  Channel: %u  Channel error type: 0x%04X\n",
-               net->cmdev_device.diag_items[ix].fmt.std.ch_nbr,
-               net->cmdev_device.diag_items[ix].fmt.std.ch_error_type);
+               "  Channel: 0x%04X  Ch.error: 0x%04X  Ext.error 0x%04X  "
+               "Add.value 0x%08" PRIX32 "\n",
+               p_diag->fmt.std.ch_nbr,
+               p_diag->fmt.std.ch_error_type,
+               p_diag->fmt.std.ext_ch_error_type,
+               p_diag->fmt.std.ext_ch_add_value);
          }
          else
          {

--- a/src/device/pf_cmdev.h
+++ b/src/device/pf_cmdev.h
@@ -244,6 +244,15 @@ int pf_cmdev_new_diag (pnet_t * net, uint16_t * p_item_ix);
 void pf_cmdev_free_diag (pnet_t * net, uint16_t item_ix);
 
 /**
+ * Generate module diffs, when needed, for the specified AR.
+ * @param net              InOut: The p-net stack instance
+ * @param p_ar             InOut: The AR instance.
+ * @return  0  if no diff was detected.
+ *          -1 if a diff was detected.
+ */
+int pf_cmdev_generate_submodule_diff (pnet_t * net, pf_ar_t * p_ar);
+
+/**
  * Return a string representation of the specified CMDEV state.
  * @param state            In:    The CMDEV state.
  * @return  A string representation of the CMDEV state.

--- a/src/device/pf_cmrdr.c
+++ b/src/device/pf_cmrdr.c
@@ -865,6 +865,7 @@ int pf_cmrdr_rm_read_ind (
          ret = 0;
          break;
       case PF_IDX_AR_MOD_DIFF:
+         pf_cmdev_generate_submodule_diff (net, p_ar);
          pf_put_ar_diff (true, p_ar, res_size, p_res, p_pos);
          ret = 0;
          break;

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -1668,8 +1668,6 @@ static int pf_cmrpc_rm_connect_ind (
    int ret = -1;
    pf_ar_t * p_ar = NULL;
    pf_ar_t * p_ar_2 = NULL; /* When looking for duplicate */
-   int loc_port_num = PNET_PORT_1;
-   pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
 
    if (p_sess->rpc_result.pnio_status.error_code != 0)
    {
@@ -1760,8 +1758,6 @@ static int pf_cmrpc_rm_connect_ind (
    }
    else
    {
-      p_port_data->pdport.adjust.active = false;
-      p_port_data->pdport.check.active = false;
       pf_lldp_tx_restart (net, true);
    }
 

--- a/src/device/pf_diag.c
+++ b/src/device/pf_diag.c
@@ -588,6 +588,8 @@ int pf_diag_update (
             p_item->next = p_subslot->diag_list;
             p_subslot->diag_list = item_ix;
 
+            pf_diag_update_submodule_state (net, p_ar, p_subslot);
+
             /* TODO Use better strategy to find AR */
             if (pf_diag_find_first_ar (net, &p_ar) == 0)
             {
@@ -743,6 +745,7 @@ int pf_diag_remove (
                   "DIAG(%d): No active connection, so no alarm is sent.\n",
                   __LINE__);
             }
+            pf_diag_update_submodule_state (net, p_ar, p_subslot);
          }
 
          /* Free diag entry */

--- a/src/device/pf_diag.c
+++ b/src/device/pf_diag.c
@@ -47,6 +47,11 @@
 #include "pf_block_reader.h"
 #include "pf_block_writer.h"
 
+/** Which diagnosis mechanism to use when messaging the PLC.
+ *  Normally PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS would be used as it has
+ *  more features, but it does not yet seem fully supported by Wireshark. */
+#define PF_DIAG_PREFERRED_DIAGNOSIS_USI PF_USI_EXTENDED_CHANNEL_DIAGNOSIS
+
 int pf_diag_init (void)
 {
    return 0;
@@ -231,9 +236,34 @@ static void pf_diag_find_entry (
    }
 }
 
+/**
+ * @internal
+ * Find first used ar.
+ *
+ * @param net              InOut: The p-net stack instance.
+ * @param pp_ar            Out:   Resulting ar
+ * @return 0 on success, -1 on error.
+ */
+static int pf_diag_find_first_ar (pnet_t * net, pf_ar_t ** pp_ar)
+{
+   int ret = -1;
+   uint16_t ix;
+
+   for (ix = 0; ix < NELEMENTS (net->cmrpc_ar); ix++)
+   {
+      if (net->cmrpc_ar[ix].in_use == true)
+      {
+         *pp_ar = &net->cmrpc_ar[ix];
+         ret = 0;
+         break;
+      }
+   }
+
+   return ret;
+}
+
 int pf_diag_add (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    pnet_diag_ch_prop_type_values_t ch_bits,
    pnet_diag_ch_prop_maint_values_t severity,
@@ -252,6 +282,7 @@ int pf_diag_add (
    bool overwrite = false;
    pf_diag_item_t old_item;
    uint16_t ch_properties = 0;
+   pf_ar_t * p_ar = NULL;
 
    /* Remove reserved bits before we use it */
    /* TODO: Validate qual_ch_qualifier */
@@ -351,10 +382,7 @@ int pf_diag_add (
                   ch_properties,
                   PNET_DIAG_CH_PROP_SPEC_APPEARS);
 
-               p_item->usi = PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS;
-               PNET_DIAG_CH_PROP_SPEC_SET (
-                  p_item->fmt.std.ch_properties,
-                  PNET_DIAG_CH_PROP_SPEC_APPEARS);
+               p_item->usi = PF_DIAG_PREFERRED_DIAGNOSIS_USI;
                p_item->fmt.std.ch_nbr = p_diag_source->ch;
                p_item->fmt.std.ch_properties = ch_properties;
                p_item->fmt.std.ch_error_type = ch_error_type;
@@ -363,21 +391,22 @@ int pf_diag_add (
                p_item->fmt.std.qual_ch_qualifier = qual_ch_qualifier;
             }
 
-            ret = pf_alarm_send_diagnosis (
-               net,
-               p_ar,
-               p_diag_source->api,
-               p_diag_source->slot,
-               p_diag_source->subslot,
-               p_item);
+            /* Link it into the sub-slot reported list */
+            p_item->next = p_subslot->diag_list;
+            p_subslot->diag_list = item_ix;
 
-            pf_diag_update_station_problem_indicator (net, p_ar, p_subslot);
-
-            if (ret == 0)
+            /* TODO Use better strategy to find AR */
+            if (pf_diag_find_first_ar (net, &p_ar) == 0)
             {
-               /* Link it into the sub-slot reported list */
-               p_item->next = p_subslot->diag_list;
-               p_subslot->diag_list = item_ix;
+               ret = pf_alarm_send_diagnosis (
+                  net,
+                  p_ar,
+                  p_diag_source->api,
+                  p_diag_source->slot,
+                  p_diag_source->subslot,
+                  p_item);
+
+               pf_diag_update_station_problem_indicator (net, p_ar, p_subslot);
 
                if (overwrite == true)
                {
@@ -398,6 +427,17 @@ int pf_diag_add (
                      &old_item);
                }
             }
+            else
+            {
+               LOG_ERROR (
+                  PNET_LOG,
+                  "DIAG(%d): No active connection, so no alarm is sent.\n",
+                  __LINE__);
+            }
+         }
+         else
+         {
+            LOG_ERROR (PNET_LOG, "DIAG(%d): p_item is NULL\n", __LINE__);
          }
       }
       else
@@ -413,7 +453,6 @@ int pf_diag_add (
 
 int pf_diag_update (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type,
@@ -427,6 +466,7 @@ int pf_diag_update (
    pf_diag_item_t * p_item = NULL;
    pf_diag_item_t old_item;
    uint16_t item_ix = PF_DIAG_IX_NULL;
+   pf_ar_t * p_ar = NULL;
 
    if (usi > PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS)
    {
@@ -476,26 +516,30 @@ int pf_diag_update (
                p_item->fmt.std.ext_ch_add_value = ext_ch_add_value;
             }
 
-            ret = pf_alarm_send_diagnosis (
-               net,
-               p_ar,
-               p_diag_source->api,
-               p_diag_source->slot,
-               p_diag_source->subslot,
-               p_item);
-            if (ret == 0)
-            {
-               /* Link it into the sub-slot diag list */
-               p_item->next = p_subslot->diag_list;
-               p_subslot->diag_list = item_ix;
+            /* Link it into the sub-slot diag list */
+            p_item->next = p_subslot->diag_list;
+            p_subslot->diag_list = item_ix;
 
+            /* TODO Use better strategy to find AR */
+            if (pf_diag_find_first_ar (net, &p_ar) == 0)
+            {
+               ret = pf_alarm_send_diagnosis (
+                  net,
+                  p_ar,
+                  p_diag_source->api,
+                  p_diag_source->slot,
+                  p_diag_source->subslot,
+                  p_item);
+
+               pf_diag_update_station_problem_indicator (net, p_ar, p_subslot);
+
+               /* Remove the old diag by sending a disappear alarm */
                if (old_item.usi >= PF_USI_CHANNEL_DIAGNOSIS)
                {
                   PNET_DIAG_CH_PROP_SPEC_SET (
                      old_item.fmt.std.ch_properties,
                      PNET_DIAG_CH_PROP_SPEC_DIS_OTHERS_REMAIN);
                }
-               /* Remove the old diag by sending a disappear alarm */
                ret = pf_alarm_send_diagnosis (
                   net,
                   p_ar,
@@ -504,8 +548,13 @@ int pf_diag_update (
                   p_diag_source->subslot,
                   &old_item);
             }
-
-            pf_diag_update_station_problem_indicator (net, p_ar, p_subslot);
+            else
+            {
+               LOG_ERROR (
+                  PNET_LOG,
+                  "DIAG(%d): No active connection, so no alarm is sent.\n",
+                  __LINE__);
+            }
          }
          else
          {
@@ -526,7 +575,6 @@ int pf_diag_update (
 
 int pf_diag_remove (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type,
@@ -537,6 +585,7 @@ int pf_diag_remove (
    pf_subslot_t * p_subslot = NULL;
    uint16_t item_ix = PF_DIAG_IX_NULL;
    pf_diag_item_t * p_item = NULL;
+   pf_ar_t * p_ar = NULL;
 
    if (usi > PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS)
    {
@@ -569,57 +618,72 @@ int pf_diag_remove (
       {
          if (pf_cmdev_get_diag_item (net, item_ix, &p_item) == 0)
          {
-            if (p_subslot->diag_list != PF_DIAG_IX_NULL)
+            /* TODO Use better strategy to find AR */
+            if (pf_diag_find_first_ar (net, &p_ar) == 0)
             {
-               /*
-                * If diagnosis information is removed a diagnosis alarm with
-                * specifier DISAPPEARS is queued into the alarm queue. ToDo: If
-                * the channel has other diagnosis information of the same
-                * severity, the specifier PNET_DIAG_CH_SPEC_DIS_OTHERS_REMAIN is
-                * used instead.
-                */
-               if (p_item->usi >= PF_USI_CHANNEL_DIAGNOSIS)
+               if (p_subslot->diag_list != PF_DIAG_IX_NULL)
                {
+                  /*
+                   * If diagnosis information is removed a diagnosis alarm with
+                   * specifier DISAPPEARS is queued into the alarm queue. ToDo:
+                   * If the channel has other diagnosis information of the same
+                   * severity, the specifier PNET_DIAG_CH_SPEC_DIS_OTHERS_REMAIN
+                   * is used instead.
+                   */
+                  if (p_item->usi >= PF_USI_CHANNEL_DIAGNOSIS)
+                  {
+                     PNET_DIAG_CH_PROP_SPEC_SET (
+                        p_item->fmt.std.ch_properties,
+                        PNET_DIAG_CH_PROP_SPEC_DISAPPEARS);
+                  }
+                  ret = pf_alarm_send_diagnosis (
+                     net,
+                     p_ar,
+                     p_diag_source->api,
+                     p_diag_source->slot,
+                     p_diag_source->subslot,
+                     p_item);
+               }
+               else
+               {
+                  /* If the channel has no diagnosis information of any
+                   * severity,
+                   * the specifier PNET_DIAG_CH_SPEC_ALL_DISAPPEARS is used. */
+                  /* Overwrite the item to remove with correct cr_properties for
+                   * this diag message. */
+                  p_item->usi = PF_USI_EXTENDED_CHANNEL_DIAGNOSIS;
+                  PNET_DIAG_CH_PROP_MAINT_SET (
+                     p_item->fmt.std.ch_properties,
+                     PNET_DIAG_CH_PROP_MAINT_FAULT);
                   PNET_DIAG_CH_PROP_SPEC_SET (
                      p_item->fmt.std.ch_properties,
-                     PNET_DIAG_CH_PROP_SPEC_DISAPPEARS);
+                     PNET_DIAG_CH_PROP_SPEC_ALL_DISAPPEARS);
+
+                  ret = pf_alarm_send_diagnosis (
+                     net,
+                     p_ar,
+                     p_diag_source->api,
+                     p_diag_source->slot,
+                     p_diag_source->subslot,
+                     p_item);
                }
-               ret = pf_alarm_send_diagnosis (
-                  net,
-                  p_ar,
-                  p_diag_source->api,
-                  p_diag_source->slot,
-                  p_diag_source->subslot,
-                  p_item);
             }
             else
             {
-               /* If the channel has no diagnosis information of any severity,
-                * the specifier PNET_DIAG_CH_SPEC_ALL_DISAPPEARS is used. */
-               /* Overwrite the item to remove with correct cr_properties for
-                * this diag message. */
-               p_item->usi = PF_USI_CHANNEL_DIAGNOSIS;
-               PNET_DIAG_CH_PROP_MAINT_SET (
-                  p_item->fmt.std.ch_properties,
-                  PNET_DIAG_CH_PROP_MAINT_FAULT);
-               PNET_DIAG_CH_PROP_SPEC_SET (
-                  p_item->fmt.std.ch_properties,
-                  PNET_DIAG_CH_PROP_SPEC_ALL_DISAPPEARS);
-
-               ret = pf_alarm_send_diagnosis (
-                  net,
-                  p_ar,
-                  p_diag_source->api,
-                  p_diag_source->slot,
-                  p_diag_source->subslot,
-                  p_item);
+               LOG_ERROR (
+                  PNET_LOG,
+                  "DIAG(%d): No active connection, so no alarm is sent.\n",
+                  __LINE__);
             }
          }
 
          /* Free diag entry */
          pf_cmdev_free_diag (net, item_ix);
 
-         pf_diag_update_station_problem_indicator (net, p_ar, p_subslot);
+         if (p_ar != NULL)
+         {
+            pf_diag_update_station_problem_indicator (net, p_ar, p_subslot);
+         }
       }
       else
       {
@@ -637,7 +701,6 @@ int pf_diag_remove (
 
 int pf_diag_std_add (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    pnet_diag_ch_prop_type_values_t ch_bits,
    pnet_diag_ch_prop_maint_values_t severity,
@@ -648,7 +711,6 @@ int pf_diag_std_add (
 {
    return pf_diag_add (
       net,
-      p_ar,
       p_diag_source,
       ch_bits,
       severity,
@@ -656,13 +718,12 @@ int pf_diag_std_add (
       ext_ch_error_type,
       ext_ch_add_value,
       qual_ch_qualifier,
-      PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS,
+      PF_DIAG_PREFERRED_DIAGNOSIS_USI,
       NULL);
 }
 
 int pf_diag_std_update (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type,
@@ -670,36 +731,32 @@ int pf_diag_std_update (
 {
    return pf_diag_update (
       net,
-      p_ar,
       p_diag_source,
       ch_error_type,
       ext_ch_error_type,
       ext_ch_add_value,
-      PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS,
+      PF_DIAG_PREFERRED_DIAGNOSIS_USI,
       NULL);
 }
 
 int pf_diag_std_remove (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type)
 {
    return pf_diag_remove (
       net,
-      p_ar,
       p_diag_source,
       ch_error_type,
       ext_ch_error_type,
-      PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS);
+      PF_DIAG_PREFERRED_DIAGNOSIS_USI);
 }
 
 /************************** Diagnosis in USI format **************************/
 
 int pf_diag_usi_add (
    pnet_t * net,
-   pf_ar_t * p_ar,
    uint32_t api_id,
    uint16_t slot_nbr,
    uint16_t subslot_nbr,
@@ -729,7 +786,6 @@ int pf_diag_usi_add (
 
    return pf_diag_add (
       net,
-      p_ar,
       &diag_source,
       PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
       PNET_DIAG_CH_PROP_MAINT_FAULT,
@@ -743,7 +799,6 @@ int pf_diag_usi_add (
 
 int pf_diag_usi_update (
    pnet_t * net,
-   pf_ar_t * p_ar,
    uint32_t api_id,
    uint16_t slot_nbr,
    uint16_t subslot_nbr,
@@ -771,12 +826,11 @@ int pf_diag_usi_update (
       return -1;
    }
 
-   return pf_diag_update (net, p_ar, &diag_source, 0, 0, 0, usi, p_manuf_data);
+   return pf_diag_update (net, &diag_source, 0, 0, 0, usi, p_manuf_data);
 }
 
 int pf_diag_usi_remove (
    pnet_t * net,
-   pf_ar_t * p_ar,
    uint32_t api_id,
    uint16_t slot_nbr,
    uint16_t subslot_nbr,
@@ -803,5 +857,5 @@ int pf_diag_usi_remove (
       return -1;
    }
 
-   return pf_diag_remove (net, p_ar, &diag_source, 0, 0, usi);
+   return pf_diag_remove (net, &diag_source, 0, 0, usi);
 }

--- a/src/device/pf_diag.h
+++ b/src/device/pf_diag.h
@@ -56,7 +56,6 @@ int pf_diag_exit (void);
  * This sends a diagnosis alarm.
  *
  * @param net                 InOut: The p-net stack instance.
- * @param p_ar                InOut: The AR instance.
  * @param p_diag_source       In:    Slot, subslot, channel, direction etc.
  * @param ch_bits             In:    Number of bits in the channel.
  * @param severity            In:    Diagnosis severity.
@@ -73,7 +72,6 @@ int pf_diag_exit (void);
  */
 int pf_diag_add (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    pnet_diag_ch_prop_type_values_t ch_bits,
    pnet_diag_ch_prop_maint_values_t severity,
@@ -105,7 +103,6 @@ int pf_diag_add (
  * This sends a diagnosis alarm.
  *
  * @param net               InOut: The p-net stack instance.
- * @param p_ar              InOut: The AR instance.
  * @param p_diag_source     In:    Slot, subslot, channel, direction etc.
  * @param ch_error_type     In:    The channel error type.
  * @param ext_ch_error_type In:    The extended channel error type, or 0.
@@ -118,7 +115,6 @@ int pf_diag_add (
  */
 int pf_diag_update (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type,
@@ -143,7 +139,6 @@ int pf_diag_update (
  * This sends a diagnosis alarm.
  *
  * @param net               InOut: The p-net stack instance.
- * @param p_ar              InOut: The AR instance.
  * @param p_diag_source     In:    Slot, subslot, channel, direction etc.
  * @param ch_error_type     In:    The channel error type.
  * @param ext_ch_error_type In:    The extended channel error type, or 0.
@@ -153,7 +148,6 @@ int pf_diag_update (
  */
 int pf_diag_remove (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type,
@@ -167,7 +161,6 @@ int pf_diag_remove (
  * This sends a diagnosis alarm.
  *
  * @param net                 InOut: The p-net stack instance.
- * @param p_ar                InOut: The AR instance.
  * @param p_diag_source       In:    Slot, subslot, channel, direction etc.
  * @param ch_bits             In:    Number of bits in the channel.
  * @param severity            In:    Diagnosis severity.
@@ -181,7 +174,6 @@ int pf_diag_remove (
  */
 int pf_diag_std_add (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    pnet_diag_ch_prop_type_values_t ch_bits,
    pnet_diag_ch_prop_maint_values_t severity,
@@ -196,7 +188,6 @@ int pf_diag_std_add (
  * This sends a diagnosis alarm.
  *
  * @param net               InOut: The p-net stack instance.
- * @param p_ar              InOut: The AR instance.
  * @param p_diag_source     In:    Slot, subslot, channel, direction etc.
  * @param ch_error_type     In:    The channel error type.
  * @param ext_ch_error_type In:    The extended channel error type.
@@ -206,7 +197,6 @@ int pf_diag_std_add (
  */
 int pf_diag_std_update (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type,
@@ -218,7 +208,6 @@ int pf_diag_std_update (
  * This sends a diagnosis alarm.
  *
  * @param net               InOut: The p-net stack instance.
- * @param p_ar              InOut: The AR instance.
  * @param p_diag_source     In:    Slot, subslot, channel, direction etc.
  * @param ch_error_type     In:    The channel error type.
  * @param ext_ch_error_type In:    The extended channel error type.
@@ -227,7 +216,6 @@ int pf_diag_std_update (
  */
 int pf_diag_std_remove (
    pnet_t * net,
-   pf_ar_t * p_ar,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type);
@@ -245,7 +233,6 @@ int pf_diag_std_remove (
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
- * @param p_ar             InOut: The AR instance.
  * @param api_id           In:    The API.
  * @param slot_nbr         In:    The slot.
  * @param subslot_nbr      In:    The sub-slot.
@@ -256,7 +243,6 @@ int pf_diag_std_remove (
  */
 int pf_diag_usi_add (
    pnet_t * net,
-   pf_ar_t * p_ar,
    uint32_t api_id,
    uint16_t slot_nbr,
    uint16_t subslot_nbr,
@@ -271,7 +257,6 @@ int pf_diag_usi_add (
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
- * @param p_ar             InOut: The AR instance.
  * @param api_id           In:    The API.
  * @param slot_nbr         In:    The slot.
  * @param subslot_nbr      In:    The sub-slot.
@@ -282,7 +267,6 @@ int pf_diag_usi_add (
  */
 int pf_diag_usi_update (
    pnet_t * net,
-   pf_ar_t * p_ar,
    uint32_t api_id,
    uint16_t slot_nbr,
    uint16_t subslot_nbr,
@@ -295,7 +279,6 @@ int pf_diag_usi_update (
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
- * @param p_ar             InOut: The AR instance.
  * @param api_id           In:    The API.
  * @param slot_nbr         In:    The slot.
  * @param subslot_nbr      In:    The sub-slot.
@@ -305,7 +288,6 @@ int pf_diag_usi_update (
  */
 int pf_diag_usi_remove (
    pnet_t * net,
-   pf_ar_t * p_ar,
    uint32_t api_id,
    uint16_t slot_nbr,
    uint16_t subslot_nbr,

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -295,6 +295,102 @@ int pf_pdport_read_ind (
 }
 
 /**
+ * Run peer check
+ *
+ * Compare llpd peer information with configured pdport peer.
+ * Trigger an alarm if wrong peer is connected.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param loc_port_num     In:    Local port number.
+ *                                Valid range: 1 .. N, where N is the total
+ *                                number of local ports used by p-net stack.
+ * @param p_lldp_peer_info In:    Currently received peer info
+ */
+static void pf_pdport_run_peer_check (
+   pnet_t * net,
+   int loc_port_num,
+   const pnet_lldp_peer_info_t * p_lldp_peer_info)
+{
+   bool peer_stationname_is_correct = false;
+
+   bool peer_portname_is_correct = false;
+   pnet_diag_source_t diag_source = {0};
+   pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
+   pf_check_peer_t * p_wanted_peer = &p_port_data->pdport.check.peer;
+
+   if (p_port_data->pdport.check.active == true)
+   {
+      if (
+         strncmp (
+            p_lldp_peer_info->chassis_id.string,
+            (char *)p_wanted_peer->peer_station_name,
+            p_lldp_peer_info->chassis_id.len) == 0)
+      {
+         peer_stationname_is_correct = true;
+      }
+
+      // TODO Update also peer_portname_is_correct
+
+      diag_source.api = PNET_API_NO_APPLICATION_PROFILE;
+      diag_source.slot = PNET_SLOT_DAP_IDENT;
+      diag_source.subslot = PNET_SUBSLOT_DAP_INTERFACE_1_PORT_0_IDENT; /* TODO should depend on port number */
+      diag_source.ch = PNET_CHANNEL_WHOLE_SUBMODULE;
+      diag_source.ch_grouping = PNET_DIAG_CH_INDIVIDUAL_CHANNEL;
+      diag_source.ch_direction = PNET_DIAG_CH_PROP_DIR_MANUF_SPEC;
+
+      if (peer_stationname_is_correct == false)
+      {
+         LOG_DEBUG (
+            PNET_LOG,
+            "PDPORT(%d): Sending peer station name mismatch alarm: %s (Port: "
+            "%s) "
+            "Wanted peer station name: %.*s (Port: %.*s)\n",
+            __LINE__,
+            p_lldp_peer_info->chassis_id.string,
+            p_lldp_peer_info->port_id,
+            p_wanted_peer->length_peer_station_name,
+            p_wanted_peer->peer_station_name,
+            p_wanted_peer->length_peer_port_name,
+            p_wanted_peer->peer_port_name);
+         (void)pf_diag_std_add (
+            net,
+            &diag_source,
+            PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
+            PNET_DIAG_CH_PROP_MAINT_FAULT,
+            PF_WRT_ERROR_REMOTE_MISMATCH,
+            PF_WRT_ERROR_PEER_STATIONNAME_MISMATCH,
+            0,
+            0);
+      }
+      else
+      {
+         LOG_DEBUG (
+            PNET_LOG,
+            "PDPORT(%d): Peer station name is correct: %s (Port: "
+            "%s). Remove diagnosis.\n",
+            __LINE__,
+            p_lldp_peer_info->chassis_id.string,
+            p_lldp_peer_info->port_id);
+         (void)pf_diag_std_remove (
+            net,
+            &diag_source,
+            PF_WRT_ERROR_REMOTE_MISMATCH,
+            PF_WRT_ERROR_PEER_STATIONNAME_MISMATCH);
+      }
+
+      (void)peer_portname_is_correct; /* TODO use in the decision making */
+   }
+   else
+   {
+      LOG_DEBUG (
+         PNET_LOG,
+         "PDPORT(%d): We do not check peer name and portID, so no port change "
+         "alarm is sent.\n",
+         __LINE__);
+   }
+}
+
+/**
  * @internal
  * Write PDPort data check
  *
@@ -365,7 +461,7 @@ static int pf_pdport_write_data_check (
                check_peers.peers[0].length_peer_port_name,
                check_peers.peers[0].peer_port_name);
 
-            /* Todo -  Generate Alarm on mismatch*/
+            pf_pdport_run_peer_check (net, 0, &net->port[0].lldp.peer_info);
 
             ret = 0;
          }
@@ -517,4 +613,12 @@ int pf_pdport_write_req (
       (void)pf_pdport_save (net);
    }
    return ret;
+}
+
+void pf_pdport_peer_indication (
+   pnet_t * net,
+   int loc_port_num,
+   const pnet_lldp_peer_info_t * p_lldp_peer_info)
+{
+   pf_pdport_run_peer_check (net, loc_port_num, p_lldp_peer_info);
 }

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -128,8 +128,75 @@ static int pf_pdport_save (pnet_t * net)
 }
 
 /**
+ * @internal
+ * Get DAP subslot for using local port number
+ * @param loc_port_num     In:    Local port number.
+ *                                Valid range: 1 .. N, where N is the total
+ *                                number of local ports used by p-net stack.
+ * @return DAP subslot number for port identity
+ */
+static uint16_t pf_pdport_loc_port_num_to_dap_subslot (int loc_port_num)
+{
+   CC_ASSERT (loc_port_num == PNET_PORT_1);
+   return PNET_SUBSLOT_DAP_INTERFACE_1_PORT_0_IDENT;
+}
+
+/**
+ * @internal
+ * Initialize pdport diagnostic source
+ * @param diag_source      InOut: Diag source to be initialized
+ * @param loc_port_num     In:    Local port number.
+ *                                Valid range: 1 .. N, where N is the total
+ *                                number of local ports used by p-net stack.
+ * @return Index in port array
+ */
+static void pf_pdport_init_diag_source (
+   pnet_diag_source_t * diag_source,
+   int loc_port_num)
+{
+   diag_source->api = PNET_API_NO_APPLICATION_PROFILE;
+   diag_source->slot = PNET_SLOT_DAP_IDENT;
+   diag_source->subslot = pf_pdport_loc_port_num_to_dap_subslot (loc_port_num);
+   diag_source->ch = PNET_CHANNEL_WHOLE_SUBMODULE;
+   diag_source->ch_grouping = PNET_DIAG_CH_INDIVIDUAL_CHANNEL;
+   diag_source->ch_direction = PNET_DIAG_CH_PROP_DIR_MANUF_SPEC;
+}
+
+/**
+ * Delete all active diagnostics handled by pdport
+ * @param net              InOut: The p-net stack instance
+ */
+static void pf_pdport_remove_all_diag (pnet_t * net)
+{
+   pnet_diag_source_t diag_source = {0};
+
+   pf_pdport_init_diag_source (&diag_source, PNET_PORT_1);
+
+   (void)pf_diag_std_remove (
+      net,
+      &diag_source,
+      PF_WRT_ERROR_REMOTE_MISMATCH,
+      PF_WRT_ERROR_PEER_STATIONNAME_MISMATCH);
+
+   (void)pf_diag_std_remove (
+      net,
+      &diag_source,
+      PF_WRT_ERROR_REMOTE_MISMATCH,
+      PF_WRT_ERROR_PEER_PORTNAME_MISMATCH);
+
+   (void)pf_diag_std_remove (
+      net,
+      &diag_source,
+      PF_WRT_ERROR_REMOTE_MISMATCH,
+      PF_WRT_ERROR_NO_PEER_DETECTED);
+}
+
+/**
  * Init PDPort data.
  * Load port configuration from nvm.
+
+ * If a check is loaded it will be run when pdport receives
+ * data from lldp.
  *
  * @param net              InOut: The p-net stack instance
  * @return  0  if the operation succeeded.
@@ -148,6 +215,7 @@ int pf_pdport_init (pnet_t * net)
 /**
  * Reset port configuration data for all ports.
  * Clear configuration in nvm.
+ * Remove diagnosis
  *
  * @param net              InOut: The p-net stack instance
  * @return  0  if the operation succeeded.
@@ -162,6 +230,8 @@ int pf_pdport_reset_all (pnet_t * net)
    pf_file_clear (p_file_directory, PNET_FILENAME_PDPORT);
 
    memset (&p_port_data->pdport, 0, sizeof (p_port_data->pdport));
+   pf_pdport_remove_all_diag (net);
+
    return 0;
 }
 
@@ -295,10 +365,12 @@ int pf_pdport_read_ind (
 }
 
 /**
- * Run peer check
+ * @internal
+ * Run peer station name check
  *
  * Compare llpd peer information with configured pdport peer.
  * Trigger an alarm if wrong peer is connected.
+ * Remove diagnosis if expected peer data is received.
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
@@ -306,85 +378,182 @@ int pf_pdport_read_ind (
  *                                number of local ports used by p-net stack.
  * @param p_lldp_peer_info In:    Currently received peer info
  */
-static void pf_pdport_run_peer_check (
+static void pf_pdport_check_peer_station_name (
    pnet_t * net,
    int loc_port_num,
    const pnet_lldp_peer_info_t * p_lldp_peer_info)
 {
    bool peer_stationname_is_correct = false;
-
-   bool peer_portname_is_correct = false;
    pnet_diag_source_t diag_source = {0};
    pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
    pf_check_peer_t * p_wanted_peer = &p_port_data->pdport.check.peer;
 
+   pf_pdport_init_diag_source (&diag_source, loc_port_num);
+
    if (p_port_data->pdport.check.active == true)
+
+   if (
+      strncmp (
+         p_lldp_peer_info->chassis_id.string,
+         (char *)p_wanted_peer->peer_station_name,
+         p_lldp_peer_info->chassis_id.len) == 0)
    {
-      if (
-         strncmp (
-            p_lldp_peer_info->chassis_id.string,
-            (char *)p_wanted_peer->peer_station_name,
-            p_lldp_peer_info->chassis_id.len) == 0)
-      {
-         peer_stationname_is_correct = true;
-      }
+      peer_stationname_is_correct = true;
+   }
 
-      // TODO Update also peer_portname_is_correct
+   if (peer_stationname_is_correct == false)
+   {
+      LOG_DEBUG (
+         PNET_LOG,
+         "PDPORT(%d): Sending peer station name mismatch alarm: %s (Port: "
+         "%s) "
+         "Wanted peer station name: %.*s (Port: %.*s)\n",
+         __LINE__,
+         p_lldp_peer_info->chassis_id.string,
+         p_lldp_peer_info->port_id,
+         p_wanted_peer->length_peer_station_name,
+         p_wanted_peer->peer_station_name,
+         p_wanted_peer->length_peer_port_name,
+         p_wanted_peer->peer_port_name);
 
-      diag_source.api = PNET_API_NO_APPLICATION_PROFILE;
-      diag_source.slot = PNET_SLOT_DAP_IDENT;
-      diag_source.subslot = PNET_SUBSLOT_DAP_INTERFACE_1_PORT_0_IDENT; /* TODO should depend on port number */
-      diag_source.ch = PNET_CHANNEL_WHOLE_SUBMODULE;
-      diag_source.ch_grouping = PNET_DIAG_CH_INDIVIDUAL_CHANNEL;
-      diag_source.ch_direction = PNET_DIAG_CH_PROP_DIR_MANUF_SPEC;
-
-      if (peer_stationname_is_correct == false)
-      {
-         LOG_DEBUG (
-            PNET_LOG,
-            "PDPORT(%d): Sending peer station name mismatch alarm: %s (Port: "
-            "%s) "
-            "Wanted peer station name: %.*s (Port: %.*s)\n",
-            __LINE__,
-            p_lldp_peer_info->chassis_id.string,
-            p_lldp_peer_info->port_id,
-            p_wanted_peer->length_peer_station_name,
-            p_wanted_peer->peer_station_name,
-            p_wanted_peer->length_peer_port_name,
-            p_wanted_peer->peer_port_name);
-         (void)pf_diag_std_add (
-            net,
-            &diag_source,
-            PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
-            PNET_DIAG_CH_PROP_MAINT_FAULT,
-            PF_WRT_ERROR_REMOTE_MISMATCH,
-            PF_WRT_ERROR_PEER_STATIONNAME_MISMATCH,
-            0,
-            0);
-      }
-      else
-      {
-         LOG_DEBUG (
-            PNET_LOG,
-            "PDPORT(%d): Peer station name is correct: %s (Port: "
-            "%s). Remove diagnosis.\n",
-            __LINE__,
-            p_lldp_peer_info->chassis_id.string,
-            p_lldp_peer_info->port_id);
-         (void)pf_diag_std_remove (
-            net,
-            &diag_source,
-            PF_WRT_ERROR_REMOTE_MISMATCH,
-            PF_WRT_ERROR_PEER_STATIONNAME_MISMATCH);
-      }
-
-      (void)peer_portname_is_correct; /* TODO use in the decision making */
+      (void)pf_diag_std_add (
+         net,
+         &diag_source,
+         PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
+         PNET_DIAG_CH_PROP_MAINT_FAULT,
+         PF_WRT_ERROR_REMOTE_MISMATCH,
+         PF_WRT_ERROR_PEER_STATIONNAME_MISMATCH,
+         0,
+         0);
    }
    else
    {
       LOG_DEBUG (
          PNET_LOG,
-         "PDPORT(%d): We do not check peer name and portID, so no port change "
+         "PDPORT(%d): Peer station name is correct: %s (Port: "
+         "%s). Remove diagnosis.\n",
+         __LINE__,
+         p_lldp_peer_info->chassis_id.string,
+         p_lldp_peer_info->port_id);
+      (void)pf_diag_std_remove (
+         net,
+         &diag_source,
+         PF_WRT_ERROR_REMOTE_MISMATCH,
+         PF_WRT_ERROR_PEER_STATIONNAME_MISMATCH);
+   }
+}
+
+/**
+ * @internal
+ * Run peer port name check
+ *
+ * Compare llpd peer information with configured pdport peer.
+ * Trigger an diagnosis if unexpected peer data is connected.
+ * Remove diagnosis if expected peer data is received.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param loc_port_num     In:    Local port number.
+ *                                Valid range: 1 .. N, where N is the total
+ *                                number of local ports used by p-net stack.
+ * @param p_lldp_peer_info In:    Peer info
+ */
+static void pf_pdport_check_peer_port_name (
+   pnet_t * net,
+   int loc_port_num,
+   const pnet_lldp_peer_info_t * p_lldp_peer_info)
+{
+   bool peer_portname_is_correct = false;
+   pnet_diag_source_t diag_source = {0};
+   pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
+   pf_check_peer_t * p_wanted_peer = &p_port_data->pdport.check.peer;
+
+   pf_pdport_init_diag_source (&diag_source, loc_port_num);
+
+   if (
+      strncmp (
+         p_lldp_peer_info->port_id,
+         (char *)p_wanted_peer->peer_port_name,
+         p_wanted_peer->length_peer_port_name) == 0)
+   {
+      peer_portname_is_correct = true;
+   }
+
+   pf_pdport_init_diag_source (&diag_source, loc_port_num);
+
+   if (peer_portname_is_correct == false)
+   {
+      LOG_DEBUG (
+         PNET_LOG,
+         "PDPORT(%d): Sending peer port name mismatch alarm: %s (Port: "
+         "%s) "
+         "Wanted peer station name: %.*s (Port: %.*s)\n",
+         __LINE__,
+         p_lldp_peer_info->chassis_id.string,
+         p_lldp_peer_info->port_id,
+         p_wanted_peer->length_peer_station_name,
+         p_wanted_peer->peer_station_name,
+         p_wanted_peer->length_peer_port_name,
+         p_wanted_peer->peer_port_name);
+
+      (void)pf_diag_std_add (
+         net,
+         &diag_source,
+         PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
+         PNET_DIAG_CH_PROP_MAINT_FAULT,
+         PF_WRT_ERROR_REMOTE_MISMATCH,
+         PF_WRT_ERROR_PEER_PORTNAME_MISMATCH,
+         0,
+         0);
+   }
+   else
+   {
+      LOG_DEBUG (
+         PNET_LOG,
+         "PDPORT(%d): Peer port name is correct: %s (Port: "
+         "%s). Remove diagnosis.\n",
+         __LINE__,
+         p_lldp_peer_info->chassis_id.string,
+         p_lldp_peer_info->port_id);
+      (void)pf_diag_std_remove (
+         net,
+         &diag_source,
+         PF_WRT_ERROR_REMOTE_MISMATCH,
+         PF_WRT_ERROR_PEER_PORTNAME_MISMATCH);
+   }
+}
+
+/**
+ * @internal
+ * Run peer check
+ *
+ * Compare llpd peer information with configured pdport peer.
+ * Trigger an diagnosis if unexpected peer data is connected.
+ * Remove diagnosis if expected peer data is received.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param loc_port_num     In:    Local port number.
+ *                                Valid range: 1 .. N, where N is the total
+ *                                number of local ports used by p-net stack.
+ * @param p_lldp_peer_info In:    Peer info
+ */
+static void pf_pdport_run_peer_check (
+   pnet_t * net,
+   int loc_port_num,
+   const pnet_lldp_peer_info_t * p_lldp_peer_info)
+{
+   pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
+
+   if (p_port_data->pdport.check.active == true)
+   {
+      pf_pdport_check_peer_port_name (net, loc_port_num, p_lldp_peer_info);
+
+      pf_pdport_check_peer_station_name (net, loc_port_num, p_lldp_peer_info);
+   }
+   else
+   {
+      LOG_DEBUG (
+         PNET_LOG,
+         "PDPORT(%d): We do not check peer name or portID, so no port change "
          "alarm is sent.\n",
          __LINE__);
    }
@@ -461,7 +630,7 @@ static int pf_pdport_write_data_check (
                check_peers.peers[0].length_peer_port_name,
                check_peers.peers[0].peer_port_name);
 
-            pf_pdport_run_peer_check (net, 0, &net->port[0].lldp.peer_info);
+            pf_pdport_run_peer_check (net, PNET_PORT_1, &net->port[0].lldp.peer_info);
 
             ret = 0;
          }

--- a/src/device/pf_pdport.h
+++ b/src/device/pf_pdport.h
@@ -35,6 +35,7 @@ int pf_pdport_init (pnet_t * net);
 /**
  * Reset PDPort configuration data for all ports.
  * Clear DPPort configuration in nvm.
+ * Remove all active diagnostics items related to DPPort.
  *
  * @param net              InOut: The p-net stack instance
  * @return  0  if the operation succeeded.

--- a/src/device/pf_pdport.h
+++ b/src/device/pf_pdport.h
@@ -104,6 +104,22 @@ int pf_pdport_write_req (
    uint16_t data_length,
    pnet_result_t * p_result);
 
+/**
+ * Verify that correct peer is connected to the port.
+ *
+ * Triggers an alarm if wrong peer is connected.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param loc_port_num     In:    Local port number.
+ *                                Valid range: 1 .. N, where N is the total
+ *                                number of local ports used by p-net stack.
+ * @param p_lldp_peer_info In:    Peer info
+ */
+void pf_pdport_peer_indication (
+   pnet_t * net,
+   int loc_port_num,
+   const pnet_lldp_peer_info_t * p_lldp_peer_info);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -100,7 +100,10 @@ pnet_t * pnet_init (
    net = os_malloc (sizeof (*net));
    if (net == NULL)
    {
-      LOG_ERROR (PNET_LOG, "Failed to allocate memory for pnet_t (%zu bytes)\n", sizeof (*net));
+      LOG_ERROR (
+         PNET_LOG,
+         "Failed to allocate memory for pnet_t (%zu bytes)\n",
+         sizeof (*net));
       return NULL;
    }
 
@@ -494,7 +497,6 @@ int pnet_alarm_send_ack (
 
 int pnet_diag_std_add (
    pnet_t * net,
-   uint32_t arep,
    const pnet_diag_source_t * p_diag_source,
    pnet_diag_ch_prop_type_values_t ch_bits,
    pnet_diag_ch_prop_maint_values_t severity,
@@ -503,132 +505,75 @@ int pnet_diag_std_add (
    uint32_t ext_ch_add_value,
    uint32_t qual_ch_qualifier)
 {
-   int ret = -1;
-   pf_ar_t * p_ar = NULL;
-
-   if (pf_ar_find_by_arep (net, arep, &p_ar) == 0)
-   {
-      ret = pf_diag_std_add (
-         net,
-         p_ar,
-         p_diag_source,
-         ch_bits,
-         severity,
-         ch_error_type,
-         ext_ch_error_type,
-         ext_ch_add_value,
-         qual_ch_qualifier);
-   }
-
-   return ret;
+   return pf_diag_std_add (
+      net,
+      p_diag_source,
+      ch_bits,
+      severity,
+      ch_error_type,
+      ext_ch_error_type,
+      ext_ch_add_value,
+      qual_ch_qualifier);
 }
 
 int pnet_diag_std_update (
    pnet_t * net,
-   uint32_t arep,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type,
    uint32_t ext_ch_add_value)
 {
-   int ret = -1;
-   pf_ar_t * p_ar = NULL;
-
-   if (pf_ar_find_by_arep (net, arep, &p_ar) == 0)
-   {
-      ret = pf_diag_std_update (
-         net,
-         p_ar,
-         p_diag_source,
-         ch_error_type,
-         ext_ch_error_type,
-         ext_ch_add_value);
-   }
-
-   return ret;
+   return pf_diag_std_update (
+      net,
+      p_diag_source,
+      ch_error_type,
+      ext_ch_error_type,
+      ext_ch_add_value);
 }
 
 int pnet_diag_std_remove (
    pnet_t * net,
-   uint32_t arep,
    const pnet_diag_source_t * p_diag_source,
    uint16_t ch_error_type,
    uint16_t ext_ch_error_type)
 {
-   int ret = -1;
-   pf_ar_t * p_ar = NULL;
-
-   if (pf_ar_find_by_arep (net, arep, &p_ar) == 0)
-   {
-      ret = pf_diag_std_remove (
-         net,
-         p_ar,
-         p_diag_source,
-         ch_error_type,
-         ext_ch_error_type);
-   }
-
-   return ret;
+   return pf_diag_std_remove (
+      net,
+      p_diag_source,
+      ch_error_type,
+      ext_ch_error_type);
 }
 
 /************************** Diagnosis in USI format **************************/
 
 int pnet_diag_usi_add (
    pnet_t * net,
-   uint32_t arep,
    uint32_t api,
    uint16_t slot,
    uint16_t subslot,
    uint16_t usi,
    const uint8_t * p_manuf_data)
 {
-   int ret = -1;
-   pf_ar_t * p_ar = NULL;
-
-   if (pf_ar_find_by_arep (net, arep, &p_ar) == 0)
-   {
-      ret = pf_diag_usi_add (net, p_ar, api, slot, subslot, usi, p_manuf_data);
-   }
-
-   return ret;
+   return pf_diag_usi_add (net, api, slot, subslot, usi, p_manuf_data);
 }
 
 int pnet_diag_usi_update (
    pnet_t * net,
-   uint32_t arep,
    uint32_t api,
    uint16_t slot,
    uint16_t subslot,
    uint16_t usi,
    const uint8_t * p_manuf_data)
 {
-   int ret = -1;
-   pf_ar_t * p_ar = NULL;
-
-   if (pf_ar_find_by_arep (net, arep, &p_ar) == 0)
-   {
-      ret =
-         pf_diag_usi_update (net, p_ar, api, slot, subslot, usi, p_manuf_data);
-   }
-
-   return ret;
+   return pf_diag_usi_update (net, api, slot, subslot, usi, p_manuf_data);
 }
 
 int pnet_diag_usi_remove (
    pnet_t * net,
-   uint32_t arep,
    uint32_t api,
    uint16_t slot,
    uint16_t subslot,
    uint16_t usi)
 {
-   int ret = -1;
-   pf_ar_t * p_ar = NULL;
-
-   if (pf_ar_find_by_arep (net, arep, &p_ar) == 0)
-   {
-      ret = pf_diag_usi_remove (net, p_ar, api, slot, subslot, usi);
-   }
-
-   return ret;
+   return pf_diag_usi_remove (net, api, slot, subslot, usi);
 }

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -216,8 +216,8 @@ typedef enum pf_write_req_error_type_values
 
 typedef enum pf_write_req_ext_error_type_values
 {
-   PF_WRT_ERROR_PORTID_MISMATCH = 0x8000,
-   PF_WRT_ERROR_CHASSISID_MISMATCH = 0x8001,
+   PF_WRT_ERROR_PEER_STATIONNAME_MISMATCH = 0x8000,
+   PF_WRT_ERROR_PEER_PORTNAME_MISMATCH = 0x8001,
    PF_WRT_ERROR_NO_PEER_DETECTED = 0x8005
 } pf_write_req_ext_error_type_t;
 

--- a/test/test_alarm.cpp
+++ b/test/test_alarm.cpp
@@ -24,6 +24,272 @@ class AlarmTest : public PnetIntegrationTest
 {
 };
 
-TEST_F (AlarmTest, AlarmRunTest)
+class AlarmUnitTest : public PnetUnitTest
 {
+};
+
+TEST_F (AlarmUnitTest, AlarmCheckAddDiagItemToSummary)
+{
+   pnet_alarm_spec_t alarm_specifier;
+   uint32_t maint_status = 0;
+   pf_diag_item_t diag_item;
+   pf_subslot_t subslot;
+   pf_ar_t ar;
+
+   /* Prepare default input data */
+   memset (&ar, 0, sizeof (ar));
+   memset (&subslot, 0, sizeof (subslot));
+   subslot.p_ar = &ar;
+
+   memset (&diag_item, 0, sizeof (diag_item));
+   diag_item.usi = PF_USI_EXTENDED_CHANNEL_DIAGNOSIS;
+   PNET_DIAG_CH_PROP_SPEC_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_SPEC_APPEARS);
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_FAULT);
+
+   /* Happy case */
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, 0UL);
+
+   /* Other AR */
+   subslot.p_ar = NULL;
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, 0UL);
+   subslot.p_ar = &ar;
+
+   /* Manufacturer specific (in USI format) */
+   diag_item.usi = TEST_DIAG_USI_CUSTOM;
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_FALSE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, 0UL);
+   diag_item.usi = PF_USI_EXTENDED_CHANNEL_DIAGNOSIS;
+
+   /* Disappearing diagnosis */
+   PNET_DIAG_CH_PROP_SPEC_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_SPEC_DISAPPEARS);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_FALSE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, 0UL);
+   PNET_DIAG_CH_PROP_SPEC_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_SPEC_APPEARS);
+
+   /* Maintenance required */
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_REQUIRED);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, BIT (0));
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_FAULT);
+
+   /* Maintenance required, via qualified channel diagnosis (qual 7..16) */
+   diag_item.usi = PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS;
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_QUALIFIED);
+   diag_item.fmt.std.qual_ch_qualifier = BIT (7);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, (BIT (7) | BIT (0)));
+
+   diag_item.fmt.std.qual_ch_qualifier = BIT (16);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, (BIT (16) | BIT (0)));
+   diag_item.usi = PF_USI_EXTENDED_CHANNEL_DIAGNOSIS;
+   diag_item.fmt.std.qual_ch_qualifier = 0;
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_FAULT);
+
+   /* Maintenance demanded */
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_DEMANDED);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, BIT (1));
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_FAULT);
+
+   /* Maintenance demanded, via qualified channel diagnosis (qual 17..26) */
+   diag_item.usi = PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS;
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_QUALIFIED);
+   diag_item.fmt.std.qual_ch_qualifier = BIT (17);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, (BIT (17) | BIT (1)));
+
+   diag_item.fmt.std.qual_ch_qualifier = BIT (26);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, (BIT (26) | BIT (1)));
+   diag_item.usi = PF_USI_EXTENDED_CHANNEL_DIAGNOSIS;
+   diag_item.fmt.std.qual_ch_qualifier = 0;
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_FAULT);
+
+   /* Fault, via qualified channel diagnosis (qual 27..31) */
+   diag_item.usi = PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS;
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_QUALIFIED);
+   diag_item.fmt.std.qual_ch_qualifier = BIT (27);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, BIT (27));
+
+   diag_item.fmt.std.qual_ch_qualifier = BIT (31);
+
+   memset (&alarm_specifier, 0, sizeof (alarm_specifier));
+   maint_status = 0;
+   pf_alarm_add_diag_item_to_summary (
+      &ar,
+      &subslot,
+      &diag_item,
+      &alarm_specifier,
+      &maint_status);
+   EXPECT_TRUE ((bool)alarm_specifier.channel_diagnosis);
+   EXPECT_FALSE ((bool)alarm_specifier.manufacturer_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.submodule_diagnosis);
+   EXPECT_TRUE ((bool)alarm_specifier.ar_diagnosis);
+   EXPECT_EQ (maint_status, BIT (31));
+   diag_item.usi = PF_USI_EXTENDED_CHANNEL_DIAGNOSIS;
+   diag_item.fmt.std.qual_ch_qualifier = 0;
+   PNET_DIAG_CH_PROP_MAINT_SET (
+      diag_item.fmt.std.ch_properties,
+      PNET_DIAG_CH_PROP_MAINT_FAULT);
 }

--- a/test/test_cmrdr.cpp
+++ b/test/test_cmrdr.cpp
@@ -349,7 +349,6 @@ TEST_F (CmrdrTest, CmrdrRunTest)
    TEST_TRACE ("\nCreate a diag and an alarm.\n");
    pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_FAULT,

--- a/test/test_diag.cpp
+++ b/test/test_diag.cpp
@@ -245,7 +245,6 @@ TEST_F (DiagTest, DiagRunTest)
                "remove it.\n");
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_FAULT,
@@ -257,7 +256,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_update (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE,
@@ -266,7 +264,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -276,7 +273,6 @@ TEST_F (DiagTest, DiagRunTest)
                "remove them.\n");
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_FAULT,
@@ -288,7 +284,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_REQUIRED,
@@ -300,7 +295,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_DEMANDED,
@@ -312,7 +306,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_QUALIFIED,
@@ -324,7 +317,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -332,7 +324,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE_B,
       TEST_DIAG_EXT_ERRTYPE);
@@ -340,7 +331,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE_C,
       TEST_DIAG_EXT_ERRTYPE);
@@ -348,7 +338,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE_D,
       TEST_DIAG_EXT_ERRTYPE);
@@ -357,7 +346,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Try to remove it again\n");
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -366,7 +354,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Remove non-existing errortype\n");
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE_NONEXIST,
       TEST_DIAG_EXT_ERRTYPE);
@@ -375,7 +362,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Try to add two of the same kind\n");
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_REQUIRED,
@@ -389,7 +375,6 @@ TEST_F (DiagTest, DiagRunTest)
     * overwritten. */
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_REQUIRED,
@@ -401,7 +386,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -410,7 +394,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Update with the same value\n");
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_REQUIRED,
@@ -422,7 +405,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_update (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE,
@@ -431,7 +413,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -440,7 +421,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Try to update a diag entry that does not exist\n");
    ret = pnet_diag_std_update (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE,
@@ -449,7 +429,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_update (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE_NONEXIST,
       TEST_DIAG_EXT_ERRTYPE,
@@ -460,7 +439,6 @@ TEST_F (DiagTest, DiagRunTest)
    diag_source.slot = TEST_SUBSLOT_NONEXIST_IDENT;
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_REQUIRED,
@@ -475,7 +453,6 @@ TEST_F (DiagTest, DiagRunTest)
    diag_source.ch = TEST_CHANNEL_ILLEGAL;
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_REQUIRED,
@@ -487,7 +464,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_update (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE,
@@ -496,7 +472,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -507,7 +482,6 @@ TEST_F (DiagTest, DiagRunTest)
                "before removing the diagnosis.\n");
    ret = pnet_diag_std_add (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_NUMBER_OF_BITS,
       PNET_DIAG_CH_PROP_MAINT_FAULT,
@@ -520,7 +494,6 @@ TEST_F (DiagTest, DiagRunTest)
    diag_source.api = TEST_API_NONEXIST_IDENT;
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -530,7 +503,6 @@ TEST_F (DiagTest, DiagRunTest)
    diag_source.slot = TEST_SLOT_NONEXIST_IDENT;
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -540,7 +512,6 @@ TEST_F (DiagTest, DiagRunTest)
    diag_source.subslot = TEST_SUBSLOT_NONEXIST_IDENT;
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -550,7 +521,6 @@ TEST_F (DiagTest, DiagRunTest)
    diag_source.ch = TEST_CHANNEL_NONEXIST_IDENT;
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -560,7 +530,6 @@ TEST_F (DiagTest, DiagRunTest)
    diag_source.ch_grouping = PNET_DIAG_CH_CHANNEL_GROUP;
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -570,7 +539,6 @@ TEST_F (DiagTest, DiagRunTest)
    diag_source.ch_direction = PNET_DIAG_CH_PROP_DIR_INPUT;
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -579,7 +547,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE_NONEXIST,
       TEST_DIAG_EXT_ERRTYPE);
@@ -587,7 +554,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE_NONEXIST);
@@ -595,7 +561,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_std_remove (
       net,
-      appdata.main_arep,
       &diag_source,
       TEST_CHANNEL_ERRORTYPE,
       TEST_DIAG_EXT_ERRTYPE);
@@ -604,7 +569,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Test with a manufacturer specific USI\n");
    ret = pnet_diag_usi_add (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
@@ -615,7 +579,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Update data for a manufacturer specific USI, via add()\n");
    ret = pnet_diag_usi_add (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
@@ -626,7 +589,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Update data for a manufacturer specific USI, via update()\n");
    ret = pnet_diag_usi_update (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
@@ -637,7 +599,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Update for wrong USI and wrong subslot\n");
    ret = pnet_diag_usi_update (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
@@ -647,7 +608,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_usi_update (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_NONEXIST_IDENT,
@@ -658,7 +618,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Remove wrong USI\n");
    ret = pnet_diag_usi_remove (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
@@ -668,7 +627,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Remove correct USI\n");
    ret = pnet_diag_usi_remove (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
@@ -678,7 +636,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Add for invalid subslot\n");
    ret = pnet_diag_usi_add (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_NONEXIST_IDENT,
@@ -689,7 +646,6 @@ TEST_F (DiagTest, DiagRunTest)
    TEST_TRACE ("Add, update and remove diagnosis for invalid USI\n");
    ret = pnet_diag_usi_add (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
@@ -699,7 +655,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_usi_update (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
@@ -709,7 +664,6 @@ TEST_F (DiagTest, DiagRunTest)
 
    ret = pnet_diag_usi_remove (
       net,
-      appdata.main_arep,
       TEST_API_IDENT,
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,


### PR DESCRIPTION
- Peer port check added
- Queue for outgoing alarms added
- Alarms enabled on application ready response from PLC
- PDPort alarms triggered from main context - previously data was not protected properly

With these fixes testcases for alarm and diagnostics pass