### PR TITLE
pf_lldp_get_port_config() should return a pointer

### DIFF
--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -1127,7 +1127,7 @@ static int pf_alarm_apms_a_data_req (
    pnet_ethaddr_t mac_address;
    uint16_t u16 = 0;
 
-   pf_cmina_get_macaddr (net, &mac_address);
+   pf_cmina_get_device_macaddr (net, &mac_address);
 
    if (p_apmx->p_ar->alarm_cr_request.alarm_cr_properties.transport_udp == true)
    {

--- a/src/common/pf_dcp.c
+++ b/src/common/pf_dcp.c
@@ -834,7 +834,7 @@ static int pf_dcp_get_set (
    pf_dcp_header_t * p_dst_dcphdr;
    pnet_ethaddr_t mac_address;
 
-   pf_cmina_get_macaddr (net, &mac_address);
+   pf_cmina_get_device_macaddr (net, &mac_address);
 
    if (p_buf != NULL)
    {
@@ -1120,7 +1120,7 @@ int pf_dcp_hello_req (pnet_t * net)
    pf_ip_suite_t ip_suite;
    pnet_ethaddr_t mac_address;
 
-   pf_cmina_get_macaddr (net, &mac_address);
+   pf_cmina_get_device_macaddr (net, &mac_address);
 
    if (p_buf != NULL)
    {
@@ -1381,7 +1381,7 @@ static int pf_dcp_identify_req (
    (void)alias_position;
    (void)alias_len;
 
-   pf_cmina_get_macaddr (net, &mac_address);
+   pf_cmina_get_device_macaddr (net, &mac_address);
 
    /*
     * IdentifyReqBlock = DeviceRoleBlock ^ DeviceVendorBlock ^ DeviceIDBlock ^

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -55,16 +55,16 @@ int pf_lldp_get_peer_timestamp (
 /**
  * Get LLDP port configuration for a port.
  *
+ * If the local port number is out of range this operation will assert.
+ * NULL will never be returned.
+ *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
  *                                Valid range: 1 .. PNET_MAX_PORT
- * @param pp_port_cfg      Out:   LLDP port configuration, or NULL if not
- *                                found.
  */
-void pf_lldp_get_port_config (
+const pnet_lldp_port_cfg_t * pf_lldp_get_port_config (
    pnet_t * net,
-   int loc_port_num,
-   const pnet_lldp_port_cfg_t ** pp_port_cfg);
+   int loc_port_num);
 
 /**
  * Get Chassis ID of local device.

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3549,14 +3549,10 @@ void pf_put_pdport_data_real (
    uint8_t numPeers = 0;
    uint8_t temp_u8 = 0;
    pf_lldp_chassis_id_t chassis_id;
-   const pnet_lldp_port_cfg_t * p_port_config = NULL;
-   const pnet_lldp_peer_info_t * p_peer_info = NULL;
+   const pnet_lldp_port_cfg_t * p_port_config =
+      pf_lldp_get_port_config (net, loc_port_num);
    pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
-
-   pf_lldp_get_port_config (net, loc_port_num, &p_port_config);
-   CC_ASSERT (p_port_config != NULL);
-
-   p_peer_info = &p_port_data->lldp.peer_info;
+   const pnet_lldp_peer_info_t * p_peer_info = &p_port_data->lldp.peer_info;
 
    numPeers = p_peer_info->ttl ? 1 : 0;
 

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -4611,7 +4611,7 @@ int pf_cmdev_rm_connect_ind (
    const char * p_station_name = NULL;
    pnet_ethaddr_t mac_address;
 
-   pf_cmina_get_macaddr (net, &mac_address);
+   pf_cmina_get_device_macaddr (net, &mac_address);
 
    /* RM_Connect.ind */
    if (

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -1248,7 +1248,7 @@ int pf_cmina_get_ipaddr (pnet_t * net, pnal_ipaddr_t * p_ipaddr)
    return 0;
 }
 
-int pf_cmina_get_macaddr (pnet_t * net, pnet_ethaddr_t * p_macaddr)
+int pf_cmina_get_device_macaddr (pnet_t * net, pnet_ethaddr_t * p_macaddr)
 {
    *p_macaddr = net->cmina_current_dcp_ase.mac_address;
    return 0;

--- a/src/device/pf_cmina.h
+++ b/src/device/pf_cmina.h
@@ -57,9 +57,9 @@ void pf_cmina_show (pnet_t * net);
 
 /**
  * Convert IPv4 address to string
- * @param ip               In: IP address
- * @param outputstring     Out: Resulting string. Should have length
- * PNAL_INET_ADDRSTRLEN.
+ * @param ip               In:    IP address
+ * @param outputstring     Out:   Resulting string. Should have length
+ *                                PNAL_INET_ADDRSTRLEN.
  */
 void pf_cmina_ip_to_string (pnal_ipaddr_t ip, char * outputstring);
 
@@ -67,7 +67,7 @@ void pf_cmina_ip_to_string (pnal_ipaddr_t ip, char * outputstring);
  * Retrieve the path to the directory for saving files.
  * @param net                 InOut: The p-net stack instance
  * @param pp_file_directory   Out:   The absolute path to the file directory.
- * Terminated string or NULL.
+ *                                   Terminated string or NULL.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */
@@ -85,20 +85,20 @@ int pf_cmina_get_station_name (pnet_t * net, const char ** pp_station_name);
 /**
  * Retrieve the current IP address of the device.
  * @param net              InOut: The p-net stack instance
- * @param p_ipaddr         Out:  The ip_address.
+ * @param p_ipaddr         Out:   The ip_address.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */
 int pf_cmina_get_ipaddr (pnet_t * net, pnal_ipaddr_t * p_ipaddr);
 
 /**
- * Retrieve the MAC address.
+ * Retrieve the device MAC address.
  * @param net              InOut: The p-net stack instance
- * @param p_macaddr        Out:  The MAC address.
+ * @param p_macaddr        Out:   The MAC address.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */
-int pf_cmina_get_macaddr (pnet_t * net, pnet_ethaddr_t * p_macaddr);
+int pf_cmina_get_device_macaddr (pnet_t * net, pnet_ethaddr_t * p_macaddr);
 
 /**
  * Save one block of data for incoming DCP set command.
@@ -106,12 +106,12 @@ int pf_cmina_get_macaddr (pnet_t * net, pnet_ethaddr_t * p_macaddr);
  * Triggers the \a pnet_reset_ind() callback for some incoming DCP set commands.
  *
  * @param net              InOut: The p-net stack instance
- * @param opt              In:   The option key.
- * @param sub              In:   The sub-option key.
- * @param block_qualifier  In:   The block qualifier.
- * @param value_length     In:   The length of the data to set.
- * @param p_value          In:   The data to set.
- * @param p_block_error    Out:  The block error code, if any.
+ * @param opt              In:    The option key.
+ * @param sub              In:    The sub-option key.
+ * @param block_qualifier  In:    The block qualifier.
+ * @param value_length     In:    The length of the data to set.
+ * @param p_value          In:    The data to set.
+ * @param p_block_error    Out:   The block error code, if any.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */
@@ -144,7 +144,7 @@ int pf_cmina_dcp_set_ind (
  * must be called afterwards.
  *
  * @param net              InOut: The p-net stack instance
- * @param reset_mode       In:   Reset mode.
+ * @param reset_mode       In:    Reset mode.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */
@@ -164,12 +164,12 @@ void pf_cmina_dcp_set_commit (pnet_t * net);
  * Also used in DCP Hello and DCP Identify.
  *
  * @param net              InOut: The p-net stack instance
- * @param opt              In:   The option key.
- * @param sub              In:   The sub-option key.
- * @param value_length     In:   The length of the pp_value buffer.
- *                         Out:  The length of the read data.
- * @param pp_value         Out:  The retrieved data.
- * @param p_block_error    Out:  The block error code, if any.
+ * @param opt              In:    The option key.
+ * @param sub              In:    The sub-option key.
+ * @param value_length     In:    The length of the pp_value buffer.
+ *                         Out:   The length of the read data.
+ * @param pp_value         Out:   The retrieved data.
+ * @param p_block_error    Out:   The block error code, if any.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -459,7 +459,7 @@ static int pf_session_allocate (pnet_t * net, pf_session_info_t ** pp_sess)
    pf_session_info_t * p_sess = NULL;
    pnet_ethaddr_t mac_address;
 
-   pf_cmina_get_macaddr (net, &mac_address);
+   pf_cmina_get_device_macaddr (net, &mac_address);
 
    os_mutex_lock (net->p_cmrpc_rpc_mutex);
    while ((ix < NELEMENTS (net->cmrpc_session_info)) &&


### PR DESCRIPTION
Rename getter for MAC address to indicate that it is for the
device MAC address, not any port MAC address.