### PR TITLE
lldp: Store received optional variables

### DIFF
--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -211,40 +211,6 @@ int pf_lldp_get_peer_management_address (
    pf_lldp_management_address_t * p_man_address);
 
 /**
- * Get ManAddrIfId for local interface.
- *
- * See IEEE 802.1AB-2005 (LLDPv1) ch. 9.5.9 "Management Address TLV".
- *
- * @param net              In:    The p-net stack instance.
- * @param p_man_port_index Out:   Index in IfTable for Management port.
- */
-void pf_lldp_get_management_port_index (
-   pnet_t * net,
-   pf_lldp_management_port_index_t * p_man_port_index);
-
-/**
- * Get ManAddrIfId for remote interface connected to local port.
- *
- * Note that the remote device may have multiple interfaces. Only the remote
- * interface connected to the local port is relevant here.
- *
- * See IEEE 802.1AB-2005 (LLDPv1) ch. 9.5.9 "Management Address TLV".
- *
- * @param net              In:    The p-net stack instance.
- * @param loc_port_num     In:    Local port number for port directly
- *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
- *                                See pf_port_get_list_of_ports().
- * @param p_man_port_index Out:   Index in remote IfTable for Management port.
- * @return  0 if the operation succeeded.
- *         -1 if an error occurred (no info from remote device received).
- */
-int pf_lldp_get_peer_management_port_index (
-   pnet_t * net,
-   int loc_port_num,
-   pf_lldp_management_port_index_t * p_man_port_index);
-
-/**
  * Get remote station name for remote interface connected to local port.
  *
  * The station name is usually a string, but may also be the MAC address of
@@ -384,13 +350,13 @@ void pf_lldp_send_enable (pnet_t * net, int loc_port_num);
 void pf_lldp_send_disable (pnet_t * net, int loc_port_num);
 
 /**
- * Receive an LLDP message.
+ * Process received LLDP message.
  *
  * Parse LLDP tlv format and store selected information.
  * Trigger alarms if needed.
- * @param net              InOut: The p-net stack instance
- * @param p_frame_buf      In:    The Ethernet frame
- * @param offset           In:    The offset to start of LLDP data
+ * @param net              InOut: The p-net stack instance.
+ * @param p_frame_buf      InOut: The Ethernet frame.
+ * @param offset           In:    The offset to start of LLDP data.
  * @return  0     If the frame was NOT handled by this function.
  *          1     If the frame was handled and the buffer freed.
  */
@@ -403,6 +369,16 @@ int pf_lldp_generate_alias_name (
    const char * chassis_id,
    char * alias,
    uint16_t len);
+
+int pf_lldp_parse_packet (
+   const uint8_t buf[],
+   uint16_t len,
+   pf_lldp_peer_info_t * peer_info);
+
+void pf_lldp_store_peer_info (
+   pnet_t * net,
+   int loc_port_num,
+   const pf_lldp_peer_info_t * new_info);
 
 #ifdef __cplusplus
 }

--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -69,10 +69,10 @@ static void pf_snmp_encode_link_status (
    const pf_lldp_link_status_t * plain)
 {
    /* See RFC 2579 "Textual Conventions for SMIv2": "TruthValue" */
-   encoded->auto_neg_supported = plain->auto_neg_supported ? 1 : 2;
-   encoded->auto_neg_enabled = plain->auto_neg_enabled ? 1 : 2;
+   encoded->auto_neg_supported = plain->is_autonegotiation_supported ? 1 : 2;
+   encoded->auto_neg_enabled = plain->is_autonegotiation_enabled ? 1 : 2;
 
-   encoded->oper_mau_type = plain->oper_mau_type;
+   encoded->oper_mau_type = plain->operational_mau_type;
 
    /* See RFC 1906 "Transport Mappings for Version 2 of the
     *  Simple Network Management Protocol (SNMPv2)", ch. 8:
@@ -87,10 +87,10 @@ static void pf_snmp_encode_link_status (
     *  if any, of the final octet are set to zero on generation and
     *  ignored on receipt."
     */
-   encoded->auto_neg_advertised_cap[0] =
-      pf_snmp_bit_reversed_byte ((plain->auto_neg_advertised_cap >> 0) & 0xff);
-   encoded->auto_neg_advertised_cap[1] =
-      pf_snmp_bit_reversed_byte ((plain->auto_neg_advertised_cap >> 8) & 0xff);
+   encoded->auto_neg_advertised_cap[0] = pf_snmp_bit_reversed_byte (
+      (plain->autonegotiation_advertised_capabilities >> 0) & 0xff);
+   encoded->auto_neg_advertised_cap[1] = pf_snmp_bit_reversed_byte (
+      (plain->autonegotiation_advertised_capabilities >> 8) & 0xff);
 }
 
 /**
@@ -115,6 +115,21 @@ static void pf_snmp_encode_management_address (
    encoded->len = plain->len + 1;
    encoded->value[0] = plain->len;
    memcpy (&encoded->value[1], plain->value, plain->len);
+}
+
+/**
+ * Encode signal delays for use in SNMP response.
+ *
+ * @param encoded          Out:   Encoded signal delays.
+ * @param plain            In:    Unencoded signal delays.
+ */
+static void pf_snmp_encode_signal_delays (
+   pf_snmp_signal_delay_t * encoded,
+   const pf_lldp_signal_delay_t * plain)
+{
+   encoded->port_tx_delay_ns = plain->tx_delay_local;
+   encoded->port_rx_delay_ns = plain->rx_delay_local;
+   encoded->line_propagation_delay_ns = plain->cable_delay_local;
 }
 
 void pf_snmp_get_system_name (pnet_t * net, pf_snmp_system_name_t * name)
@@ -358,7 +373,7 @@ int pf_snmp_get_peer_management_address (
 
    error =
       pf_lldp_get_peer_management_address (net, loc_port_num, &man_address);
-   if (error == false)
+   if (error == 0)
    {
       pf_snmp_encode_management_address (p_man_address, &man_address);
    }
@@ -368,20 +383,30 @@ int pf_snmp_get_peer_management_address (
 
 void pf_snmp_get_management_port_index (
    pnet_t * net,
-   pf_lldp_management_port_index_t * p_man_port_index)
+   pf_lldp_interface_number_t * p_man_port_index)
 {
-   pf_lldp_get_management_port_index (net, p_man_port_index);
+   pf_lldp_management_address_t man_address;
+
+   pf_lldp_get_management_address (net, &man_address);
+   *p_man_port_index = man_address.interface_number;
 }
 
 int pf_snmp_get_peer_management_port_index (
    pnet_t * net,
    int loc_port_num,
-   pf_lldp_management_port_index_t * p_man_port_index)
+   pf_lldp_interface_number_t * p_man_port_index)
 {
-   return pf_lldp_get_peer_management_port_index (
-      net,
-      loc_port_num,
-      p_man_port_index);
+   int error;
+   pf_lldp_management_address_t man_address;
+
+   error =
+      pf_lldp_get_peer_management_address (net, loc_port_num, &man_address);
+   if (error == 0)
+   {
+      *p_man_port_index = man_address.interface_number;
+   }
+
+   return error;
 }
 
 void pf_snmp_get_station_name (
@@ -416,17 +441,29 @@ int pf_snmp_get_peer_station_name (
 void pf_snmp_get_signal_delays (
    pnet_t * net,
    int loc_port_num,
-   pf_lldp_signal_delay_t * p_delays)
+   pf_snmp_signal_delay_t * p_delays)
 {
-   pf_lldp_get_signal_delays (net, loc_port_num, p_delays);
+   pf_lldp_signal_delay_t delays;
+
+   pf_lldp_get_signal_delays (net, loc_port_num, &delays);
+   pf_snmp_encode_signal_delays (p_delays, &delays);
 }
 
 int pf_snmp_get_peer_signal_delays (
    pnet_t * net,
    int loc_port_num,
-   pf_lldp_signal_delay_t * p_delays)
+   pf_snmp_signal_delay_t * p_delays)
 {
-   return pf_lldp_get_peer_signal_delays (net, loc_port_num, p_delays);
+   pf_lldp_signal_delay_t delays;
+   int error;
+
+   error = pf_lldp_get_peer_signal_delays (net, loc_port_num, &delays);
+   if (error == 0)
+   {
+      pf_snmp_encode_signal_delays (p_delays, &delays);
+   }
+
+   return error;
 }
 
 void pf_snmp_get_link_status (
@@ -449,7 +486,7 @@ int pf_snmp_get_peer_link_status (
    int error;
 
    error = pf_lldp_get_peer_link_status (net, loc_port_num, &link_status);
-   if (error == false)
+   if (error == 0)
    {
       pf_snmp_encode_link_status (p_link_status, &link_status);
    }

--- a/src/common/pf_snmp.h
+++ b/src/common/pf_snmp.h
@@ -213,14 +213,14 @@ typedef struct pf_snmp_system_description
 /**
  * Encoded management address.
  *
- * Contains the same information as pf_lldp_management_address_t, but the
+ * Contains similar information as pf_lldp_management_address_t, but the
  * fields have been encoded so they may be immediately placed in SNMP response.
  */
 typedef struct pf_snmp_management_address
 {
-   uint8_t value[31]; /**< First byte is size of actual address */
-   uint8_t subtype;   /**< 1 for IPv4 */
-   size_t len;        /**< 5 for IPv4 */
+   uint8_t value[1 + 31]; /**< First byte is size of actual address */
+   uint8_t subtype;       /**< 1 for IPv4 */
+   size_t len;            /**< 5 for IPv4 */
 } pf_snmp_management_address_t;
 
 /**
@@ -236,6 +236,25 @@ typedef struct pf_snmp_link_status
    uint8_t auto_neg_advertised_cap[2]; /**< OCTET STRING encoding of BITS */
    int32_t oper_mau_type;
 } pf_snmp_link_status_t;
+
+/**
+ * Measured signal delays in nanoseconds
+ *
+ * If a signal delay was not measured, its value is zero.
+ *
+ * See IEC CDV 61158-6-10 (PN-AL-Protocol) Annex U: "LLDP EXT MIB", fields
+ * lldpXPnoLocLPDValue / lldpXPnoRemLPDValue,
+ * lldpXPnoLocPortTxDValue / lldpXPnoRemPortTxDValue,
+ * lldpXPnoLocPortRxDValue / lldpXPnoRemPortRxDValue.
+ *
+ * See also pf_lldp_signal_delay_t.
+ */
+typedef struct pf_snmp_signal_delay
+{
+   uint32_t port_tx_delay_ns;
+   uint32_t port_rx_delay_ns;
+   uint32_t line_propagation_delay_ns;
+} pf_snmp_signal_delay_t;
 
 /**
  * Get system description.
@@ -609,7 +628,7 @@ int pf_snmp_get_peer_management_address (
  */
 void pf_snmp_get_management_port_index (
    pnet_t * net,
-   pf_lldp_management_port_index_t * p_man_port_index);
+   pf_lldp_interface_number_t * p_man_port_index);
 
 /**
  * Get ManAddrIfId for remote interface connected to local port.
@@ -637,7 +656,7 @@ void pf_snmp_get_management_port_index (
 int pf_snmp_get_peer_management_port_index (
    pnet_t * net,
    int loc_port_num,
-   pf_lldp_management_port_index_t * p_man_port_index);
+   pf_lldp_interface_number_t * p_man_port_index);
 
 /**
  * Get local station name.
@@ -713,7 +732,7 @@ int pf_snmp_get_peer_station_name (
 void pf_snmp_get_signal_delays (
    pnet_t * net,
    int loc_port_num,
-   pf_lldp_signal_delay_t * p_delays);
+   pf_snmp_signal_delay_t * p_delays);
 
 /**
  * Get measured signal delays on remote port.
@@ -737,7 +756,7 @@ void pf_snmp_get_signal_delays (
 int pf_snmp_get_peer_signal_delays (
    pnet_t * net,
    int loc_port_num,
-   pf_lldp_signal_delay_t * p_delays);
+   pf_snmp_signal_delay_t * p_delays);
 
 /**
  * Get encoded link status of local port.

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3616,12 +3616,12 @@ void pf_put_pdport_data_real (
       pf_put_uint16 (is_big_endian, temp_u16, res_len, p_bytes, p_pos);
 
       /* Length peer_id */
-      pf_put_byte (p_peer_info->port_id_len, res_len, p_bytes, p_pos);
+      pf_put_byte (p_peer_info->port_id.len, res_len, p_bytes, p_pos);
 
       /* peer_id */
       pf_put_mem (
-         p_peer_info->port_id,
-         p_peer_info->port_id_len,
+         p_peer_info->port_id.string,
+         p_peer_info->port_id.len,
          res_len,
          p_bytes,
          p_pos);

--- a/src/ports/linux/mib/lldpLocManAddrTable.c
+++ b/src/ports/linux/mib/lldpLocManAddrTable.c
@@ -122,7 +122,7 @@ int lldpLocManAddrTable_handler (
    pnet_t * pnet = reginfo->my_reg_void;
    void * my_data_context;
    pf_snmp_management_address_t address;
-   pf_lldp_management_port_index_t port_index;
+   pf_lldp_interface_number_t port_index;
 
    LOG_DEBUG (PF_SNMP_LOG, "lldpLocManAddrTable(%d): handler entry\n", __LINE__);
 
@@ -176,7 +176,7 @@ int lldpLocManAddrTable_handler (
             snmp_set_var_typed_integer (
                request->requestvb,
                ASN_INTEGER,
-               port_index.index);
+               port_index.value);
             break;
          default:
             netsnmp_set_request_error (reqinfo, request, SNMP_NOSUCHOBJECT);

--- a/src/ports/linux/mib/lldpRemManAddrTable.c
+++ b/src/ports/linux/mib/lldpRemManAddrTable.c
@@ -170,7 +170,7 @@ int lldpRemManAddrTable_handler (
    netsnmp_table_request_info * table_info;
    pnet_t * pnet = reginfo->my_reg_void;
    void * my_data_context;
-   pf_lldp_management_port_index_t port_index;
+   pf_lldp_interface_number_t port_index;
    int port;
    int error;
 
@@ -229,7 +229,7 @@ int lldpRemManAddrTable_handler (
             snmp_set_var_typed_integer (
                request->requestvb,
                ASN_INTEGER,
-               port_index.index);
+               port_index.value);
             break;
          default:
             netsnmp_set_request_error (reqinfo, request, SNMP_NOSUCHOBJECT);

--- a/src/ports/linux/mib/lldpXPnoLocTable.c
+++ b/src/ports/linux/mib/lldpXPnoLocTable.c
@@ -138,7 +138,7 @@ int lldpXPnoLocTable_handler (
    netsnmp_table_request_info * table_info;
    pnet_t * pnet = reginfo->my_reg_void;
    void * my_data_context;
-   pf_lldp_signal_delay_t delays;
+   pf_snmp_signal_delay_t delays;
    pf_lldp_station_name_t station_name;
    int port;
 

--- a/src/ports/linux/mib/lldpXPnoRemTable.c
+++ b/src/ports/linux/mib/lldpXPnoRemTable.c
@@ -155,7 +155,7 @@ int lldpXPnoRemTable_handler (
    netsnmp_table_request_info * table_info;
    pnet_t * pnet = reginfo->my_reg_void;
    void * my_data_context;
-   pf_lldp_signal_delay_t delays;
+   pf_snmp_signal_delay_t delays;
    pf_lldp_station_name_t station_name;
    int port;
    int error;

--- a/src/ports/rt-kernel/lldp-ext-pno-mib.c
+++ b/src/ports/rt-kernel/lldp-ext-pno-mib.c
@@ -253,7 +253,7 @@ static s16_t lldpxpnoloctable_get_value (
    {
       /* lldpXPnoLocLPDValue */
       u32_t * v = (u32_t *)value;
-      pf_lldp_signal_delay_t delays;
+      pf_snmp_signal_delay_t delays;
 
       pf_snmp_get_signal_delays (pnal_snmp.net, port, &delays);
       *v = delays.line_propagation_delay_ns;
@@ -264,7 +264,7 @@ static s16_t lldpxpnoloctable_get_value (
    {
       /* lldpXPnoLocPortTxDValue */
       u32_t * v = (u32_t *)value;
-      pf_lldp_signal_delay_t delays;
+      pf_snmp_signal_delay_t delays;
 
       pf_snmp_get_signal_delays (pnal_snmp.net, port, &delays);
       *v = delays.port_tx_delay_ns;
@@ -275,7 +275,7 @@ static s16_t lldpxpnoloctable_get_value (
    {
       /* lldpXPnoLocPortRxDValue */
       u32_t * v = (u32_t *)value;
-      pf_lldp_signal_delay_t delays;
+      pf_snmp_signal_delay_t delays;
 
       pf_snmp_get_signal_delays (pnal_snmp.net, port, &delays);
       *v = delays.port_rx_delay_ns;
@@ -412,7 +412,7 @@ static s16_t lldpxpnoremtable_get_value (
    {
       /* lldpXPnoRemLPDValue */
       u32_t * v = (u32_t *)value;
-      pf_lldp_signal_delay_t delays;
+      pf_snmp_signal_delay_t delays;
       int error;
 
       error = pf_snmp_get_peer_signal_delays (pnal_snmp.net, port, &delays);
@@ -431,7 +431,7 @@ static s16_t lldpxpnoremtable_get_value (
    {
       /* lldpXPnoRemPortTxDValue */
       u32_t * v = (u32_t *)value;
-      pf_lldp_signal_delay_t delays;
+      pf_snmp_signal_delay_t delays;
       int error;
 
       error = pf_snmp_get_peer_signal_delays (pnal_snmp.net, port, &delays);
@@ -450,7 +450,7 @@ static s16_t lldpxpnoremtable_get_value (
    {
       /* lldpXPnoRemPortRxDValue */
       u32_t * v = (u32_t *)value;
-      pf_lldp_signal_delay_t delays;
+      pf_snmp_signal_delay_t delays;
       int error;
 
       error = pf_snmp_get_peer_signal_delays (pnal_snmp.net, port, &delays);

--- a/src/ports/rt-kernel/lldp-mib.c
+++ b/src/ports/rt-kernel/lldp-mib.c
@@ -647,7 +647,7 @@ static s16_t lldplocmanaddrtable_get_value (
    {
       /* lldpLocManAddrIfSubtype */
       s32_t * v = (s32_t *)value;
-      pf_lldp_management_port_index_t port_index;
+      pf_lldp_interface_number_t port_index;
 
       pf_snmp_get_management_port_index (pnal_snmp.net, &port_index);
       value_len = sizeof (s32_t);
@@ -658,12 +658,12 @@ static s16_t lldplocmanaddrtable_get_value (
    {
       /* lldpLocManAddrIfId */
       s32_t * v = (s32_t *)value;
-      pf_lldp_management_port_index_t port_index;
+      pf_lldp_interface_number_t port_index;
 
       pf_snmp_get_management_port_index (pnal_snmp.net, &port_index);
 
       value_len = sizeof (s32_t);
-      *v = port_index.index;
+      *v = port_index.value;
    }
    break;
    default:
@@ -1066,7 +1066,7 @@ static s16_t lldpremmanaddrtable_get_value (
    {
       /* lldpRemManAddrIfSubtype */
       s32_t * v = (s32_t *)value;
-      pf_lldp_management_port_index_t port_index;
+      pf_lldp_interface_number_t port_index;
       int error;
 
       error = pf_snmp_get_peer_management_port_index (
@@ -1088,7 +1088,7 @@ static s16_t lldpremmanaddrtable_get_value (
    {
       /* lldpRemManAddrIfId */
       s32_t * v = (s32_t *)value;
-      pf_lldp_management_port_index_t port_index;
+      pf_lldp_interface_number_t port_index;
       int error;
 
       error = pf_snmp_get_peer_management_port_index (
@@ -1102,7 +1102,7 @@ static s16_t lldpremmanaddrtable_get_value (
       else
       {
          value_len = sizeof (s32_t);
-         *v = port_index.index;
+         *v = port_index.value;
       }
    }
    break;

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -41,6 +41,11 @@ uint32_t mock_os_get_current_time_us (void)
    return mock_os_data.current_time_us;
 }
 
+uint32_t mock_pnal_get_system_uptime_10ms (void)
+{
+   return mock_os_data.system_uptime_10ms;
+}
+
 pnal_eth_handle_t * mock_pnal_eth_init (
    const char * if_name,
    pnal_eth_callback_t * callback,

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -43,6 +43,7 @@ typedef struct mock_os_data_obj
    uint16_t set_ip_suite_count;
 
    uint32_t current_time_us;
+   uint32_t system_uptime_10ms;
 
    char file_fullpath[100]; /* Full file path at latest save operation */
    uint16_t file_size;
@@ -64,6 +65,7 @@ extern mock_os_data_t mock_os_data;
 extern mock_lldp_data_t mock_lldp_data;
 
 uint32_t mock_os_get_current_time_us (void);
+uint32_t mock_pnal_get_system_uptime_10ms (void);
 
 void mock_init (void);
 void mock_clear (void);

--- a/test/test_lldp.cpp
+++ b/test/test_lldp.cpp
@@ -28,7 +28,20 @@
 
 #define LOCAL_PORT 1
 
-const char * chassis_id_test_sample_1 =
+#define MAX_LLDP_PAYLOAD_SIZE 1500
+
+#define LLDP_TYPE_END                0
+#define LLDP_TYPE_CHASSIS_ID         1
+#define LLDP_TYPE_PORT_ID            2
+#define LLDP_TYPE_TTL                3
+#define LLDP_TYPE_PORT_DESCRIPTION   4
+#define LLDP_TYPE_MANAGEMENT_ADDRESS 8
+#define LLDP_TYPE_ORG_SPEC           127
+
+#define TLV_BYTE_0(len, type) (((len) >> 8) | ((type) << 1))
+#define TLV_BYTE_1(len)       (((len) >> 0) & 0xff)
+
+static const char * chassis_id_test_sample_1 =
    "\x53\x43\x41\x4c\x41\x4e\x43\x45\x20\x58\x2d\x32\x30\x30\x20"
    "\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x20\x36\x47\x4b\x35\x20"
    "\x32\x30\x34\x2d\x30\x42\x41\x30\x30\x2d\x32\x42\x41\x33\x20\x20"
@@ -36,7 +49,7 @@ const char * chassis_id_test_sample_1 =
    "\x20\x20\x20\x20\x20\x39\x20\x56\x20\x20\x35\x20\x20\x34\x20\x20"
    "\x32";
 
-const char * port_id_test_sample_1 =
+static const char * port_id_test_sample_1 =
    "\x70\x6f\x72\x74\x2d\x30\x30\x33\x2e\x61\x62\x63\x64\x65\x66\x67"
    "\x68\x69\x6a\x6b\x6c\x6d\x6e\x6f\x70\x71\x72\x73\x74\x75\x76\x77"
    "\x78\x79\x7a\x2d\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b\x6c"
@@ -53,6 +66,237 @@ const char * port_id_test_sample_1 =
    "\x77\x78\x79\x7a\x2d\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b"
    "\x6c\x6d\x6e\x6f\x70\x71\x72\x73\x74\x75\x76\x77\x78\x79\x7a\x31"
    "\x32\x33\x34\x35\x36\x37\x38\x39\x30";
+
+static pf_lldp_peer_info_t fake_peer_info (void)
+{
+   pf_lldp_peer_info_t peer;
+
+   memset (&peer, 0, sizeof (peer));
+
+   snprintf (
+      peer.chassis_id.string,
+      sizeof (peer.chassis_id.string),
+      "%s",
+      "Chassis ID received from remote device");
+   peer.chassis_id.len = strlen (peer.chassis_id.string);
+   peer.chassis_id.subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
+   peer.chassis_id.is_valid = true;
+
+   snprintf (
+      peer.port_id.string,
+      sizeof (peer.port_id.string),
+      "%s",
+      "Port ID received from remote device");
+   peer.port_id.len = strlen (peer.port_id.string);
+   peer.port_id.subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
+   peer.port_id.is_valid = true;
+
+   snprintf (
+      peer.port_description.string,
+      sizeof (peer.port_description.string),
+      "%s",
+      "Port Description");
+   peer.port_description.len = strlen (peer.port_description.string);
+   peer.port_description.is_valid = true;
+
+   peer.management_address.subtype = 1; /* IPv4 */
+   peer.management_address.value[0] = 192;
+   peer.management_address.value[1] = 168;
+   peer.management_address.value[2] = 10;
+   peer.management_address.value[3] = 102;
+   peer.management_address.len = 4;
+   peer.management_address.interface_number.subtype = 2; /* ifIndex */
+   peer.management_address.interface_number.value = 1;
+   peer.management_address.is_valid = true;
+
+   peer.phy_config.is_autonegotiation_supported = true;
+   peer.phy_config.is_autonegotiation_enabled = true;
+   peer.phy_config.autonegotiation_advertised_capabilities =
+      PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
+      PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX;
+   peer.phy_config.operational_mau_type = PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
+   peer.phy_config.is_valid = true;
+
+   peer.port_delay.cable_delay_local = 1;
+   peer.port_delay.rx_delay_local = 2;
+   peer.port_delay.tx_delay_local = 3;
+   peer.port_delay.rx_delay_remote = 4;
+   peer.port_delay.tx_delay_remote = 5;
+   peer.port_delay.is_valid = true;
+
+   return peer;
+}
+
+static size_t construct_packet_chassis_id (
+   uint8_t packet[],
+   const pf_lldp_chassis_id_t * id)
+{
+   size_t size = 0;
+
+   if (id->is_valid)
+   {
+      packet[0] = TLV_BYTE_0 (1 + id->len, LLDP_TYPE_CHASSIS_ID);
+      packet[1] = TLV_BYTE_1 (1 + id->len);
+      packet[2] = id->subtype;
+      memcpy (&packet[3], id->string, id->len);
+      size = 3 + id->len;
+   }
+
+   return size;
+}
+
+static size_t construct_packet_port_id (
+   uint8_t packet[],
+   const pf_lldp_port_id_t * id)
+{
+   size_t size = 0;
+
+   if (id->is_valid)
+   {
+      packet[0] = TLV_BYTE_0 (1 + id->len, LLDP_TYPE_PORT_ID);
+      packet[1] = TLV_BYTE_1 (1 + id->len);
+      packet[2] = id->subtype;
+      memcpy (&packet[3], id->string, id->len);
+      size = 3 + id->len;
+   }
+
+   return size;
+}
+
+static size_t construct_packet_port_description (
+   uint8_t packet[],
+   const pf_lldp_port_description_t * description)
+{
+   size_t size = 0;
+
+   if (description->is_valid)
+   {
+      packet[0] = TLV_BYTE_0 (description->len, LLDP_TYPE_PORT_DESCRIPTION);
+      packet[1] = TLV_BYTE_1 (description->len);
+      memcpy (&packet[2], description->string, description->len);
+      size = 2 + description->len;
+   }
+
+   return size;
+}
+
+static size_t construct_packet_management_address (
+   uint8_t packet[],
+   const pf_lldp_management_address_t * address)
+{
+   size_t size = 0;
+
+   if (address->is_valid)
+   {
+      uint32_t big_endian;
+
+      packet[0] =
+         TLV_BYTE_0 (2 + address->len + 6, LLDP_TYPE_MANAGEMENT_ADDRESS);
+      packet[1] = TLV_BYTE_1 (2 + address->len + 6);
+      packet[2] = 1 + address->len;
+      packet[3] = address->subtype;
+      memcpy (&packet[4], address->value, address->len);
+      size += 4 + address->len;
+
+      big_endian = CC_TO_BE32 (address->interface_number.value);
+      packet[0 + size] = address->interface_number.subtype;
+      memcpy (&packet[1 + size], &big_endian, 4);
+      packet[5 + size] = 0; /* OID string length */
+      size += 6;
+   }
+
+   return size;
+}
+
+static size_t construct_packet_link_status (
+   uint8_t packet[],
+   const pf_lldp_link_status_t * status)
+{
+   size_t size = 0;
+
+   if (status->is_valid)
+   {
+      packet[0] = TLV_BYTE_0 (9, LLDP_TYPE_ORG_SPEC);
+      packet[1] = TLV_BYTE_1 (9);
+      packet[2] = 0x00; /* 802.3 OUI */
+      packet[3] = 0x12; /* 802.3 OUI */
+      packet[4] = 0x0F; /* 802.3 OUI */
+      packet[5] = 1;    /* subtype */
+      packet[6] = ((uint8_t)status->is_autonegotiation_supported << 0) |
+                  ((uint8_t)status->is_autonegotiation_enabled << 1);
+      packet[7] = status->autonegotiation_advertised_capabilities >> 8;
+      packet[8] = status->autonegotiation_advertised_capabilities >> 0;
+      packet[9] = status->operational_mau_type >> 8;
+      packet[10] = status->operational_mau_type >> 0;
+      size = 11;
+   }
+
+   return size;
+}
+
+static size_t construct_packet_signal_delay (
+   uint8_t packet[],
+   const pf_lldp_signal_delay_t * delay)
+{
+   size_t size = 0;
+   uint32_t bigendian;
+
+   if (delay->is_valid)
+   {
+      packet[0] = TLV_BYTE_0 (24, LLDP_TYPE_ORG_SPEC);
+      packet[1] = TLV_BYTE_1 (24);
+      packet[2] = 0x00; /* Profinet OUI */
+      packet[3] = 0x0E; /* Profinet OUI */
+      packet[4] = 0xCF; /* Profinet OUI */
+      packet[5] = 1;    /* subtype */
+      bigendian = CC_TO_BE32 (delay->rx_delay_local);
+      memcpy (&packet[6], &bigendian, 4);
+      bigendian = CC_TO_BE32 (delay->rx_delay_remote);
+      memcpy (&packet[10], &bigendian, 4);
+      bigendian = CC_TO_BE32 (delay->tx_delay_local);
+      memcpy (&packet[14], &bigendian, 4);
+      bigendian = CC_TO_BE32 (delay->tx_delay_remote);
+      memcpy (&packet[18], &bigendian, 4);
+      bigendian = CC_TO_BE32 (delay->cable_delay_local);
+      memcpy (&packet[22], &bigendian, 4);
+      size = 26;
+   }
+
+   return size;
+}
+
+static size_t construct_packet_end_marker (uint8_t packet[])
+{
+   size_t size;
+
+   packet[0] = TLV_BYTE_0 (0, LLDP_TYPE_END);
+   packet[1] = TLV_BYTE_1 (0);
+   size = 2;
+
+   return size;
+}
+
+static size_t construct_packet (
+   uint8_t packet[MAX_LLDP_PAYLOAD_SIZE],
+   const pf_lldp_peer_info_t * data)
+{
+   memset (packet, 0xff, MAX_LLDP_PAYLOAD_SIZE);
+   size_t size = 0;
+
+   size += construct_packet_chassis_id (&packet[size], &data->chassis_id);
+   size += construct_packet_port_id (&packet[size], &data->port_id);
+   size += construct_packet_port_description (
+      &packet[size],
+      &data->port_description);
+   size += construct_packet_management_address (
+      &packet[size],
+      &data->management_address);
+   size += construct_packet_link_status (&packet[size], &data->phy_config);
+   size += construct_packet_signal_delay (&packet[size], &data->port_delay);
+   size += construct_packet_end_marker (&packet[size]);
+
+   return size;
+}
 
 class LldpTest : public PnetIntegrationTestBase
 {
@@ -139,6 +383,173 @@ TEST_F (LldpTest, LldpGenerateAliasName)
    memset (alias, 0, sizeof (alias));
 }
 
+TEST_F (LldpTest, LldpParsePacket)
+{
+   uint8_t packet[MAX_LLDP_PAYLOAD_SIZE];
+   int error;
+   size_t size;
+   pf_lldp_peer_info_t actual;
+   const pf_lldp_peer_info_t expected = fake_peer_info();
+
+   size = construct_packet (packet, &expected);
+   memset (&actual, 0xff, sizeof (actual));
+
+   error = pf_lldp_parse_packet (packet, size, &actual);
+
+   EXPECT_EQ (error, 0);
+
+   EXPECT_EQ (actual.chassis_id.is_valid, expected.chassis_id.is_valid);
+   EXPECT_EQ (actual.chassis_id.subtype, expected.chassis_id.subtype);
+   EXPECT_EQ (actual.chassis_id.len, expected.chassis_id.len);
+   EXPECT_STREQ (actual.chassis_id.string, expected.chassis_id.string);
+
+   EXPECT_EQ (actual.port_id.is_valid, expected.port_id.is_valid);
+   EXPECT_EQ (actual.port_id.subtype, expected.port_id.subtype);
+   EXPECT_EQ (actual.port_id.len, expected.port_id.len);
+   EXPECT_STREQ (actual.port_id.string, expected.port_id.string);
+
+   EXPECT_EQ (
+      actual.port_description.is_valid,
+      expected.port_description.is_valid);
+   EXPECT_EQ (actual.port_description.len, expected.port_description.len);
+   EXPECT_STREQ (
+      actual.port_description.string,
+      expected.port_description.string);
+
+   EXPECT_EQ (
+      actual.management_address.is_valid,
+      expected.management_address.is_valid);
+   EXPECT_EQ (
+      actual.management_address.subtype,
+      expected.management_address.subtype);
+   EXPECT_EQ (actual.management_address.len, expected.management_address.len);
+   EXPECT_EQ (
+      memcmp (
+         actual.management_address.value,
+         expected.management_address.value,
+         4),
+      0);
+   EXPECT_EQ (
+      actual.management_address.interface_number.subtype,
+      expected.management_address.interface_number.subtype);
+   EXPECT_EQ (
+      actual.management_address.interface_number.value,
+      expected.management_address.interface_number.value);
+
+   EXPECT_EQ (actual.phy_config.is_valid, expected.phy_config.is_valid);
+   EXPECT_EQ (
+      actual.phy_config.is_autonegotiation_supported,
+      expected.phy_config.is_autonegotiation_supported);
+   EXPECT_EQ (
+      actual.phy_config.is_autonegotiation_enabled,
+      expected.phy_config.is_autonegotiation_enabled);
+   EXPECT_EQ (
+      actual.phy_config.autonegotiation_advertised_capabilities,
+      expected.phy_config.autonegotiation_advertised_capabilities);
+   EXPECT_EQ (
+      actual.phy_config.operational_mau_type,
+      expected.phy_config.operational_mau_type);
+
+   EXPECT_EQ (actual.port_delay.is_valid, expected.port_delay.is_valid);
+   EXPECT_EQ (
+      actual.port_delay.rx_delay_local,
+      expected.port_delay.rx_delay_local);
+   EXPECT_EQ (
+      actual.port_delay.rx_delay_remote,
+      expected.port_delay.rx_delay_remote);
+   EXPECT_EQ (
+      actual.port_delay.tx_delay_local,
+      expected.port_delay.tx_delay_local);
+   EXPECT_EQ (
+      actual.port_delay.tx_delay_remote,
+      expected.port_delay.tx_delay_remote);
+   EXPECT_EQ (
+      actual.port_delay.cable_delay_local,
+      expected.port_delay.cable_delay_local);
+
+   /* Finally check that everything is as expected.
+    * While this is the only check really needed, the checks above will make
+    * it easier to find out exactly what went wrong.
+    */
+   EXPECT_EQ (memcmp (&actual, &expected, sizeof (expected)), 0);
+}
+
+TEST_F (LldpTest, LldpParsePacketWithTooBigChassisId)
+{
+   uint8_t packet[MAX_LLDP_PAYLOAD_SIZE];
+   int error;
+   size_t size;
+   pf_lldp_peer_info_t actual;
+   pf_lldp_peer_info_t peer = fake_peer_info();
+   const size_t max_len = sizeof (peer.chassis_id.string) - 1;
+
+   peer.chassis_id.len = max_len + 1;
+   size = construct_packet (packet, &peer);
+   memset (&actual, 0xff, sizeof (actual));
+
+   error = pf_lldp_parse_packet (packet, size, &actual);
+
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (actual.chassis_id.is_valid, false);
+}
+
+TEST_F (LldpTest, LldpParsePacketWithTooBigPortId)
+{
+   uint8_t packet[MAX_LLDP_PAYLOAD_SIZE];
+   int error;
+   size_t size;
+   pf_lldp_peer_info_t actual;
+   pf_lldp_peer_info_t peer = fake_peer_info();
+   const size_t max_len = sizeof (peer.port_id.string) - 1;
+
+   peer.port_id.len = max_len + 1;
+   size = construct_packet (packet, &peer);
+   memset (&actual, 0xff, sizeof (actual));
+
+   error = pf_lldp_parse_packet (packet, size, &actual);
+
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (actual.port_id.is_valid, false);
+}
+
+TEST_F (LldpTest, LldpParsePacketWithTooBigPortDescription)
+{
+   uint8_t packet[MAX_LLDP_PAYLOAD_SIZE];
+   int error;
+   size_t size;
+   pf_lldp_peer_info_t actual;
+   pf_lldp_peer_info_t peer = fake_peer_info();
+   const size_t max_len = sizeof (peer.port_description.string) - 1;
+
+   peer.port_description.len = max_len + 1;
+   size = construct_packet (packet, &peer);
+   memset (&actual, 0xff, sizeof (actual));
+
+   error = pf_lldp_parse_packet (packet, size, &actual);
+
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (actual.port_description.is_valid, false);
+}
+
+TEST_F (LldpTest, LldpParsePacketWithTooBigManagementAddress)
+{
+   uint8_t packet[MAX_LLDP_PAYLOAD_SIZE];
+   int error;
+   size_t size;
+   pf_lldp_peer_info_t actual;
+   pf_lldp_peer_info_t peer = fake_peer_info();
+   const size_t max_len = sizeof (peer.management_address.value);
+
+   peer.management_address.len = max_len + 1;
+   size = construct_packet (packet, &peer);
+   memset (&actual, 0xff, sizeof (actual));
+
+   error = pf_lldp_parse_packet (packet, size, &actual);
+
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (actual.management_address.is_valid, false);
+}
+
 TEST_F (LldpTest, LldpGetChassisId)
 {
    pf_lldp_chassis_id_t chassis_id;
@@ -195,17 +606,8 @@ TEST_F (LldpTest, LldpGetManagementAddress)
    EXPECT_EQ (man_address.value[2], 1);
    EXPECT_EQ (man_address.value[3], 171);
    EXPECT_EQ (man_address.len, 4u);
-}
-
-TEST_F (LldpTest, LldpGetManagementPortIndex)
-{
-   pf_lldp_management_port_index_t man_port_index;
-
-   memset (&man_port_index, 0xff, sizeof (man_port_index));
-
-   pf_lldp_get_management_port_index (net, &man_port_index);
-   EXPECT_EQ (man_port_index.subtype, 2); /* ifIndex */
-   EXPECT_EQ (man_port_index.index, 1);   /* TODO */
+   EXPECT_EQ (man_address.interface_number.subtype, 2); /* ifIndex */
+   EXPECT_EQ (man_address.interface_number.value, 1);   /* TODO */
 }
 
 TEST_F (LldpTest, LldpGetSignalDelays)
@@ -215,9 +617,9 @@ TEST_F (LldpTest, LldpGetSignalDelays)
    memset (&delays, 0xff, sizeof (delays));
 
    pf_lldp_get_signal_delays (net, LOCAL_PORT, &delays);
-   EXPECT_EQ (delays.port_tx_delay_ns, 0u);          /* Not measured */
-   EXPECT_EQ (delays.port_rx_delay_ns, 0u);          /* Not measured */
-   EXPECT_EQ (delays.line_propagation_delay_ns, 0u); /* Not measured */
+   EXPECT_EQ (delays.tx_delay_local, 0u);    /* Not measured */
+   EXPECT_EQ (delays.rx_delay_local, 0u);    /* Not measured */
+   EXPECT_EQ (delays.cable_delay_local, 0u); /* Not measured */
 }
 
 TEST_F (LldpTest, LldpGetLinkStatus)
@@ -227,86 +629,112 @@ TEST_F (LldpTest, LldpGetLinkStatus)
    memset (&link_status, 0xff, sizeof (link_status));
 
    pf_lldp_get_link_status (net, LOCAL_PORT, &link_status);
-   EXPECT_EQ (link_status.auto_neg_supported, true);
-   EXPECT_EQ (link_status.auto_neg_enabled, true);
+   EXPECT_EQ (link_status.is_autonegotiation_supported, true);
+   EXPECT_EQ (link_status.is_autonegotiation_enabled, true);
    EXPECT_EQ (
-      link_status.auto_neg_advertised_cap,
+      link_status.autonegotiation_advertised_capabilities,
       PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
          PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX);
-   EXPECT_EQ (link_status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
+   EXPECT_EQ (
+      link_status.operational_mau_type,
+      PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
 }
 
 TEST_F (LldpTest, LldpGetPeerTimestamp)
 {
-   uint32_t timestamp_10ms;
+   uint32_t actual;
+   const uint32_t expected = 0x87654321;
    int error;
+   pf_lldp_peer_info_t received_data;
 
    /* Nothing received */
-   error = pf_lldp_get_peer_timestamp (net, LOCAL_PORT, &timestamp_10ms);
+   error = pf_lldp_get_peer_timestamp (net, LOCAL_PORT, &actual);
    EXPECT_EQ (error, -1);
 
-   /* TODO: Add test case for scenario where LLDP packet has been received */
+   /* Receive fake data at fake timestamp */
+   mock_os_data.system_uptime_10ms = expected;
+   received_data = fake_peer_info();
+   pf_lldp_store_peer_info (net, LOCAL_PORT, &received_data);
+
+   error = pf_lldp_get_peer_timestamp (net, LOCAL_PORT, &actual);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (actual, expected);
 }
 
 TEST_F (LldpTest, LldpGetPeerChassisId)
 {
-   pf_lldp_chassis_id_t chassis_id;
+   const pf_lldp_peer_info_t received = fake_peer_info();
+   const pf_lldp_chassis_id_t expected = received.chassis_id;
+   pf_lldp_chassis_id_t actual;
    int error;
 
    /* Nothing received */
-   error = pf_lldp_get_peer_chassis_id (net, LOCAL_PORT, &chassis_id);
+   error = pf_lldp_get_peer_chassis_id (net, LOCAL_PORT, &actual);
    EXPECT_EQ (error, -1);
 
-   /* TODO: Add test case for scenario where LLDP packet has been received */
+   /* Receive fake data */
+   pf_lldp_store_peer_info (net, LOCAL_PORT, &received);
+
+   error = pf_lldp_get_peer_chassis_id (net, LOCAL_PORT, &actual);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (memcmp (&actual, &expected, sizeof (actual)), 0);
 }
 
 TEST_F (LldpTest, LldpGetPeerPortId)
 {
-   pf_lldp_port_id_t port_id;
+   const pf_lldp_peer_info_t received = fake_peer_info();
+   const pf_lldp_port_id_t expected = received.port_id;
+   pf_lldp_port_id_t actual;
    int error;
 
    /* Nothing received */
-   error = pf_lldp_get_peer_port_id (net, LOCAL_PORT, &port_id);
+   error = pf_lldp_get_peer_port_id (net, LOCAL_PORT, &actual);
    EXPECT_EQ (error, -1);
 
-   /* TODO: Add test case for scenario where LLDP packet has been received */
+   /* Receive fake data */
+   pf_lldp_store_peer_info (net, LOCAL_PORT, &received);
+
+   error = pf_lldp_get_peer_port_id (net, LOCAL_PORT, &actual);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (memcmp (&actual, &expected, sizeof (actual)), 0);
 }
 
 TEST_F (LldpTest, LldpGetPeerPortDescription)
 {
-   pf_lldp_port_description_t port_desc;
+   const pf_lldp_peer_info_t received = fake_peer_info();
+   const pf_lldp_port_description_t expected = received.port_description;
+   pf_lldp_port_description_t actual;
    int error;
 
    /* Nothing received */
-   error = pf_lldp_get_peer_port_description (net, LOCAL_PORT, &port_desc);
+   error = pf_lldp_get_peer_port_description (net, LOCAL_PORT, &actual);
    EXPECT_EQ (error, -1);
 
-   /* TODO: Add test case for scenario where LLDP packet has been received */
+   /* Receive fake data */
+   pf_lldp_store_peer_info (net, LOCAL_PORT, &received);
+
+   error = pf_lldp_get_peer_port_description (net, LOCAL_PORT, &actual);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (memcmp (&actual, &expected, sizeof (actual)), 0);
 }
 
 TEST_F (LldpTest, LldpGetPeerManagementAddress)
 {
-   pf_lldp_management_address_t man_address;
+   const pf_lldp_peer_info_t received = fake_peer_info();
+   const pf_lldp_management_address_t expected = received.management_address;
+   pf_lldp_management_address_t actual;
    int error;
 
    /* Nothing received */
-   error = pf_lldp_get_peer_management_address (net, LOCAL_PORT, &man_address);
+   error = pf_lldp_get_peer_management_address (net, LOCAL_PORT, &actual);
    EXPECT_EQ (error, -1);
 
-   /* TODO: Add test case for scenario where LLDP packet has been received */
-}
+   /* Receive fake data */
+   pf_lldp_store_peer_info (net, LOCAL_PORT, &received);
 
-TEST_F (LldpTest, LldpGetPeerManagementPortIndex)
-{
-   pf_lldp_management_port_index_t man_port_index;
-   int error;
-
-   /* Nothing received */
-   error =
-      pf_lldp_get_peer_management_port_index (net, LOCAL_PORT, &man_port_index);
-   EXPECT_EQ (error, -1);
-
-   /* TODO: Add test case for scenario where LLDP packet has been received */
+   error = pf_lldp_get_peer_management_address (net, LOCAL_PORT, &actual);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (memcmp (&actual, &expected, sizeof (actual)), 0);
 }
 
 TEST_F (LldpTest, LldpGetPeerStationName)
@@ -323,24 +751,38 @@ TEST_F (LldpTest, LldpGetPeerStationName)
 
 TEST_F (LldpTest, LldpGetPeerSignalDelays)
 {
-   pf_lldp_signal_delay_t delays;
+   const pf_lldp_peer_info_t received = fake_peer_info();
+   const pf_lldp_signal_delay_t expected = received.port_delay;
+   pf_lldp_signal_delay_t actual;
    int error;
 
    /* Nothing received */
-   error = pf_lldp_get_peer_signal_delays (net, LOCAL_PORT, &delays);
+   error = pf_lldp_get_peer_signal_delays (net, LOCAL_PORT, &actual);
    EXPECT_EQ (error, -1);
 
-   /* TODO: Add test case for scenario where LLDP packet has been received */
+   /* Receive fake data */
+   pf_lldp_store_peer_info (net, LOCAL_PORT, &received);
+
+   error = pf_lldp_get_peer_signal_delays (net, LOCAL_PORT, &actual);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (memcmp (&actual, &expected, sizeof (actual)), 0);
 }
 
 TEST_F (LldpTest, LldpGetPeerLinkStatus)
 {
-   pf_lldp_link_status_t link_status;
+   const pf_lldp_peer_info_t received = fake_peer_info();
+   const pf_lldp_link_status_t expected = received.phy_config;
+   pf_lldp_link_status_t actual;
    int error;
 
    /* Nothing received */
-   error = pf_lldp_get_peer_link_status (net, LOCAL_PORT, &link_status);
+   error = pf_lldp_get_peer_link_status (net, LOCAL_PORT, &actual);
    EXPECT_EQ (error, -1);
 
-   /* TODO: Add test case for scenario where LLDP packet has been received */
+   /* Receive fake data */
+   pf_lldp_store_peer_info (net, LOCAL_PORT, &received);
+
+   error = pf_lldp_get_peer_link_status (net, LOCAL_PORT, &actual);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (memcmp (&actual, &expected, sizeof (actual)), 0);
 }

--- a/test/test_snmp.cpp
+++ b/test/test_snmp.cpp
@@ -96,10 +96,10 @@ TEST_F (SnmpTest, SnmpGetLinkStatus)
    pf_snmp_link_status_t status;
 
    memset (&status, 0xff, sizeof (status));
-   mock_lldp_data.link_status.auto_neg_supported = true;
-   mock_lldp_data.link_status.auto_neg_enabled = true;
-   mock_lldp_data.link_status.auto_neg_advertised_cap = 0xF00F;
-   mock_lldp_data.link_status.oper_mau_type =
+   mock_lldp_data.link_status.is_autonegotiation_supported = true;
+   mock_lldp_data.link_status.is_autonegotiation_enabled = true;
+   mock_lldp_data.link_status.autonegotiation_advertised_capabilities = 0xF00F;
+   mock_lldp_data.link_status.operational_mau_type =
       PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
 
    pf_snmp_get_link_status (net, LOCAL_PORT, &status);
@@ -110,11 +110,11 @@ TEST_F (SnmpTest, SnmpGetLinkStatus)
    EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
 
    memset (&status, 0xff, sizeof (status));
-   mock_lldp_data.link_status.auto_neg_supported = true;
-   mock_lldp_data.link_status.auto_neg_enabled = false;
-   mock_lldp_data.link_status.auto_neg_advertised_cap =
+   mock_lldp_data.link_status.is_autonegotiation_supported = true;
+   mock_lldp_data.link_status.is_autonegotiation_enabled = false;
+   mock_lldp_data.link_status.autonegotiation_advertised_capabilities =
       BIT (5 + 0) | BIT (3 + 0) | BIT (6 + 8) | BIT (0 + 8);
-   mock_lldp_data.link_status.oper_mau_type =
+   mock_lldp_data.link_status.operational_mau_type =
       PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX;
 
    pf_snmp_get_link_status (net, LOCAL_PORT, &status);
@@ -131,10 +131,11 @@ TEST_F (SnmpTest, SnmpGetPeerLinkStatus)
    int error;
 
    memset (&status, 0xff, sizeof (status));
-   mock_lldp_data.peer_link_status.auto_neg_supported = true;
-   mock_lldp_data.peer_link_status.auto_neg_enabled = true;
-   mock_lldp_data.peer_link_status.auto_neg_advertised_cap = 0xF00F;
-   mock_lldp_data.peer_link_status.oper_mau_type =
+   mock_lldp_data.peer_link_status.is_autonegotiation_supported = true;
+   mock_lldp_data.peer_link_status.is_autonegotiation_enabled = true;
+   mock_lldp_data.peer_link_status.autonegotiation_advertised_capabilities =
+      0xF00F;
+   mock_lldp_data.peer_link_status.operational_mau_type =
       PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
    mock_lldp_data.error = 0;
 
@@ -147,11 +148,11 @@ TEST_F (SnmpTest, SnmpGetPeerLinkStatus)
    EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
 
    memset (&status, 0xff, sizeof (status));
-   mock_lldp_data.peer_link_status.auto_neg_supported = true;
-   mock_lldp_data.peer_link_status.auto_neg_enabled = false;
-   mock_lldp_data.peer_link_status.auto_neg_advertised_cap =
+   mock_lldp_data.peer_link_status.is_autonegotiation_supported = true;
+   mock_lldp_data.peer_link_status.is_autonegotiation_enabled = false;
+   mock_lldp_data.peer_link_status.autonegotiation_advertised_capabilities =
       BIT (5 + 0) | BIT (3 + 0) | BIT (6 + 8) | BIT (0 + 8);
-   mock_lldp_data.peer_link_status.oper_mau_type =
+   mock_lldp_data.peer_link_status.operational_mau_type =
       PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX;
    mock_lldp_data.error = 0;
 


### PR DESCRIPTION
Stores the following TLVs from incoming LLDP
packet:
* Port Description
* Management Address

Getter functions now report error if requested
variable was not found in received LLDP packet,
even if an LLDP packet has been received.

Unit tests were added for LLDP.