### PR TITLE
snmp: Change internal API

### DIFF
--- a/src/ports/rt-kernel/lldp-ext-dot3-mib.c
+++ b/src/ports/rt-kernel/lldp-ext-dot3-mib.c
@@ -253,41 +253,40 @@ static s16_t lldpxdot3locporttable_get_value (
    {
       /* lldpXdot3LocPortAutoNegSupported */
       s32_t * v = (s32_t *)value;
-      pf_lldp_link_status_t link_status;
+      pf_snmp_link_status_t link_status;
 
       pf_snmp_get_link_status (pnal_snmp.net, port, &link_status);
-      value_len = snmp_encode_truthvalue (v, link_status.auto_neg_supported);
+      value_len = sizeof (s32_t);
+      *v = link_status.auto_neg_supported;
    }
    break;
    case 2:
    {
       /* lldpXdot3LocPortAutoNegEnabled */
       s32_t * v = (s32_t *)value;
-      pf_lldp_link_status_t link_status;
+      pf_snmp_link_status_t link_status;
 
       pf_snmp_get_link_status (pnal_snmp.net, port, &link_status);
-      value_len = snmp_encode_truthvalue (v, link_status.auto_neg_enabled);
+      value_len = sizeof (s32_t);
+      *v = link_status.auto_neg_enabled;
    }
    break;
    case 3:
    {
       /* lldpXdot3LocPortAutoNegAdvertisedCap */
       u8_t * v = (u8_t *)value;
-      pf_lldp_link_status_t link_status;
+      pf_snmp_link_status_t link_status;
 
       pf_snmp_get_link_status (pnal_snmp.net, port, &link_status);
-      value_len = snmp_encode_bits (
-         v,
-         SNMP_MAX_VALUE_SIZE,
-         link_status.auto_neg_advertised_cap,
-         16);
+      value_len = 2;
+      memcpy (v, link_status.auto_neg_advertised_cap, 2);
    }
    break;
    case 4:
    {
       /* lldpXdot3LocPortOperMauType */
       s32_t * v = (s32_t *)value;
-      pf_lldp_link_status_t link_status;
+      pf_snmp_link_status_t link_status;
 
       pf_snmp_get_link_status (pnal_snmp.net, port, &link_status);
       value_len = sizeof (s32_t);
@@ -401,7 +400,7 @@ static s16_t lldpxdot3remporttable_get_value (
    {
       /* lldpXdot3RemPortAutoNegSupported */
       s32_t * v = (s32_t *)value;
-      pf_lldp_link_status_t link_status;
+      pf_snmp_link_status_t link_status;
       int error;
 
       error = pf_snmp_get_peer_link_status (pnal_snmp.net, port, &link_status);
@@ -411,7 +410,8 @@ static s16_t lldpxdot3remporttable_get_value (
       }
       else
       {
-         value_len = snmp_encode_truthvalue (v, link_status.auto_neg_supported);
+         value_len = sizeof (s32_t);
+         *v = link_status.auto_neg_supported;
       }
    }
    break;
@@ -419,7 +419,7 @@ static s16_t lldpxdot3remporttable_get_value (
    {
       /* lldpXdot3RemPortAutoNegEnabled */
       s32_t * v = (s32_t *)value;
-      pf_lldp_link_status_t link_status;
+      pf_snmp_link_status_t link_status;
       int error;
 
       error = pf_snmp_get_peer_link_status (pnal_snmp.net, port, &link_status);
@@ -429,7 +429,8 @@ static s16_t lldpxdot3remporttable_get_value (
       }
       else
       {
-         value_len = snmp_encode_truthvalue (v, link_status.auto_neg_enabled);
+         value_len = sizeof (s32_t);
+         *v = link_status.auto_neg_enabled;
       }
    }
    break;
@@ -437,7 +438,7 @@ static s16_t lldpxdot3remporttable_get_value (
    {
       /* lldpXdot3RemPortAutoNegAdvertisedCap */
       u8_t * v = (u8_t *)value;
-      pf_lldp_link_status_t link_status;
+      pf_snmp_link_status_t link_status;
       int error;
 
       error = pf_snmp_get_peer_link_status (pnal_snmp.net, port, &link_status);
@@ -447,11 +448,8 @@ static s16_t lldpxdot3remporttable_get_value (
       }
       else
       {
-         value_len = snmp_encode_bits (
-            v,
-            SNMP_MAX_VALUE_SIZE,
-            link_status.auto_neg_advertised_cap,
-            16);
+         value_len = 2;
+         memcpy (v, link_status.auto_neg_advertised_cap, 2);
       }
    }
    break;
@@ -459,7 +457,7 @@ static s16_t lldpxdot3remporttable_get_value (
    {
       /* lldpXdot3RemPortOperMauType */
       s32_t * v = (s32_t *)value;
-      pf_lldp_link_status_t link_status;
+      pf_snmp_link_status_t link_status;
       int error;
 
       error = pf_snmp_get_peer_link_status (pnal_snmp.net, port, &link_status);

--- a/src/ports/rt-kernel/lldp-mib.c
+++ b/src/ports/rt-kernel/lldp-mib.c
@@ -636,11 +636,11 @@ static s16_t lldplocmanaddrtable_get_value (
    {
       /* lldpLocManAddrLen */
       s32_t * v = (s32_t *)value;
-      pf_lldp_management_address_t address;
+      pf_snmp_management_address_t address;
 
       pf_snmp_get_management_address (pnal_snmp.net, &address);
       value_len = sizeof (s32_t);
-      *v = address.len + 1;
+      *v = address.len;
    }
    break;
    case 4:

--- a/src/ports/rt-kernel/rowindex.c
+++ b/src/ports/rt-kernel/rowindex.c
@@ -37,17 +37,16 @@ static void rowindex_construct_for_local_port (
 static void rowindex_construct_for_local_interface (
    struct snmp_obj_id * row_index)
 {
-   pf_lldp_management_address_t address;
+   pf_snmp_management_address_t address;
    size_t i;
 
    pf_snmp_get_management_address (pnal_snmp.net, &address);
    row_index->id[0] = address.subtype; /* lldpLocManAddrSubtype */
-   row_index->id[1] = address.len;     /* lldpLocManAddr length */
    for (i = 0; i < address.len; i++)
    {
-      row_index->id[2 + i] = address.value[i]; /* lldpLocManAddr value */
+      row_index->id[1 + i] = address.value[i]; /* lldpLocManAddr */
    }
-   row_index->len = 2 + address.len;
+   row_index->len = 1 + address.len;
 }
 
 static int rowindex_construct_for_remote_device (
@@ -65,7 +64,7 @@ static int rowindex_construct_for_remote_device (
 
    row_index->id[0] = timestamp; /* lldpRemTimeMark */
    row_index->id[1] = port;      /* lldpRemLocalPortNum */
-   row_index->id[2] = port;      /* lldpRemIndex TODO: Increment this  */
+   row_index->id[2] = port;      /* lldpRemIndex */
    row_index->len = 3;
 
    return error;
@@ -76,7 +75,7 @@ static int rowindex_construct_for_remote_interface (
    int port)
 {
    uint32_t timestamp;
-   pf_lldp_management_address_t address;
+   pf_snmp_management_address_t address;
    int error;
    size_t i;
 
@@ -93,14 +92,13 @@ static int rowindex_construct_for_remote_interface (
 
    row_index->id[0] = timestamp;       /* lldpRemTimeMark */
    row_index->id[1] = port;            /* lldpRemLocalPortNum */
-   row_index->id[2] = port;            /* lldpRemIndex TODO: Increment this  */
+   row_index->id[2] = port;            /* lldpRemIndex */
    row_index->id[3] = address.subtype; /* lldpRemManAddrSubtype */
-   row_index->id[4] = address.len;     /* lldpRemManAddr length */
    for (i = 0; i < address.len; i++)
    {
-      row_index->id[5 + i] = address.value[i]; /* lldpRemManAddr value */
+      row_index->id[4 + i] = address.value[i]; /* lldpRemManAddr */
    }
-   row_index->len = 5 + address.len;
+   row_index->len = 4 + address.len;
 
    return error;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ target_sources(pf_test PRIVATE
   test_ppm.cpp
   test_ptcp.cpp
   test_scheduler.cpp
+  test_snmp.cpp
   utils_for_testing.h
   utils_for_testing.cpp
 
@@ -83,6 +84,7 @@ target_sources(pf_test PRIVATE
   ${PROFINET_SOURCE_DIR}/src/common/pf_ppm.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_ptcp.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_scheduler.c
+  ${PROFINET_SOURCE_DIR}/src/common/pf_snmp.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_udp.c
   )
 

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -22,10 +22,12 @@ uint8_t pnet_log_level;
 
 os_mutex_t * mock_mutex;
 mock_os_data_t mock_os_data;
+mock_lldp_data_t mock_lldp_data;
 
 void mock_clear (void)
 {
    memset (&mock_os_data, 0, sizeof (mock_os_data));
+   memset (&mock_lldp_data, 0, sizeof (mock_lldp_data));
 }
 
 void mock_init (void)
@@ -241,4 +243,37 @@ void mock_pf_generate_uuid (
    p_uuid->data4[5] = 0x06;
    p_uuid->data4[6] = 0x07;
    p_uuid->data4[7] = 0x08;
+}
+
+void mock_pf_lldp_get_management_address (
+   pnet_t * net,
+   pf_lldp_management_address_t * p_man_address)
+{
+   *p_man_address = mock_lldp_data.management_address;
+}
+
+int mock_pf_lldp_get_peer_management_address (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_management_address_t * p_man_address)
+{
+   *p_man_address = mock_lldp_data.peer_management_address;
+   return mock_lldp_data.error;
+}
+
+void mock_pf_lldp_get_link_status (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_link_status_t * p_link_status)
+{
+   *p_link_status = mock_lldp_data.link_status;
+}
+
+int mock_pf_lldp_get_peer_link_status (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_link_status_t * p_link_status)
+{
+   *p_link_status = mock_lldp_data.peer_link_status;
+   return mock_lldp_data.error;
 }

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -50,7 +50,18 @@ typedef struct mock_os_data_obj
 
 } mock_os_data_t;
 
+typedef struct mock_lldp_data
+{
+   pf_lldp_management_address_t management_address;
+   pf_lldp_management_address_t peer_management_address;
+   pf_lldp_link_status_t link_status;
+   pf_lldp_link_status_t peer_link_status;
+   int error;
+
+} mock_lldp_data_t;
+
 extern mock_os_data_t mock_os_data;
+extern mock_lldp_data_t mock_lldp_data;
 
 uint32_t mock_os_get_current_time_us (void);
 
@@ -114,6 +125,25 @@ void mock_pf_generate_uuid (
    uint32_t session_number,
    pnet_ethaddr_t mac_address,
    pf_uuid_t * p_uuid);
+
+void mock_pf_lldp_get_management_address (
+   pnet_t * net,
+   pf_lldp_management_address_t * p_man_address);
+
+int mock_pf_lldp_get_peer_management_address (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_management_address_t * p_man_address);
+
+void mock_pf_lldp_get_link_status (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_link_status_t * p_link_status);
+
+int mock_pf_lldp_get_peer_link_status (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_link_status_t * p_link_status);
 
 #ifdef __cplusplus
 }

--- a/test/test_snmp.cpp
+++ b/test/test_snmp.cpp
@@ -1,0 +1,169 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2020 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+/**
+ * @file
+ * @brief Unit test for SNMP helper functions in pf_snmp.h.
+ *
+ */
+
+#include "utils_for_testing.h"
+#include "mocks.h"
+
+#include "pf_includes.h"
+
+#include <gtest/gtest.h>
+
+#define LOCAL_PORT 1
+
+class SnmpTest : public PnetIntegrationTest
+{
+};
+
+/* See https://tools.ietf.org/html/rfc2578#section-7.7 clause 3,
+ * for encoding of OCTET STRING field ManAddress.
+ */
+TEST_F (SnmpTest, SnmpGetManagementAddress)
+{
+   pf_snmp_management_address_t address;
+
+   memset (&address, 0xff, sizeof (address));
+   mock_lldp_data.management_address.subtype = 1;
+   mock_lldp_data.management_address.value[0] = 192;
+   mock_lldp_data.management_address.value[1] = 168;
+   mock_lldp_data.management_address.value[2] = 1;
+   mock_lldp_data.management_address.value[3] = 100;
+   mock_lldp_data.management_address.len = 4;
+
+   pf_snmp_get_management_address (net, &address);
+   EXPECT_EQ (address.subtype, 1);
+   EXPECT_EQ (address.value[0], 4); /* len */
+   EXPECT_EQ (address.value[1], 192);
+   EXPECT_EQ (address.value[2], 168);
+   EXPECT_EQ (address.value[3], 1);
+   EXPECT_EQ (address.value[4], 100);
+   EXPECT_EQ (address.len, 5u);
+}
+
+TEST_F (SnmpTest, SnmpGetPeerManagementAddress)
+{
+   pf_snmp_management_address_t address;
+   int error;
+
+   memset (&address, 0xff, sizeof (address));
+   mock_lldp_data.peer_management_address.subtype = 1;
+   mock_lldp_data.peer_management_address.value[0] = 192;
+   mock_lldp_data.peer_management_address.value[1] = 168;
+   mock_lldp_data.peer_management_address.value[2] = 1;
+   mock_lldp_data.peer_management_address.value[3] = 101;
+   mock_lldp_data.peer_management_address.len = 4;
+   mock_lldp_data.error = 0;
+
+   error = pf_snmp_get_peer_management_address (net, LOCAL_PORT, &address);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (address.subtype, 1);
+   EXPECT_EQ (address.value[0], 4); /* len */
+   EXPECT_EQ (address.value[1], 192);
+   EXPECT_EQ (address.value[2], 168);
+   EXPECT_EQ (address.value[3], 1);
+   EXPECT_EQ (address.value[4], 101);
+   EXPECT_EQ (address.len, 5u);
+
+   mock_lldp_data.error = -1;
+   error = pf_snmp_get_peer_management_address (net, LOCAL_PORT, &address);
+   EXPECT_EQ (error, -1);
+}
+
+/* See https://tools.ietf.org/html/rfc1906 for encoding of
+ * BITS field AutoNegAdvertisedCap.
+ * See https://tools.ietf.org/html/rfc2579 for encoding of
+ * TruthValue fields AutoNegSupported and AutoNegEnabled.
+ */
+TEST_F (SnmpTest, SnmpGetLinkStatus)
+{
+   pf_snmp_link_status_t status;
+
+   memset (&status, 0xff, sizeof (status));
+   mock_lldp_data.link_status.auto_neg_supported = true;
+   mock_lldp_data.link_status.auto_neg_enabled = true;
+   mock_lldp_data.link_status.auto_neg_advertised_cap = 0xF00F;
+   mock_lldp_data.link_status.oper_mau_type =
+      PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
+
+   pf_snmp_get_link_status (net, LOCAL_PORT, &status);
+   EXPECT_EQ (status.auto_neg_supported, 1); /* true */
+   EXPECT_EQ (status.auto_neg_enabled, 1);   /* true */
+   EXPECT_EQ (status.auto_neg_advertised_cap[0], 0xF0);
+   EXPECT_EQ (status.auto_neg_advertised_cap[1], 0x0F);
+   EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
+
+   memset (&status, 0xff, sizeof (status));
+   mock_lldp_data.link_status.auto_neg_supported = true;
+   mock_lldp_data.link_status.auto_neg_enabled = false;
+   mock_lldp_data.link_status.auto_neg_advertised_cap =
+      BIT (5 + 0) | BIT (3 + 0) | BIT (6 + 8) | BIT (0 + 8);
+   mock_lldp_data.link_status.oper_mau_type =
+      PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX;
+
+   pf_snmp_get_link_status (net, LOCAL_PORT, &status);
+   EXPECT_EQ (status.auto_neg_supported, 1); /* true */
+   EXPECT_EQ (status.auto_neg_enabled, 2);   /* false */
+   EXPECT_EQ (status.auto_neg_advertised_cap[0], BIT (2) | BIT (4));
+   EXPECT_EQ (status.auto_neg_advertised_cap[1], BIT (1) | BIT (7));
+   EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX);
+}
+
+TEST_F (SnmpTest, SnmpGetPeerLinkStatus)
+{
+   pf_snmp_link_status_t status;
+   int error;
+
+   memset (&status, 0xff, sizeof (status));
+   mock_lldp_data.peer_link_status.auto_neg_supported = true;
+   mock_lldp_data.peer_link_status.auto_neg_enabled = true;
+   mock_lldp_data.peer_link_status.auto_neg_advertised_cap = 0xF00F;
+   mock_lldp_data.peer_link_status.oper_mau_type =
+      PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
+   mock_lldp_data.error = 0;
+
+   error = pf_snmp_get_peer_link_status (net, LOCAL_PORT, &status);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (status.auto_neg_supported, 1); /* true */
+   EXPECT_EQ (status.auto_neg_enabled, 1);   /* true */
+   EXPECT_EQ (status.auto_neg_advertised_cap[0], 0xF0);
+   EXPECT_EQ (status.auto_neg_advertised_cap[1], 0x0F);
+   EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
+
+   memset (&status, 0xff, sizeof (status));
+   mock_lldp_data.peer_link_status.auto_neg_supported = true;
+   mock_lldp_data.peer_link_status.auto_neg_enabled = false;
+   mock_lldp_data.peer_link_status.auto_neg_advertised_cap =
+      BIT (5 + 0) | BIT (3 + 0) | BIT (6 + 8) | BIT (0 + 8);
+   mock_lldp_data.peer_link_status.oper_mau_type =
+      PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX;
+   mock_lldp_data.error = 0;
+
+   error = pf_snmp_get_peer_link_status (net, LOCAL_PORT, &status);
+   EXPECT_EQ (error, 0);
+   EXPECT_EQ (status.auto_neg_supported, 1); /* true */
+   EXPECT_EQ (status.auto_neg_enabled, 2);   /* false */
+   EXPECT_EQ (status.auto_neg_advertised_cap[0], BIT (2) | BIT (4));
+   EXPECT_EQ (status.auto_neg_advertised_cap[1], BIT (1) | BIT (7));
+   EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX);
+
+   mock_lldp_data.error = -1;
+   error = pf_snmp_get_peer_link_status (net, LOCAL_PORT, &status);
+   EXPECT_EQ (error, -1);
+}


### PR DESCRIPTION
Encoding of SNMP variables is now done in the
API functions instead of at the call site.
Some new structs were introduced containing
encoded values.

The following functions now returns new structs:
- pf_snmp_get_management_address()
- pf_snmp_get_link_status()
- pf_snmp_get_peer_management_address()
- pf_snmp_get_peer_link_status()