### PR TITLE
Rename pnet_set_state() to pnet_set_primary_state()

### DIFF
--- a/doc/api_documentation.rst
+++ b/doc/api_documentation.rst
@@ -47,7 +47,7 @@ Periodic data
 
 Redundant state etc
 -------------------
-.. doxygenfunction:: pnet_set_state
+.. doxygenfunction:: pnet_set_primary_state
 .. doxygenfunction:: pnet_set_redundancy_state
 
 

--- a/doc/implementation_details.rst
+++ b/doc/implementation_details.rst
@@ -410,7 +410,7 @@ Implements these user functions (via ``pnet_api.c``):
 
 * ``pnet_input_set_data_and_iops()``
 * ``pnet_output_set_iocs()``
-* ``pnet_set_state()``
+* ``pnet_set_primary_state()``
 * ``pnet_set_redundancy_state()``
 * ``pnet_set_provider_state()``
 

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1628,7 +1628,7 @@ PNET_EXPORT int pnet_output_set_iocs (
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */
-PNET_EXPORT int pnet_set_state (pnet_t * net, bool primary);
+PNET_EXPORT int pnet_set_primary_state (pnet_t * net, bool primary);
 
 /**
  * Set the state to redundant in the cyclic data sent to the IO-Controller.

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -304,7 +304,7 @@ int pnet_pull_submodule (
    return pf_cmdev_pull_submodule (net, api, slot, subslot);
 }
 
-int pnet_set_state (pnet_t * net, bool primary)
+int pnet_set_primary_state (pnet_t * net, bool primary)
 {
    int ret = 0; /* Assume all goes well */
    uint16_t ar_ix;


### PR DESCRIPTION
It is difficult to know what a function pnet_set_state() is about.
With the new name it is easier to understand that it is related
to primary and backup state of the cyclic data communication.