### PR TITLE
Constify parsed buffer

### DIFF
--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -1660,7 +1660,7 @@ static int pf_alarm_apmr_a_data_ind (
    pf_alarm_data_t alarm_data;
    pnet_pnio_status_t pnio_status;
    uint16_t data_usi;
-   uint8_t * p_data;
+   const uint8_t * p_data;
 
    switch (p_apmx->apmr_state)
    {

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -64,7 +64,7 @@ typedef struct lldp_tlv
 {
    uint8_t type;
    uint16_t len;
-   uint8_t * p_data;
+   const uint8_t * p_data;
 } lldp_tlv_t;
 
 static const char org_id_pnio[] = {0x00, 0x0e, 0xcf};
@@ -1053,7 +1053,7 @@ void pf_lldp_send_disable (pnet_t * net, int loc_port_num)
  * @return 0 if parsing is successful, -1 on error.
  */
 int pf_lldp_parse_packet (
-   uint8_t buf[],
+   const uint8_t buf[],
    uint16_t len,
    pnet_lldp_peer_info_t * lldp_peer_info)
 {

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -3878,7 +3878,7 @@ static int pf_cmrpc_dce_packet (
    pnet_t * net,
    uint32_t ip_addr,
    uint16_t port,
-   uint8_t * p_req, /* Not const as it is used in a pf_get_info_t */
+   const uint8_t * p_req,
    uint32_t req_len,
    uint8_t * p_res,
    uint16_t * p_res_len,

--- a/src/device/pf_cmwrr.c
+++ b/src/device/pf_cmwrr.c
@@ -148,7 +148,7 @@ static int pf_cmwrr_write (
    pnet_t * net,
    const pf_ar_t * p_ar,
    const pf_iod_write_request_t * p_write_request,
-   uint8_t * p_req_buf,
+   const uint8_t * p_req_buf,
    uint16_t data_length,
    uint16_t * p_req_pos,
    pnet_result_t * p_result)
@@ -210,7 +210,7 @@ int pf_cmwrr_rm_write_ind (
    const pf_iod_write_request_t * p_write_request,
    pf_iod_write_result_t * p_write_result,
    pnet_result_t * p_result,
-   uint8_t * p_req_buf, /* request buffer */
+   const uint8_t * p_req_buf, /* request buffer */
    uint16_t data_length,
    uint16_t * p_req_pos) /* In/out: position in request buffer */
 {

--- a/src/device/pf_cmwrr.h
+++ b/src/device/pf_cmwrr.h
@@ -69,7 +69,7 @@ int pf_cmwrr_rm_write_ind (
    const pf_iod_write_request_t * p_write_request,
    pf_iod_write_result_t * p_write_result,
    pnet_result_t * p_result,
-   uint8_t * p_req_buf,
+   const uint8_t * p_req_buf,
    uint16_t data_length,
    uint16_t * p_req_pos);
 

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -728,7 +728,7 @@ int pf_fspm_cm_write_ind (
    const pf_ar_t * p_ar,
    const pf_iod_write_request_t * p_write_request,
    uint16_t write_length,
-   uint8_t * p_write_data,
+   const uint8_t * p_write_data,
    pnet_result_t * p_write_status)
 {
    int ret = -1;

--- a/src/device/pf_fspm.h
+++ b/src/device/pf_fspm.h
@@ -88,7 +88,7 @@ int pf_fspm_cm_write_ind (
    const pf_ar_t * p_ar,
    const pf_iod_write_request_t * p_write_request,
    uint16_t write_length,
-   uint8_t * p_write_data,
+   const uint8_t * p_write_data,
    pnet_result_t * p_result);
 
 /**

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -667,7 +667,7 @@ static int pf_pdport_write_data_check (
    const pf_ar_t * p_ar,
    const pf_iod_write_request_t * p_write_req,
    int loc_port_num,
-   uint8_t * p_bytes, /* Not const as it is used in a pf_get_info_t */
+   const uint8_t * p_bytes,
    uint16_t p_datalength,
    pnet_result_t * p_result)
 {
@@ -773,7 +773,7 @@ static int pf_pdport_write_data_adj (
    const pf_ar_t * p_ar,
    const pf_iod_write_request_t * p_write_req,
    int loc_port_num,
-   uint8_t * p_bytes, /* Not const as it is used in a pf_get_info_t */
+   const uint8_t * p_bytes,
    uint16_t p_datalength,
    pnet_result_t * p_result)
 {
@@ -844,7 +844,7 @@ int pf_pdport_write_req (
    const pf_ar_t * p_ar,
    const pf_iod_write_request_t * p_write_req,
    int loc_port_num,
-   uint8_t * p_bytes,
+   const uint8_t * p_bytes,
    uint16_t data_length,
    pnet_result_t * p_result)
 {

--- a/src/device/pf_pdport.h
+++ b/src/device/pf_pdport.h
@@ -115,7 +115,7 @@ int pf_pdport_write_req (
    const pf_ar_t * p_ar,
    const pf_iod_write_request_t * p_write_req,
    int loc_port_num,
-   uint8_t * p_req_buf,
+   const uint8_t * p_req_buf,
    uint16_t data_length,
    pnet_result_t * p_result);
 

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -1790,7 +1790,7 @@ typedef struct pf_get_info
 {
    pf_get_result_t result;
    bool is_big_endian;
-   uint8_t * p_buf;
+   const uint8_t * p_buf;
    uint16_t len;
 } pf_get_info_t;
 


### PR DESCRIPTION
Adds the 'const' qualifier on the buffer in the
type pf_get_info_t used for parsing a received
packet.