### PR TITLE
Add option to configure size of port description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ set(PNET_MAX_DIRECTORYPATH_LENGTH 240
 set(PNET_MAX_FILENAME_LENGTH 30
   CACHE STRING "Max length of filenames, including termination")
 
+set(PNET_MAX_PORT_DESCRIPTION_LENGTH 60
+  CACHE STRING "Max length of port description, including termination")
+
 set(LOG_STATE_VALUES "ON;OFF")
 set(LOG_LEVEL_VALUES "DEBUG;INFO;WARNING;ERROR;FATAL")
 

--- a/options.h.in
+++ b/options.h.in
@@ -173,6 +173,11 @@
 #define PNET_MAX_FILENAME_LENGTH @PNET_MAX_FILENAME_LENGTH@
 #endif
 
+/** Max port description length */
+#if !defined (PNET_MAX_PORT_DESCRIPTION_LENGTH)
+#define PNET_MAX_PORT_DESCRIPTION_LENGTH @PNET_MAX_PORT_DESCRIPTION_LENGTH@
+#endif
+
 
 /**
  * # Logging

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -39,6 +39,13 @@
 #include <string.h>
 #include <ctype.h>
 
+#if PNET_MAX_PORT_DESCRIPTION_LENGTH > 256
+#error "Port description can't be larger than 255 bytes plus termination"
+#endif
+#if PNET_MAX_PORT_DESCRIPTION_LENGTH < PNET_MAX_INTERFACE_NAME_LENGTH
+#error "Port description should be at least as large as interface name"
+#endif
+
 #define LLDP_TYPE_END              0
 #define LLDP_TYPE_CHASSIS_ID       1
 #define LLDP_TYPE_PORT_ID          2

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2432,12 +2432,11 @@ typedef struct pf_lldp_link_status
  *
  * Note: According to the SNMP specification, the string could be up
  * to 255 characters. The p-net stack limits it to
- * PNET_MAX_INTERFACE_NAME_LENGTH.
- * An extra byte is added as to ensure null-termination.
+ * PNET_MAX_PORT_DESCRIPTION_LENGTH (including termination).
  */
 typedef struct pf_lldp_port_description
 {
-   char string[PNET_MAX_INTERFACE_NAME_LENGTH + 1]; /* Terminated */
+   char string[PNET_MAX_PORT_DESCRIPTION_LENGTH]; /* Terminated */
    bool is_valid;
    size_t len;
 } pf_lldp_port_description_t;


### PR DESCRIPTION
This increases the max size of port description
strings from 16 to 60 by default. The default
value of 60 is arbitrary, but hopefully large
enough to contain any received string.