### PR TITLE
Ensure consistency  for device location variable

### DIFF
--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -239,19 +239,15 @@ void pf_snmp_get_system_location (
    pnet_t * net,
    pf_snmp_system_location_t * location)
 {
-   snprintf (
-      location->string,
-      sizeof (location->string),
-      "%s",
-      net->fspm_cfg.im_1_data.im_tag_location);
+   pf_fspm_get_system_location (net, location);
 }
 
 int pf_snmp_set_system_location (
    pnet_t * net,
    const pf_snmp_system_location_t * location)
 {
-   /* TODO: Write to I&M1 */
-   return -1;
+   pf_fspm_save_system_location (net, location);
+   return 0;
 }
 
 void pf_snmp_get_system_description (

--- a/src/common/pf_snmp.h
+++ b/src/common/pf_snmp.h
@@ -156,35 +156,6 @@ typedef struct pf_snmp_system_contact
 } pf_snmp_system_contact_t;
 
 /**
- * System location (sysLocation).
- *
- * "The physical location of this node (e.g.,
- * 'telephone closet, 3rd floor'). If the location is unknown,
- *  the value is the zero-length string."
- * - IETF RFC 3418 (SNMP MIB-II).
- *
- * The value is supplied by network manager. By default, it is
- * the zero-length string.
- *
- * This should have the same value as "IM_Tag_Location" in I&M1.
- * See PN-Topology ch. 11.5.2: "Consistency".
- *
- * Note: According to the SNMP specification, the string could be up
- * to 255 characters. The p-net stack limits it to the length of
- * IM_Tag_Location, which is 22.
- * An extra byte is added as to ensure null-termination.
- *
- * This is a writable variable. As such, it is stored in persistent memory.
- * Only writable variables (using SNMP Set) need to be stored
- * in persistent memory.
- * See IEC CDV 61158-5-10 (PN-AL-Services) ch. 7.3.3.3.6.2: "Persistency".
- */
-typedef struct pf_snmp_system_location
-{
-   char string[PNET_LOCATION_MAX_LEN + 1]; /* Terminated */
-} pf_snmp_system_location_t;
-
-/**
  * System description (sysDescr).
  *
  * "A textual description of the entity. This value

--- a/src/device/pf_block_reader.h
+++ b/src/device/pf_block_reader.h
@@ -350,7 +350,7 @@ void pf_get_port_data_check_check_peers (
  * pf_get_port_data_adjust_peer_to_peer_boundary().
  * @param p_info                   InOut: The parser information.
  * @param p_pos                    InOut: The current parsing position.
- * @param pf_port_data_adjust_t:   Out:   Destination structure
+ * @param p_port_data_check        Out:    Destination structure
  */
 void pf_get_port_data_adjust (
    pf_get_info_t * p_info,
@@ -361,7 +361,7 @@ void pf_get_port_data_adjust (
  * Extract a AdjustPeerToPeerBoundary data block from a buffer.
  * @param p_info           InOut: The parser information.
  * @param p_pos            InOut: The current parsing position.
- * @param p_im_1           Out:   Destination structure.
+ * @param boundary         Out:   Destination structure.
  */
 void pf_get_port_data_adjust_peer_to_peer_boundary (
    pf_get_info_t * p_info,

--- a/src/device/pf_cmrdr.c
+++ b/src/device/pf_cmrdr.c
@@ -197,27 +197,34 @@ int pf_cmrdr_rm_read_ind (
       case PF_IDX_SUB_IM_1:
          if ((data_len == sizeof (pnet_im_1_t)) && (*p_pos + data_len < res_size))
          {
+            os_mutex_lock (net->fspm_im_mutex);
             pf_put_im_1 (true, (pnet_im_1_t *)p_data, res_size, p_res, p_pos);
+            os_mutex_unlock (net->fspm_im_mutex);
             ret = 0;
          }
          break;
       case PF_IDX_SUB_IM_2:
          if ((data_len == sizeof (pnet_im_2_t)) && (*p_pos + data_len < res_size))
          {
+            os_mutex_lock (net->fspm_im_mutex);
             pf_put_im_2 (true, (pnet_im_2_t *)p_data, res_size, p_res, p_pos);
+            os_mutex_unlock (net->fspm_im_mutex);
             ret = 0;
          }
          break;
       case PF_IDX_SUB_IM_3:
          if ((data_len == sizeof (pnet_im_3_t)) && (*p_pos + data_len < res_size))
          {
+            os_mutex_lock (net->fspm_im_mutex);
             pf_put_im_3 (true, (pnet_im_3_t *)p_data, res_size, p_res, p_pos);
+            os_mutex_unlock (net->fspm_im_mutex);
             ret = 0;
          }
          break;
       case PF_IDX_SUB_IM_4:
          if ((data_len == sizeof (pnet_im_4_t)) && (*p_pos + data_len < res_size))
          {
+            os_mutex_lock (net->fspm_im_mutex);
             pf_put_record_data_read (
                true,
                PF_BT_IM_4,
@@ -226,6 +233,7 @@ int pf_cmrdr_rm_read_ind (
                res_size,
                p_res,
                p_pos);
+            os_mutex_unlock (net->fspm_im_mutex);
             ret = 0;
          }
          break;

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -262,10 +262,12 @@ static void pf_fspm_load_im (pnet_t * net)
          PNET_LOG,
          "FSPM(%d): Did read I&M settings from nvm.\n",
          __LINE__);
+      os_mutex_lock (net->fspm_im_mutex);
       memcpy (&net->fspm_cfg.im_1_data, &file_im.im1, sizeof (pnet_im_1_t));
       memcpy (&net->fspm_cfg.im_2_data, &file_im.im2, sizeof (pnet_im_2_t));
       memcpy (&net->fspm_cfg.im_3_data, &file_im.im3, sizeof (pnet_im_3_t));
       memcpy (&net->fspm_cfg.im_4_data, &file_im.im4, sizeof (pnet_im_4_t));
+      os_mutex_unlock (net->fspm_im_mutex);
    }
    else
    {
@@ -293,10 +295,12 @@ static void pf_fspm_save_im (pnet_t * net)
    const char * p_file_directory = NULL;
    int res = 0;
 
+   os_mutex_lock (net->fspm_im_mutex);
    memcpy (&output_im.im1, &net->fspm_cfg.im_1_data, sizeof (pnet_im_1_t));
    memcpy (&output_im.im2, &net->fspm_cfg.im_2_data, sizeof (pnet_im_2_t));
    memcpy (&output_im.im3, &net->fspm_cfg.im_3_data, sizeof (pnet_im_3_t));
    memcpy (&output_im.im4, &net->fspm_cfg.im_4_data, sizeof (pnet_im_4_t));
+   os_mutex_unlock (net->fspm_im_mutex);
 
    (void)pf_cmina_get_file_directory (net, &p_file_directory);
 
@@ -336,6 +340,48 @@ static void pf_fspm_save_im (pnet_t * net)
    }
 }
 
+/**
+ * Set system location in I&M data record 1.
+ *
+ * Also see pf_fspm_save_system_location().
+ * 
+ * @param net              InOut: The p-net stack instance
+ * @param p_location       In:    New system location.
+ */
+static void pf_fspm_set_system_location (
+   pnet_t * net,
+   const pf_snmp_system_location_t * p_location)
+{
+   os_mutex_lock (net->fspm_im_mutex);
+   snprintf (
+      net->fspm_cfg.im_1_data.im_tag_location,
+      sizeof (net->fspm_cfg.im_1_data.im_tag_location),
+      "%s",
+      p_location->string);
+   os_mutex_unlock (net->fspm_im_mutex);
+}
+
+void pf_fspm_get_system_location (
+   pnet_t * net,
+   pf_snmp_system_location_t * p_location)
+{
+   os_mutex_lock (net->fspm_im_mutex);
+   snprintf (
+      p_location->string,
+      sizeof (p_location->string),
+      "%s",
+      net->fspm_cfg.im_1_data.im_tag_location);
+   os_mutex_unlock (net->fspm_im_mutex);
+}
+
+void pf_fspm_save_system_location (
+   pnet_t * net,
+   const pf_snmp_system_location_t * p_location)
+{
+   pf_fspm_set_system_location (net, p_location);
+   pf_fspm_save_im (net);
+}
+
 int pf_fspm_init (pnet_t * net, const pnet_cfg_t * p_cfg)
 {
    if (pf_fspm_validate_configuration (p_cfg) != 0)
@@ -349,6 +395,12 @@ int pf_fspm_init (pnet_t * net, const pnet_cfg_t * p_cfg)
 
    /* Reference to the default settings (used at factory reset) */
    net->p_fspm_default_cfg = p_cfg;
+
+   /* Create mutex for protecting writable I&M data */
+   if (net->fspm_im_mutex == NULL)
+   {
+      net->fspm_im_mutex = os_mutex_create();
+   }
 
    /* Load I&M data modifications from file, if any */
    pf_fspm_load_im (net);
@@ -417,6 +469,7 @@ void pf_fspm_create_log_book_entry (
 
 int pf_fspm_clear_im_data (pnet_t * net)
 {
+   os_mutex_lock (net->fspm_im_mutex);
    memset (
       net->fspm_cfg.im_1_data.im_tag_function,
       ' ',
@@ -447,6 +500,7 @@ int pf_fspm_clear_im_data (pnet_t * net)
       net->fspm_cfg.im_4_data.im_signature,
       0,
       sizeof (net->fspm_cfg.im_4_data.im_signature));
+   os_mutex_unlock (net->fspm_im_mutex);
 
    pf_fspm_save_im (net);
 
@@ -797,7 +851,9 @@ int pf_fspm_cm_write_ind (
             get_info.is_big_endian = true;
             get_info.len = write_length; /* Bytes in input buffer */
 
+            os_mutex_lock (net->fspm_im_mutex);
             pf_get_im_1 (&get_info, &pos, &net->fspm_cfg.im_1_data);
+            os_mutex_unlock (net->fspm_im_mutex);
             if ((get_info.result == PF_PARSE_OK) && (pos == write_length))
             {
                LOG_INFO (
@@ -843,12 +899,14 @@ int pf_fspm_cm_write_ind (
             /* Do not count the terminator byte */
             if (write_length == (sizeof (net->fspm_cfg.im_2_data) - 1))
             {
+               os_mutex_lock (net->fspm_im_mutex);
                memcpy (
                   &net->fspm_cfg.im_2_data,
                   p_write_data,
                   sizeof (net->fspm_cfg.im_2_data) - 1);
                net->fspm_cfg.im_2_data
                   .im_date[sizeof (net->fspm_cfg.im_2_data) - 1] = '\0';
+               os_mutex_unlock (net->fspm_im_mutex);
                LOG_INFO (
                   PNET_LOG,
                   "FSPM(%d): PLC is writing I&M2 data. Date: %s\n",
@@ -890,12 +948,14 @@ int pf_fspm_cm_write_ind (
             /* Do not count the terminator byte */
             if (write_length == (sizeof (net->fspm_cfg.im_3_data) - 1))
             {
+               os_mutex_lock (net->fspm_im_mutex);
                memcpy (
                   &net->fspm_cfg.im_3_data,
                   p_write_data,
                   sizeof (net->fspm_cfg.im_3_data) - 1);
                net->fspm_cfg.im_3_data
                   .im_descriptor[sizeof (net->fspm_cfg.im_3_data) - 1] = '\0';
+               os_mutex_unlock (net->fspm_im_mutex);
                LOG_INFO (
                   PNET_LOG,
                   "FSPM(%d): PLC is writing I&M3 data. Descriptor: %s\n",
@@ -940,10 +1000,12 @@ int pf_fspm_cm_write_ind (
                   PNET_LOG,
                   "FSPM(%d): PLC is writing I&M4 data\n",
                   __LINE__);
+               os_mutex_lock (net->fspm_im_mutex);
                memcpy (
                   &net->fspm_cfg.im_4_data,
                   p_write_data,
                   sizeof (net->fspm_cfg.im_4_data));
+               os_mutex_unlock (net->fspm_im_mutex);
                ret = 0;
             }
             else

--- a/src/device/pf_fspm.h
+++ b/src/device/pf_fspm.h
@@ -335,6 +335,30 @@ void pf_fspm_get_cfg (pnet_t * net, pnet_cfg_t ** pp_cfg);
 void pf_fspm_get_default_cfg (pnet_t * net, const pnet_cfg_t ** pp_cfg);
 
 /**
+ * Get system location from I&M data record 1.
+ * 
+ * Note that the SNMP thread may call this at any time.
+ * 
+ * @param net              InOut: The p-net stack instance
+ * @param p_location       Out:   Current system location.
+ */
+void pf_fspm_get_system_location (
+   pnet_t * net,
+   pf_snmp_system_location_t * p_location);
+
+/**
+ * Set system location in I&M data record 1 and save it to persistent memory.
+ * 
+ * Note that the SNMP thread may call this at any time.
+ * 
+ * @param net              InOut: The p-net stack instance
+ * @param p_location       In:    New system location.
+ */
+void pf_fspm_save_system_location (
+   pnet_t * net,
+   const pf_snmp_system_location_t * p_location);
+
+/**
  * Clear the I&M data records 1-4.
  * @param net              InOut: The p-net stack instance
  * @return  0  if operation succeeded.

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2319,6 +2319,35 @@ typedef struct pf_log_book
 } pf_log_book_t;
 
 /**
+ * System location (sysLocation).
+ *
+ * "The physical location of this node (e.g.,
+ * 'telephone closet, 3rd floor'). If the location is unknown,
+ *  the value is the zero-length string."
+ * - IETF RFC 3418 (SNMP MIB-II).
+ *
+ * The value is supplied by network manager. By default, it is
+ * the zero-length string.
+ *
+ * This should have the same value as "IM_Tag_Location" in I&M1.
+ * See PN-Topology ch. 11.5.2: "Consistency".
+ *
+ * Note: According to the SNMP specification, the string could be up
+ * to 255 characters. The p-net stack limits it to the length of
+ * IM_Tag_Location, which is 22.
+ * An extra byte is added as to ensure null-termination.
+ *
+ * This is a writable variable. As such, it is stored in persistent memory.
+ * Only writable variables (using SNMP Set) need to be stored
+ * in persistent memory.
+ * See IEC CDV 61158-5-10 (PN-AL-Services) ch. 7.3.3.3.6.2: "Persistency".
+ */
+typedef struct pf_snmp_system_location
+{
+   char string[PNET_LOCATION_MAX_LEN + 1]; /* Terminated */
+} pf_snmp_system_location_t;
+
+/**
  *
  * Substitution name: PDPortDataCheck
  * BlockHeader, Padding, Padding, SlotNumber, SubslotNumber, { [CheckPeers],

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2756,6 +2756,14 @@ struct pnet
                            during runtime */
    pf_log_book_t fspm_log_book;
    os_mutex_t * fspm_log_book_mutex;
+
+   /* Mutex for protecting access to writable I&M data.
+    *
+    * Note I&M may be both read and written by SNMP, which executes from
+    * its own thread context.
+    */
+   os_mutex_t * fspm_im_mutex;
+
    pf_interface_stats_t interface_statistics; /* Keeps track of number of sent
                                                    and discarded packets */
 

--- a/src/ports/rt-kernel/0001-rtkernel-for-Profinet.patch
+++ b/src/ports/rt-kernel/0001-rtkernel-for-Profinet.patch
@@ -1,4 +1,4 @@
-From e54e445a15b3519bf45b7b9de1ad19fe42b8608d Mon Sep 17 00:00:00 2001
+From 9b158e79a2e7183fbfebce9fee53347714009e35 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fredrik=20M=C3=B6ller?= <fredrik.moller@rt-labs.com>
 Date: Tue, 15 Sep 2020 18:22:53 +0200
 Subject: [PATCH] rtkernel for Profinet
@@ -145,7 +145,7 @@ index ce2e3d29..7946cb05 100644
        MIB2_STATS_INC(mib2.udpindatagrams);
  #if SO_REUSE && SO_REUSE_RXTOALL
 diff --git a/lwip/src/include/lwip/lwipopts.h b/lwip/src/include/lwip/lwipopts.h
-index c48a69b7..0307f8da 100644
+index c48a69b7..15141e15 100644
 --- a/lwip/src/include/lwip/lwipopts.h
 +++ b/lwip/src/include/lwip/lwipopts.h
 @@ -49,7 +49,12 @@
@@ -185,7 +185,7 @@ index c48a69b7..0307f8da 100644
  /* Stack sizes */
  #define DEFAULT_THREAD_STACKSIZE    1024
  #define TCPIP_THREAD_STACKSIZE      1768
-+#define SNMP_STACK_SIZE             2300
++#define SNMP_STACK_SIZE             3000
  
  /* TCPIP thread priority */
  #define TCPIP_THREAD_PRIO           5
@@ -213,5 +213,5 @@ index c48a69b7..0307f8da 100644
  
  #endif  /* __LWIPOPTS_H__ */
 -- 
-2.25.1
+2.28.0.windows.1
 


### PR DESCRIPTION
The SNMP variable sysLocation should be the same as the I&M variable IM_Tag_Location.
This PR ensures that by letting SNMP server access IM_Tag_Location when sysLocation is requested.

The SNMP server executes from its own thread. A mutex is added for thread safety.
