### PR TITLE
DCP should use three different timers

### DIFF
--- a/src/common/pf_scheduler.h
+++ b/src/common/pf_scheduler.h
@@ -36,12 +36,12 @@ void pf_scheduler_init (pnet_t * net, uint32_t tick_interval);
  * @param net              InOut: The p-net stack instance
  * @param delay            In:    The delay until the function shall be called,
  *                                in microseconds. Max
- * PF_SCHEDULER_MAX_DELAY_US.
+ *                                PF_SCHEDULER_MAX_DELAY_US.
  * @param p_name           In:    Caller/owner (for debugging).
  * @param cb               In:    The call-back.
  * @param arg              In:    Argument to the call-back.
  * @param p_timeout        Out:   The timeout instance (used to remove if
- * necessary).
+ *                                necessary).
  * @return  0  if the call-back was scheduled.
  *          -1 if an error occurred.
  */
@@ -56,9 +56,10 @@ int pf_scheduler_add (
 /**
  * Stop a timeout. If it is not scheduled then ignore.
  * @param net              InOut: The p-net stack instance
- * @param p_name           In: Must be exactly the same address as in the
- * _add().
- * @param timeout          In: Time instance to remove (see pf_scheduler_add)
+ * @param p_name           In:    Must be exactly the same address as in the
+ *                                pf_scheduler_add().
+ * @param timeout          In:    Time instance to remove
+ *                                (see pf_scheduler_add)
  */
 void pf_scheduler_remove (pnet_t * net, const char * p_name, uint32_t timeout);
 

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -927,7 +927,6 @@ typedef struct pf_alarm_queue
    uint16_t count;
 } pf_alarm_queue_t;
 
-
 #define PF_MAX_SESSION (2 * (PNET_MAX_AR) + 1) /* 2 per ar, and one spare. */
 
 /*
@@ -2121,8 +2120,6 @@ typedef enum pf_diag_filter_level
    PF_DIAG_FILTER_M_DEM      /* Manufacturer specific or maintenance demanded */
 } pf_diag_filter_level_t;
 
-
-
 typedef struct pf_subslot
 {
    bool in_use;
@@ -2691,8 +2688,10 @@ struct pnet
    pnet_ethaddr_t dcp_sam; /* Source address (MAC) of current DCP remote peer */
    bool dcp_delayed_response_waiting; /* A response to DCP IDENTIFY is waiting
                                          to be sent */
-   uint32_t dcp_timeout;
-   uint32_t dcp_sam_timeout; /* Handle to the SAM timeout instance */
+   uint32_t dcp_led_timeout;          /* Handle to the LED timeout instance */
+   uint32_t dcp_sam_timeout;          /* Handle to the SAM timeout instance */
+   uint32_t dcp_identresp_timeout;    /* Handle to the DCP identify timeout
+                                         instance */
    pnal_eth_handle_t * eth_handle;
    pf_eth_frame_id_map_t eth_id_map[PF_ETH_MAX_MAP];
    volatile pf_scheduler_timeouts_t scheduler_timeouts[PF_MAX_TIMEOUTS];


### PR DESCRIPTION
The timers for clearing allowed MAC address, for flashing LED and
for sending a delayed response should be independent of eachother.