### PR TITLE
lldp: Report correct ifIndex value

### DIFF
--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -15,6 +15,7 @@
 
 #ifdef UNIT_TEST
 #define pnal_get_system_uptime_10ms mock_pnal_get_system_uptime_10ms
+#define pnal_get_interface_index    mock_pnal_get_interface_index
 #endif
 
 /**
@@ -609,9 +610,9 @@ void pf_lldp_get_management_address (
    memcpy (p_man_address->value, &ipaddr, sizeof (ipaddr));
    p_man_address->len = sizeof (ipaddr);
 
-   /* TODO: Get actual ifIndex value */
    p_man_address->interface_number.subtype = 2; /* ifIndex */
-   p_man_address->interface_number.value = 1;
+   p_man_address->interface_number.value =
+      pnal_get_interface_index (net->eth_handle);
 
    p_man_address->is_valid = true;
 }

--- a/src/pnal.h
+++ b/src/pnal.h
@@ -158,6 +158,19 @@ void pnal_buf_free (pnal_buf_t * p);
 uint8_t pnal_buf_header (pnal_buf_t * p, int16_t header_size_increment);
 
 /**
+ * Get network interface index
+ *
+ * The interface index (ifIndex) is the (row) index for the network interface
+ * in the table ifTable, which is part of the SNMP MIB-II data structure.
+ * See RFC 2863 "The Interfaces Group MIB".
+ *
+ * @param handle           In:    Ethernet handle
+ *
+ * @return  The interface index, or 0 if not available.
+ */
+int pnal_get_interface_index (pnal_eth_handle_t * handle);
+
+/**
  * Send raw Ethernet data
  *
  * @param handle        In: Ethernet handle

--- a/src/ports/linux/pnal.c
+++ b/src/ports/linux/pnal.c
@@ -159,9 +159,18 @@ uint32_t pnal_get_system_uptime_10ms (void)
 {
    uint32_t uptime;
 
-   /* TODO: Implement this */
+   /* TODO: Get sysUptime from SNMP MIB-II */
    uptime = 0;
    return uptime;
+}
+
+int pnal_get_interface_index (pnal_eth_handle_t * handle)
+{
+   int index;
+
+   /* TODO: Get ifIndex from ifTable in SNMP MIB-II */
+   index = 0;
+   return index;
 }
 
 uint32_t pnal_buf_alloc_cnt = 0; /* Count outstanding buffers */

--- a/src/ports/rt-kernel/pnal_eth.c
+++ b/src/ports/rt-kernel/pnal_eth.c
@@ -17,6 +17,7 @@
 #include "osal_log.h"
 
 #include <lwip/netif.h>
+#include <lwip/apps/snmp_core.h>
 #include <drivers/dev.h>
 
 #define MAX_NUMBER_OF_IF 1
@@ -24,6 +25,16 @@
 
 static struct netif * interface[MAX_NUMBER_OF_IF];
 static int nic_index = 0;
+
+int pnal_get_interface_index (pnal_eth_handle_t * handle)
+{
+   struct netif * netif = interface[handle->if_id];
+   u8_t index;
+
+   index = netif_to_num (netif);
+
+   return index;
+}
 
 pnal_eth_handle_t * pnal_eth_init (
    const char * if_name,

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -146,6 +146,11 @@ void mock_pnal_udp_close (uint32_t id)
 {
 }
 
+int mock_pnal_get_interface_index (pnal_eth_handle_t * handle)
+{
+   return mock_os_data.interface_index;
+}
+
 int mock_pnal_save_file (
    const char * fullpath,
    const void * object_1,

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -45,6 +45,8 @@ typedef struct mock_os_data_obj
    uint32_t current_time_us;
    uint32_t system_uptime_10ms;
 
+   int interface_index;
+
    char file_fullpath[100]; /* Full file path at latest save operation */
    uint16_t file_size;
    uint8_t file_content[2000];
@@ -98,6 +100,7 @@ int mock_pnal_set_ip_suite (
    const pnal_ipaddr_t * p_gw,
    const char * hostname,
    bool permanent);
+int mock_pnal_get_interface_index (pnal_eth_handle_t * handle);
 
 int mock_pnal_save_file (
    const char * fullpath,

--- a/test/test_lldp.cpp
+++ b/test/test_lldp.cpp
@@ -597,6 +597,7 @@ TEST_F (LldpTest, LldpGetManagementAddress)
 {
    pf_lldp_management_address_t man_address;
 
+   mock_os_data.interface_index = 3;
    memset (&man_address, 0xff, sizeof (man_address));
 
    pf_lldp_get_management_address (net, &man_address);
@@ -607,7 +608,7 @@ TEST_F (LldpTest, LldpGetManagementAddress)
    EXPECT_EQ (man_address.value[3], 171);
    EXPECT_EQ (man_address.len, 4u);
    EXPECT_EQ (man_address.interface_number.subtype, 2); /* ifIndex */
-   EXPECT_EQ (man_address.interface_number.value, 1);   /* TODO */
+   EXPECT_EQ (man_address.interface_number.value, 3);
 }
 
 TEST_F (LldpTest, LldpGetSignalDelays)


### PR DESCRIPTION
This change enables the SNMP server to return the correct ifIndex value to cllient