### PR TITLE
Rename string length constants to show if they include terminator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,14 +89,14 @@ set(PNET_MAX_MAN_SPECIFIC_FAST_STARTUP_DATA_LENGTH 0
 set(PNET_MAX_SESSION_BUFFER_SIZE 4500
   CACHE STRING "Max fragmented RPC request/response length")
 
-set(PNET_MAX_DIRECTORYPATH_LENGTH 240
-  CACHE STRING "Max length of directory path, including termination")
+set(PNET_MAX_DIRECTORYPATH_SIZE 240
+  CACHE STRING "Max size of directory path, including termination")
 
-set(PNET_MAX_FILENAME_LENGTH 30
-  CACHE STRING "Max length of filenames, including termination")
+set(PNET_MAX_FILENAME_SIZE 30
+  CACHE STRING "Max size of filename, including termination")
 
-set(PNET_MAX_PORT_DESCRIPTION_LENGTH 60
-  CACHE STRING "Max length of port description, including termination")
+set(PNET_MAX_PORT_DESCRIPTION_SIZE 60
+  CACHE STRING "Max size of port description, including termination")
 
 set(LOG_STATE_VALUES "ON;OFF")
 set(LOG_LEVEL_VALUES "DEBUG;INFO;WARNING;ERROR;FATAL")

--- a/doc/getting_started_rtkernel.rst
+++ b/doc/getting_started_rtkernel.rst
@@ -268,7 +268,7 @@ Run tests on XMC4800 target
 ---------------------------
 In order to compile the test code, make sure to use BUILD_TESTING and that
 TEST_DEBUG is disabled. Set PNET_MAX_AR to 1, and reduce
-PNET_MAX_FILENAME_LENGTH to 30 bytes.
+PNET_MAX_FILENAME_SIZE to 30 bytes.
 This is done via ccmake, which should be started in the build directory::
 
     ccmake .

--- a/doc/network_topology_detection.rst
+++ b/doc/network_topology_detection.rst
@@ -344,7 +344,7 @@ Device details:
 | sysContact                     | String, max 255 char. Writable. Contact info to a person.       |
 +--------------------------------+-----------------------------------------------------------------+
 | sysName                        | String, writable. Fully qualified domain name?                  |
-|                                | Here limited to PNAL_HOST_NAME_MAX (typically 64 char).         |
+|                                | Here limited to PNAL_HOSTNAME_MAX_SIZE (typically 64 char).     |
 +--------------------------------+-----------------------------------------------------------------+
 | sysLocation                    | String, writable. Here same as I&M1 location (max 22 char).     |
 +--------------------------------+-----------------------------------------------------------------+

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -39,20 +39,19 @@ extern "C" {
 #include <stdint.h>
 #include <stdio.h>
 
-#define PNET_PRODUCT_NAME_MAX_LEN  25
-#define PNET_ORDER_ID_MAX_LEN      20
-#define PNET_SERIAL_NUMBER_MAX_LEN 16
-#define PNET_LOCATION_MAX_LEN      22
+#define PNET_PRODUCT_NAME_MAX_LEN  25 /* Not including termination */
+#define PNET_ORDER_ID_MAX_LEN      20 /* Not including termination */
+#define PNET_SERIAL_NUMBER_MAX_LEN 16 /* Not including termination */
 
-#define PNET_MAX_FILE_FULLPATH_LEN                                             \
-   (PNET_MAX_DIRECTORYPATH_LENGTH + PNET_MAX_FILENAME_LENGTH) /** Including    \
-                                                                 separator and \
-                                                                 one           \
-                                                                 termination   \
-                                                               */
+/* Including termination. Standard says 22 (without termination) */
+#define PNET_LOCATION_MAX_SIZE     23
 
-#define PNET_MAX_INTERFACE_NAME_LENGTH                                         \
-   16 /** Including termination. Based on Linux IFNAMSIZ */
+/** Including separator and one termination */
+#define PNET_MAX_FILE_FULLPATH_SIZE                                            \
+   (PNET_MAX_DIRECTORYPATH_SIZE + PNET_MAX_FILENAME_SIZE)
+
+/** Including termination. Based on Linux IFNAMSIZ */
+#define PNET_INTERFACE_NAME_MAX_SIZE 16
 
 /** Supported block version by this implementation */
 #define PNET_BLOCK_VERSION_HIGH 1
@@ -1046,8 +1045,7 @@ typedef struct pnet_im_0
    uint8_t im_vendor_id_hi;
    uint8_t im_vendor_id_lo;
    char im_order_id[PNET_ORDER_ID_MAX_LEN + 1]; /**< Terminated string */
-   char im_serial_number[PNET_SERIAL_NUMBER_MAX_LEN + 1]; /**< Terminated string
-                                                           */
+   char im_serial_number[PNET_SERIAL_NUMBER_MAX_LEN + 1]; /**< Terminated */
    uint16_t im_hardware_revision;
    char im_sw_revision_prefix;
    uint8_t im_sw_revision_functional_enhancement;
@@ -1072,8 +1070,8 @@ typedef struct pnet_im_0
  */
 typedef struct pnet_im_1
 {
-   char im_tag_function[32 + 1];                    /**< Terminated string */
-   char im_tag_location[PNET_LOCATION_MAX_LEN + 1]; /**< Terminated string */
+   char im_tag_function[32 + 1];                 /**< Terminated string */
+   char im_tag_location[PNET_LOCATION_MAX_SIZE]; /**< Terminated string */
 } pnet_im_1_t;
 
 /**
@@ -1156,12 +1154,21 @@ typedef struct pnet_ethaddr
    uint8_t addr[6];
 } pnet_ethaddr_t;
 
-#define PNET_CHASSIS_ID_MAX_LEN      (240)
-#define PNET_STATION_NAME_MAX_LEN    (240)
-#define PNET_PORT_ID_MAX_LEN         (14)
-#define PNET_LLDP_CHASSIS_ID_MAX_LEN (PNET_CHASSIS_ID_MAX_LEN)
-#define PNET_LLDP_PORT_ID_MAX_LEN                                              \
-   (PNET_STATION_NAME_MAX_LEN + PNET_PORT_ID_MAX_LEN)
+/* Including termination. Standard says 240 (without termination) */
+#define PNET_CHASSIS_ID_MAX_SIZE   (241)
+
+/* Including termination. Standard says 240 (without termination) */
+#define PNET_STATION_NAME_MAX_SIZE (241)
+
+/* Including termination. Standard says 14 (without termination) */
+#define PNET_PORT_ID_MAX_SIZE      (15)
+
+/** Including termination */
+#define PNET_LLDP_CHASSIS_ID_MAX_SIZE (PNET_CHASSIS_ID_MAX_SIZE)
+
+/** Including termination */
+#define PNET_LLDP_PORT_ID_MAX_SIZE                                             \
+   (PNET_STATION_NAME_MAX_SIZE + PNET_PORT_ID_MAX_SIZE)
 
 #define PNET_LLDP_TTL 20 /* seconds. Mandatory value */
 
@@ -1197,7 +1204,7 @@ typedef struct pnet_ethaddr
  */
 typedef struct pnet_lldp_port_cfg
 {
-   char port_id[PNET_LLDP_PORT_ID_MAX_LEN + 1]; /**< Terminated string */
+   char port_id[PNET_LLDP_PORT_ID_MAX_SIZE]; /**< Terminated string */
    pnet_ethaddr_t port_addr;
    uint16_t rtclass_2_status;
    uint16_t rtclass_3_status;
@@ -1249,9 +1256,7 @@ typedef struct pnet_cfg
    /** Identities */
    pnet_cfg_device_id_t device_id;
    pnet_cfg_device_id_t oem_device_id;
-   char station_name[PNET_STATION_NAME_MAX_LEN + 1]; /**< Terminated string */
-   char manufacturer_specific_string[240 + 1];       /**< Terminated string
-                                                          Not yet used */
+   char station_name[PNET_STATION_NAME_MAX_SIZE]; /**< Terminated string */
 
    /**
     * Product name
@@ -1283,7 +1288,7 @@ typedef struct pnet_cfg
    pnet_ethaddr_t eth_addr; /* Interface MAC address, not port MAC address */
 
    /** Storage between runs */
-   char file_directory[PNET_MAX_DIRECTORYPATH_LENGTH]; /**< Terminated string
+   char file_directory[PNET_MAX_DIRECTORYPATH_SIZE]; /**< Terminated string
                                                           with absolute path.
                                                           Use NULL or empty
                                                           string for current
@@ -1888,7 +1893,7 @@ PNET_EXPORT int pnet_diag_std_remove (
  * @param subslot          In:    The sub-slot.
  * @param usi              In:    The USI. Range 0..0x7fff
  * @param p_manuf_data     In:    The manufacturer specific diagnosis data.
- *                                Size PF_DIAG_MANUF_DATA_LEN.
+ *                                Size PF_DIAG_MANUF_DATA_SIZE.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */
@@ -1916,7 +1921,7 @@ PNET_EXPORT int pnet_diag_usi_add (
  * @param subslot          In:    The sub-slot.
  * @param usi              In:    The USI. Range 0..0x7fff
  * @param p_manuf_data     In:    New manufacturer specific diagnosis data.
- *                                Size PF_DIAG_MANUF_DATA_LEN.
+ *                                Size PF_DIAG_MANUF_DATA_SIZE.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */

--- a/options.h.in
+++ b/options.h.in
@@ -163,19 +163,19 @@
 #define PNET_MAX_SESSION_BUFFER_SIZE @PNET_MAX_SESSION_BUFFER_SIZE@
 #endif
 
-/** Max directory path length */
-#if !defined (PNET_MAX_DIRECTORYPATH_LENGTH)
-#define PNET_MAX_DIRECTORYPATH_LENGTH @PNET_MAX_DIRECTORYPATH_LENGTH@
+#if !defined (PNET_MAX_DIRECTORYPATH_SIZE)
+/** Max directory path size, including termination */
+#define PNET_MAX_DIRECTORYPATH_SIZE @PNET_MAX_DIRECTORYPATH_SIZE@
 #endif
 
-/** Max filename length */
-#if !defined (PNET_MAX_FILENAME_LENGTH)
-#define PNET_MAX_FILENAME_LENGTH @PNET_MAX_FILENAME_LENGTH@
+#if !defined (PNET_MAX_FILENAME_SIZE)
+/** Max filename size, including termination  */
+#define PNET_MAX_FILENAME_SIZE @PNET_MAX_FILENAME_SIZE@
 #endif
 
-/** Max port description length */
-#if !defined (PNET_MAX_PORT_DESCRIPTION_LENGTH)
-#define PNET_MAX_PORT_DESCRIPTION_LENGTH @PNET_MAX_PORT_DESCRIPTION_LENGTH@
+#if !defined (PNET_MAX_PORT_DESCRIPTION_SIZE)
+/** Max port description size, including termination  */
+#define PNET_MAX_PORT_DESCRIPTION_SIZE @PNET_MAX_PORT_DESCRIPTION_SIZE@
 #endif
 
 

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -44,14 +44,14 @@ static void print_bytes (const uint8_t * bytes, int32_t len)
 /**
  * Convert IPv4 address to string
  * @param ip               In:    IP address
- * @param outputstring     Out:   Resulting string. Should have length
- *                                PNAL_INET_ADDRSTRLEN.
+ * @param outputstring     Out:   Resulting string buffer. Should have size
+ *                                PNAL_INET_ADDRSTR_SIZE.
  */
 static void ip_to_string (pnal_ipaddr_t ip, char * outputstring)
 {
    snprintf (
       outputstring,
-      PNAL_INET_ADDRSTRLEN,
+      PNAL_INET_ADDRSTR_SIZE,
       "%u.%u.%u.%u",
       (uint8_t) ((ip >> 24) & 0xFF),
       (uint8_t) ((ip >> 16) & 0xFF),
@@ -62,14 +62,14 @@ static void ip_to_string (pnal_ipaddr_t ip, char * outputstring)
 /**
  * Convert MAC address to string
  * @param mac              In:    MAC address
- * @param outputstring     Out:   Resulting string. Should have length
- *                                PNAL_ETH_ADDRSTRLEN.
+ * @param outputstring     Out:   Resulting string buffer. Should have size
+ *                                PNAL_ETH_ADDRSTR_SIZE.
  */
 static void mac_to_string (pnal_ethaddr_t mac, char * outputstring)
 {
    snprintf (
       outputstring,
-      PNAL_ETH_ADDRSTRLEN,
+      PNAL_ETH_ADDRSTR_SIZE,
       "%02X:%02X:%02X:%02X:%02X:%02X",
       mac.addr[0],
       mac.addr[1],
@@ -193,11 +193,11 @@ void app_print_network_details (
    pnal_ipaddr_t netmask,
    pnal_ipaddr_t gateway)
 {
-   char ip_string[PNAL_INET_ADDRSTRLEN];
-   char netmask_string[PNAL_INET_ADDRSTRLEN];
-   char gateway_string[PNAL_INET_ADDRSTRLEN];
-   char mac_string[PNAL_ETH_ADDRSTRLEN];
-   char hostname_string[PNAL_HOST_NAME_MAX];
+   char ip_string[PNAL_INET_ADDRSTR_SIZE];       /* Terminated string */
+   char netmask_string[PNAL_INET_ADDRSTR_SIZE];  /* Terminated string */
+   char gateway_string[PNAL_INET_ADDRSTR_SIZE];  /* Terminated string */
+   char mac_string[PNAL_ETH_ADDRSTR_SIZE];       /* Terminated string */
+   char hostname_string[PNAL_HOSTNAME_MAX_SIZE]; /* Terminated string */
 
    mac_to_string (*p_macbuffer, mac_string);
    ip_to_string (ip, ip_string);
@@ -1281,7 +1281,6 @@ int app_adjust_stack_configuration (pnet_cfg_t * stack_config)
    stack_config->oem_device_id.vendor_id_lo = 0xff;
    stack_config->oem_device_id.device_id_hi = 0xee;
    stack_config->oem_device_id.device_id_lo = 0x01;
-   strcpy (stack_config->manufacturer_specific_string, "PNET demo");
    strcpy (stack_config->product_name, "rt-labs PNET demo");
 
    /* Timing */

--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -153,11 +153,11 @@ static const cfg_submodule_type_t cfg_available_submodule_types[] = {
 
 struct cmd_args
 {
-   char path_button1[PNET_MAX_FILE_FULLPATH_LEN];
-   char path_button2[PNET_MAX_FILE_FULLPATH_LEN];
-   char path_storage_directory[PNET_MAX_DIRECTORYPATH_LENGTH];
-   char station_name[64];
-   char eth_interface[PNET_MAX_INTERFACE_NAME_LENGTH];
+   char path_button1[PNET_MAX_FILE_FULLPATH_SIZE]; /** Terminated string */
+   char path_button2[PNET_MAX_FILE_FULLPATH_SIZE]; /** Terminated string */
+   char path_storage_directory[PNET_MAX_DIRECTORYPATH_SIZE]; /** Terminated */
+   char station_name[PNET_STATION_NAME_MAX_SIZE];    /** Terminated string */
+   char eth_interface[PNET_INTERFACE_NAME_MAX_SIZE]; /** Terminated string */
    int verbosity;
    int show;
    bool factory_reset;

--- a/src/common/pf_file.c
+++ b/src/common/pf_file.c
@@ -41,17 +41,17 @@
 /* Increase every time the saved contents have another format */
 #define PF_FILE_VERSION 0x00000001U
 
-/* The configurable constant PNET_MAX_FILENAME_LENGTH should be at least
+/* The configurable constant PNET_MAX_FILENAME_SIZE should be at least
  * as large as the longest filename used, including termination.
  */
-CC_STATIC_ASSERT (PNET_MAX_FILENAME_LENGTH >= sizeof (PF_FILENAME_IP));
-CC_STATIC_ASSERT (PNET_MAX_FILENAME_LENGTH >= sizeof (PF_FILENAME_SYSCONTACT));
-CC_STATIC_ASSERT (PNET_MAX_FILENAME_LENGTH >= sizeof (PF_FILENAME_IM));
-CC_STATIC_ASSERT (PNET_MAX_FILENAME_LENGTH >= sizeof (PF_FILENAME_DIAGNOSTICS));
-CC_STATIC_ASSERT (PNET_MAX_FILENAME_LENGTH >= sizeof (PF_FILENAME_PDPORT_1));
-CC_STATIC_ASSERT (PNET_MAX_FILENAME_LENGTH >= sizeof (PF_FILENAME_PDPORT_2));
-CC_STATIC_ASSERT (PNET_MAX_FILENAME_LENGTH >= sizeof (PF_FILENAME_PDPORT_3));
-CC_STATIC_ASSERT (PNET_MAX_FILENAME_LENGTH >= sizeof (PF_FILENAME_PDPORT_4));
+CC_STATIC_ASSERT (PNET_MAX_FILENAME_SIZE >= sizeof (PF_FILENAME_IP));
+CC_STATIC_ASSERT (PNET_MAX_FILENAME_SIZE >= sizeof (PF_FILENAME_SYSCONTACT));
+CC_STATIC_ASSERT (PNET_MAX_FILENAME_SIZE >= sizeof (PF_FILENAME_IM));
+CC_STATIC_ASSERT (PNET_MAX_FILENAME_SIZE >= sizeof (PF_FILENAME_DIAGNOSTICS));
+CC_STATIC_ASSERT (PNET_MAX_FILENAME_SIZE >= sizeof (PF_FILENAME_PDPORT_1));
+CC_STATIC_ASSERT (PNET_MAX_FILENAME_SIZE >= sizeof (PF_FILENAME_PDPORT_2));
+CC_STATIC_ASSERT (PNET_MAX_FILENAME_SIZE >= sizeof (PF_FILENAME_PDPORT_3));
+CC_STATIC_ASSERT (PNET_MAX_FILENAME_SIZE >= sizeof (PF_FILENAME_PDPORT_4));
 
 /**
  * @internal
@@ -149,7 +149,7 @@ int pf_file_load (
    uint32_t version = 0;
    uint32_t magic = 0;
    uint16_t pos = 0;
-   char path[PNET_MAX_FILE_FULLPATH_LEN];
+   char path[PNET_MAX_FILE_FULLPATH_SIZE];
 
    bufferinfo.p_buf = versioning_buffer;
    bufferinfo.len = sizeof (versioning_buffer);
@@ -161,7 +161,7 @@ int pf_file_load (
          directory,
          filename,
          path,
-         PNET_MAX_FILE_FULLPATH_LEN) != 0)
+         PNET_MAX_FILE_FULLPATH_SIZE) != 0)
    {
       return -1;
    }
@@ -214,8 +214,8 @@ int pf_file_save (
    const void * p_object,
    size_t size)
 {
-   char path[PNET_MAX_FILE_FULLPATH_LEN];
-   uint8_t versioning_buffer[8] = {0}; /* Two uint32_t */
+   char path[PNET_MAX_FILE_FULLPATH_SIZE]; /**< Terminated string */
+   uint8_t versioning_buffer[8] = {0};     /* Two uint32_t */
    uint16_t pos = 0;
 
    if (
@@ -223,7 +223,7 @@ int pf_file_save (
          directory,
          filename,
          path,
-         PNET_MAX_FILE_FULLPATH_LEN) != 0)
+         PNET_MAX_FILE_FULLPATH_SIZE) != 0)
    {
       return -1;
    }
@@ -288,14 +288,14 @@ int pf_file_save_if_modified (
 
 void pf_file_clear (const char * directory, const char * filename)
 {
-   char path[PNET_MAX_FILE_FULLPATH_LEN];
+   char path[PNET_MAX_FILE_FULLPATH_SIZE];
 
    if (
       pf_file_join_directory_filename (
          directory,
          filename,
          path,
-         PNET_MAX_FILE_FULLPATH_LEN) != 0)
+         PNET_MAX_FILE_FULLPATH_SIZE) != 0)
    {
       return;
    }

--- a/src/common/pf_file.h
+++ b/src/common/pf_file.h
@@ -23,7 +23,7 @@ extern "C" {
 #include <stddef.h>
 
 /* Filenames used by p-net stack. A filename may not be longer than
- * PNET_MAX_FILENAME_LENGTH (termination included).
+ * PNET_MAX_FILENAME_SIZE (termination included).
  */
 #define PF_FILENAME_IP          "pnet_data_ip.bin"
 #define PF_FILENAME_SYSCONTACT  "pnet_data_syscontact.bin"

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -40,10 +40,10 @@
 #include <string.h>
 #include <ctype.h>
 
-#if PNET_MAX_PORT_DESCRIPTION_LENGTH > 256
+#if PNET_MAX_PORT_DESCRIPTION_SIZE > 256
 #error "Port description can't be larger than 255 bytes plus termination"
 #endif
-#if PNET_MAX_PORT_DESCRIPTION_LENGTH < PNET_MAX_INTERFACE_NAME_LENGTH
+#if PNET_MAX_PORT_DESCRIPTION_SIZE < PNET_INTERFACE_NAME_MAX_SIZE
 #error "Port description should be at least as large as interface name"
 #endif
 
@@ -515,7 +515,7 @@ void pf_lldp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id)
    CC_ASSERT (station_name != NULL);
 
    p_chassis_id->len = strlen (station_name);
-   if (p_chassis_id->len == 0 || p_chassis_id->len > PNET_LLDP_CHASSIS_ID_MAX_LEN)
+   if (p_chassis_id->len == 0 || p_chassis_id->len >= PNET_LLDP_CHASSIS_ID_MAX_SIZE)
    {
       /* Use the device MAC address */
       pf_cmina_get_device_macaddr (net, &device_mac_address);
@@ -751,7 +751,7 @@ static void pf_lldp_send (pnet_t * net, int loc_port_num)
       pf_lldp_get_port_config (net, loc_port_num);
 
 #if LOG_DEBUG_ENABLED(PF_LLDP_LOG)
-   char ip_string[PNAL_INET_ADDRSTRLEN] = {0};
+   char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
    const char * chassis_id_description = "<MAC address>";
 #endif
 

--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -136,7 +136,7 @@ void pf_snmp_get_system_name (pnet_t * net, pf_snmp_system_name_t * name)
 {
    int error;
 
-   CC_STATIC_ASSERT (sizeof (name->string) >= PNAL_HOST_NAME_MAX);
+   CC_STATIC_ASSERT (sizeof (name->string) >= PNAL_HOSTNAME_MAX_SIZE);
 
    error = pnal_get_hostname (name->string);
    if (error)

--- a/src/common/pf_snmp.h
+++ b/src/common/pf_snmp.h
@@ -118,8 +118,8 @@ extern "C" {
  * See PN-Topology Annex A.
  *
  * Note: According to the SNMP specification, the string could be up
- * to 255 characters. The p-net stack limits it to PNAL_HOST_NAME_MAX.
- * An extra byte is added as to ensure null-termination.
+ * to 255 characters (excluding termination). The p-net stack limits it to
+ * PNAL_HOSTNAME_MAX_SIZE, including null-termination.
  *
  * This is a writable variable. As such it is be in persistent memory.
  * Only writable variables (using SNMP Set) need to be stored
@@ -128,7 +128,7 @@ extern "C" {
  */
 typedef struct pf_snmp_system_name
 {
-   char string[PNAL_HOST_NAME_MAX + 1]; /* Terminated */
+   char string[PNAL_HOSTNAME_MAX_SIZE]; /* Terminated string */
 } pf_snmp_system_name_t;
 
 /**
@@ -178,7 +178,7 @@ typedef struct pf_snmp_system_contact
  */
 typedef struct pf_snmp_system_description
 {
-   char string[PNET_LLDP_CHASSIS_ID_MAX_LEN + 1]; /* Terminated */
+   char string[PNET_LLDP_CHASSIS_ID_MAX_SIZE]; /** Terminated string */
 } pf_snmp_system_description_t;
 
 /**

--- a/src/device/pf_block_reader.c
+++ b/src/device/pf_block_reader.c
@@ -918,7 +918,10 @@ static void get_check_peer (
    uint16_t * p_pos,
    pf_check_peer_t * p_check_peer)
 {
+   /* TODO: Validate length_peer_port_name and length_peer_station_name */
+
    p_check_peer->length_peer_port_name = pf_get_byte (p_info, p_pos);
+
    pf_get_mem (
       p_info,
       p_pos,
@@ -927,6 +930,7 @@ static void get_check_peer (
    p_check_peer->peer_port_name[p_check_peer->length_peer_port_name] = '\0';
 
    p_check_peer->length_peer_station_name = pf_get_byte (p_info, p_pos);
+
    pf_get_mem (
       p_info,
       p_pos,

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3532,6 +3532,7 @@ void pf_put_pdport_data_check (
 
    /* Length peer_id */
    pf_put_byte (check_peer->length_peer_port_name, res_len, p_bytes, p_pos);
+
    /* peer_id */
    pf_put_mem (
       &check_peer->peer_port_name,

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -95,9 +95,9 @@ static void pf_cmina_send_hello (pnet_t * net, void * arg, uint32_t current_time
 static void pf_cmina_save_ase (pnet_t * net, pf_cmina_dcp_ase_t * p_ase)
 {
    pf_cmina_dcp_ase_t temporary_buffer;
-   char ip_string[PNAL_INET_ADDRSTRLEN] = {0};
-   char netmask_string[PNAL_INET_ADDRSTRLEN] = {0};
-   char gateway_string[PNAL_INET_ADDRSTRLEN] = {0};
+   char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0};      /** Terminated string */
+   char netmask_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
+   char gateway_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
    const char * p_file_directory = NULL;
    int res = 0;
 
@@ -167,9 +167,9 @@ int pf_cmina_set_default_cfg (pnet_t * net, uint16_t reset_mode)
    uint16_t ix;
    bool reset_user_application = false;
    pf_cmina_dcp_ase_t file_ase;
-   char ip_string[PNAL_INET_ADDRSTRLEN] = {0};
-   char netmask_string[PNAL_INET_ADDRSTRLEN] = {0};
-   char gateway_string[PNAL_INET_ADDRSTRLEN] = {0};
+   char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0};      /** Terminated string */
+   char netmask_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
+   char gateway_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
    uint32_t ip = 0;
    uint32_t netmask = 0;
    uint32_t gateway = 0;
@@ -196,13 +196,6 @@ int pf_cmina_set_default_cfg (pnet_t * net, uint16_t reset_mode)
          sizeof (pnet_ethaddr_t));
 
       strcpy (net->cmina_nonvolatile_dcp_ase.port_name, ""); /* Terminated */
-      strncpy (
-         net->cmina_nonvolatile_dcp_ase.manufacturer_specific_string,
-         p_cfg->manufacturer_specific_string,
-         sizeof (net->cmina_nonvolatile_dcp_ase.manufacturer_specific_string));
-      net->cmina_nonvolatile_dcp_ase.manufacturer_specific_string
-         [sizeof (net->cmina_nonvolatile_dcp_ase.manufacturer_specific_string) -
-          1] = '\0';
 
       net->cmina_nonvolatile_dcp_ase.device_id = p_cfg->device_id;
       net->cmina_nonvolatile_dcp_ase.oem_device_id = p_cfg->oem_device_id;
@@ -370,9 +363,9 @@ int pf_cmina_set_default_cfg (pnet_t * net, uint16_t reset_mode)
 void pf_cmina_dcp_set_commit (pnet_t * net)
 {
    int res = 0;
-   char ip_string[PNAL_INET_ADDRSTRLEN] = {0};
-   char netmask_string[PNAL_INET_ADDRSTRLEN] = {0};
-   char gateway_string[PNAL_INET_ADDRSTRLEN] = {0};
+   char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0};      /** Terminated string */
+   char netmask_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
+   char gateway_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
    bool permanent = true;
 
    if (net->cmina_commit_ip_suite == true)
@@ -627,9 +620,9 @@ int pf_cmina_dcp_set_ind (
    bool change_dhcp = false; /* We have got a request to change DHCP settings */
    bool reset_to_factory = false; /* We have got a request to do a factory reset
                                    */
-   char ip_string[PNAL_INET_ADDRSTRLEN] = {0};
-   char netmask_string[PNAL_INET_ADDRSTRLEN] = {0};
-   char gateway_string[PNAL_INET_ADDRSTRLEN] = {0};
+   char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0};      /** Terminated string */
+   char netmask_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
+   char gateway_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
 
    bool temp = ((block_qualifier & 1) == 0);
    uint16_t reset_mode = 0;
@@ -1273,7 +1266,7 @@ void pf_cmina_ip_to_string (pnal_ipaddr_t ip, char * outputstring)
 {
    snprintf (
       outputstring,
-      PNAL_INET_ADDRSTRLEN,
+      PNAL_INET_ADDRSTR_SIZE,
       "%u.%u.%u.%u",
       (uint8_t) ((ip >> 24) & 0xFF),
       (uint8_t) ((ip >> 16) & 0xFF),
@@ -1317,7 +1310,7 @@ static const char * pf_cmina_state_to_string (pnet_t * net)
  */
 void pf_ip_address_show (uint32_t ip)
 {
-   char ip_string[PNAL_INET_ADDRSTRLEN] = {0};
+   char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
 
    pf_cmina_ip_to_string (ip, ip_string);
    printf ("%s", ip_string);
@@ -1469,7 +1462,7 @@ bool pf_cmina_is_stationname_valid (const char * station_name, uint16_t len)
     * - Labels do not start with [-]
     * - Total length is 1 to 240
     */
-   if ((station_name[0] == '-') || (len > PNET_STATION_NAME_MAX_LEN))
+   if ((station_name[0] == '-') || (len >= PNET_STATION_NAME_MAX_SIZE))
    {
       return false;
    }

--- a/src/device/pf_cmina.h
+++ b/src/device/pf_cmina.h
@@ -58,8 +58,8 @@ void pf_cmina_show (pnet_t * net);
 /**
  * Convert IPv4 address to string
  * @param ip               In:    IP address
- * @param outputstring     Out:   Resulting string. Should have length
- *                                PNAL_INET_ADDRSTRLEN.
+ * @param outputstring     Out:   Buffer with resulting string. Should have
+ *                                size PNAL_INET_ADDRSTR_SIZE.
  */
 void pf_cmina_ip_to_string (pnal_ipaddr_t ip, char * outputstring);
 

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -798,7 +798,7 @@ static int pf_cmrpc_send_once_from_buffer (
    const char * payload_description)
 {
    int ret = -1;
-   char ip_string[PNAL_INET_ADDRSTRLEN] = {0};
+   char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
 
    if (size != 0)
    {
@@ -4581,7 +4581,7 @@ void pf_cmrpc_periodic (pnet_t * net)
    uint16_t dcerpc_resp_len = 0;
    uint16_t ix;
    bool is_release = false;
-   char ip_string[PNAL_INET_ADDRSTRLEN] = {0};
+   char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
 
    /* TODO Use a common function to avoid code duplication, remove some
     * arguments for pf_cmrpc_dce_packet() */

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -125,11 +125,11 @@ void pf_fspm_option_show (const pnet_t * net)
       "PNET_MAX_DIAG_ITEMS                            : %d\n",
       PNET_MAX_DIAG_ITEMS);
    printf (
-      "PNET_MAX_DIRECTORYPATH_LENGTH                  : %d\n",
-      PNET_MAX_DIRECTORYPATH_LENGTH);
+      "PNET_MAX_DIRECTORYPATH_SIZE                    : %d\n",
+      PNET_MAX_DIRECTORYPATH_SIZE);
    printf (
-      "PNET_MAX_FILENAME_LENGTH                       : %d\n",
-      PNET_MAX_FILENAME_LENGTH);
+      "PNET_MAX_FILENAME_SIZE                         : %d\n",
+      PNET_MAX_FILENAME_SIZE);
    printf (
       "PNET_MAX_SESSION_BUFFER_SIZE                   : %d\n",
       PNET_MAX_SESSION_BUFFER_SIZE);
@@ -344,7 +344,7 @@ static void pf_fspm_save_im (pnet_t * net)
  * Set system location in I&M data record 1.
  *
  * Also see pf_fspm_save_system_location().
- * 
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_location       In:    New system location.
  */

--- a/src/device/pf_fspm.h
+++ b/src/device/pf_fspm.h
@@ -336,9 +336,9 @@ void pf_fspm_get_default_cfg (pnet_t * net, const pnet_cfg_t ** pp_cfg);
 
 /**
  * Get system location from I&M data record 1.
- * 
+ *
  * Note that the SNMP thread may call this at any time.
- * 
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_location       Out:   Current system location.
  */
@@ -348,9 +348,9 @@ void pf_fspm_get_system_location (
 
 /**
  * Set system location in I&M data record 1 and save it to persistent memory.
- * 
+ *
  * Note that the SNMP thread may call this at any time.
- * 
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_location       In:    New system location.
  */

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -14,7 +14,7 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
-#define pnal_eth_init mock_pnal_eth_init
+#define pnal_eth_init  mock_pnal_eth_init
 #define pnal_snmp_init mock_pnal_snmp_init
 #endif
 
@@ -32,13 +32,13 @@ int pnet_init_only (
 {
    memset (net, 0, sizeof (*net));
 
-   if (strlen (netif) > PNET_MAX_INTERFACE_NAME_LENGTH)
+   if (strlen (netif) >= PNET_INTERFACE_NAME_MAX_SIZE)
    {
       LOG_ERROR (
          PNET_LOG,
-         "Too long interface name. Given: %s  Max len: %d\n",
+         "Too long interface name. Given: %s  Max size incl termination: %d\n",
          netif,
-         PNET_MAX_INTERFACE_NAME_LENGTH);
+         PNET_INTERFACE_NAME_MAX_SIZE);
       return -1;
    }
    strcpy (net->interface_name, netif);
@@ -70,9 +70,9 @@ int pnet_init_only (
    pf_scheduler_init (net, tick_us);
    pf_cmina_init (net); /* Read from permanent pool */
 
-   pf_dcp_exit (net);  /* Prepare for re-init. */
-   pf_dcp_init (net);  /* Start DCP */
-   pf_port_init(net);
+   pf_dcp_exit (net); /* Prepare for re-init. */
+   pf_dcp_init (net); /* Start DCP */
+   pf_port_init (net);
    pf_lldp_init (net);
    pf_pdport_init (net);
 

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -869,10 +869,10 @@ typedef struct pf_diag_std
 } pf_diag_std_t;
 
 /* Make pf_diag_usi_t equal in size to pf_diag_std_t */
-#define PF_DIAG_MANUF_DATA_LEN sizeof (pf_diag_std_t)
+#define PF_DIAG_MANUF_DATA_SIZE sizeof (pf_diag_std_t)
 typedef struct pf_diag_usi
 {
-   uint8_t manuf_data[PF_DIAG_MANUF_DATA_LEN];
+   uint8_t manuf_data[PF_DIAG_MANUF_DATA_SIZE];
 } pf_diag_usi_t;
 
 /* This is the end of list designator. */
@@ -892,13 +892,13 @@ typedef struct pf_diag_item
    uint16_t next; /* Next in list (array index) */
 } pf_diag_item_t;
 
-#define PF_ALARM_MAX_PAYLOAD_DATA_LEN sizeof (pf_diag_item_t)
+#define PF_ALARM_MAX_PAYLOAD_DATA_SIZE sizeof (pf_diag_item_t)
 
 typedef struct pf_alarm_payload
 {
    uint16_t usi;
    uint16_t len;
-   uint8_t data[PF_ALARM_MAX_PAYLOAD_DATA_LEN];
+   uint8_t data[PF_ALARM_MAX_PAYLOAD_DATA_SIZE];
 } pf_alarm_payload_t;
 
 /* See also pnet_alarm_argument_t for a subset */
@@ -1035,21 +1035,20 @@ typedef struct pf_eth_frame_id_map
  */
 typedef struct pf_cmina_dcp_ase
 {
-   char station_name[PNET_STATION_NAME_MAX_LEN + 1]; /* Terminated */
+   char station_name[PNET_STATION_NAME_MAX_SIZE]; /* Terminated string */
 
    /*
     * DCP DeviceVendorValue is set to configured product_name
     * See PN-AL-protocol (Mar20) ch 4.3.1.4.26
     * product_name is also known as DeviceType
     */
-   char product_name[PNET_PRODUCT_NAME_MAX_LEN + 1]; /* Terminated */
+   char product_name[PNET_PRODUCT_NAME_MAX_LEN + 1]; /* Terminated string */
    uint8_t device_role;        /* Only value "1" supported */
    uint16_t device_initiative; /* 1: Should send hello. 0: No sending of hello
                                 */
 
    char alias_name
-      [PNET_STATION_NAME_MAX_LEN + 1 + PNET_PORT_ID_MAX_LEN + 1]; /* Terminated
-                                                                   */
+      [PNET_STATION_NAME_MAX_SIZE + PNET_PORT_ID_MAX_SIZE]; /** Terminated */
    struct
    {
       /* Order is important!! */
@@ -1060,9 +1059,8 @@ typedef struct pf_cmina_dcp_ase
    pnet_cfg_device_id_t device_id;
    pnet_cfg_device_id_t oem_device_id;
 
-   char port_name[14 + 1]; /* Terminated. Not used. */
+   char port_name[PNET_PORT_ID_MAX_SIZE]; /* Terminated. Not used. */
 
-   char manufacturer_specific_string[240 + 1];
    pnet_ethaddr_t mac_address;
    uint16_t standard_gw_value;
 
@@ -1071,7 +1069,7 @@ typedef struct pf_cmina_dcp_ase
 
    struct
    {
-      /* Nothing much yet */
+      /* Not yet used */
       char hostname[240 + 1];
    } dhcp_info;
 } pf_cmina_dcp_ase_t;
@@ -1250,7 +1248,7 @@ typedef struct pf_ar_param
    uint16_t cm_initiator_activity_timeout_factor; /** res: 100ms */
    uint16_t cm_initiator_udp_rt_port;             /** 0x8892 */
    uint16_t cm_initiator_station_name_len;
-   char cm_initiator_station_name[PNET_STATION_NAME_MAX_LEN + 1]; /** Terminated
+   char cm_initiator_station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated
                                                                      string. */
 } pf_ar_param_t;
 
@@ -1420,7 +1418,9 @@ typedef struct pf_prm_server
    uint16_t cm_initiator_activity_timeout_factor;                /** res: 100ms,
                                                                     allowed 1..1000 */
    uint16_t parameter_server_station_name_len;
-   char parameter_server_station_name[240 + 1]; /** Terminated */
+   char
+      parameter_server_station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated
+                                                                    string */
 } pf_prm_server_t;
 
 typedef struct pf_address_resolution_properties
@@ -1436,7 +1436,7 @@ typedef struct pf_multicast_cr
    pf_address_resolution_properties_t address_resolution_properties;
    uint16_t mci_timeout_factor; /* MCI_timeout range 0x0001..0xffff */
    uint16_t length_provider_station_name;
-   char provider_station_name[PNET_STATION_NAME_MAX_LEN + 1]; /** Terminated */
+   char provider_station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated */
 } pf_multicast_cr_t;
 
 typedef struct pf_ar_rpc_request
@@ -1513,7 +1513,7 @@ typedef struct pf_ar_fsu
 typedef struct pf_ar_server
 {
    uint16_t length_cm_responder_station_name;
-   char cm_responder_station_name[240 + 1]; /** Terminated */
+   char cm_responder_station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated */
 } pf_ar_server_t;
 
 typedef struct pf_alarm_cr_properties
@@ -2341,7 +2341,7 @@ typedef struct pf_log_book
  */
 typedef struct pf_snmp_system_location
 {
-   char string[PNET_LOCATION_MAX_LEN + 1]; /* Terminated */
+   char string[PNET_LOCATION_MAX_SIZE]; /* Terminated string */
 } pf_snmp_system_location_t;
 
 /**
@@ -2369,9 +2369,9 @@ typedef struct pf_port_data_check
 typedef struct pf_check_peer
 {
    uint8_t length_peer_port_name;
-   uint8_t peer_port_name[PNET_LLDP_PORT_ID_MAX_LEN];
+   uint8_t peer_port_name[PNET_LLDP_PORT_ID_MAX_SIZE - 1]; /** No termination */
    uint8_t length_peer_station_name;
-   uint8_t peer_station_name[PNET_STATION_NAME_MAX_LEN];
+   uint8_t peer_station_name[PNET_STATION_NAME_MAX_SIZE - 1]; /** No term */
 } pf_check_peer_t;
 
 typedef struct pf_check_peers
@@ -2457,12 +2457,12 @@ typedef struct pf_lldp_link_status
  * - IEEE 802.1AB (LLDP) ch. 9.5.5.2 "port description".
  *
  * Note: According to the SNMP specification, the string could be up
- * to 255 characters. The p-net stack limits it to
- * PNET_MAX_PORT_DESCRIPTION_LENGTH (including termination).
+ * to 255 characters (excluding termination). The p-net stack limits it to
+ * PNET_MAX_PORT_DESCRIPTION_SIZE (including termination).
  */
 typedef struct pf_lldp_port_description
 {
-   char string[PNET_MAX_PORT_DESCRIPTION_LENGTH]; /* Terminated */
+   char string[PNET_MAX_PORT_DESCRIPTION_SIZE]; /* Terminated string */
    bool is_valid;
    size_t len;
 } pf_lldp_port_description_t;
@@ -2506,8 +2506,8 @@ typedef struct pf_port_iterator
  */
 typedef struct pf_lldp_chassis_id
 {
-   char string[PNET_LLDP_CHASSIS_ID_MAX_LEN + 1]; /**< Terminated string */
-   uint8_t subtype;                               /* PF_LLDP_SUBTYPE_xxx */
+   char string[PNET_LLDP_CHASSIS_ID_MAX_SIZE]; /**< Terminated string */
+   uint8_t subtype;                            /* PF_LLDP_SUBTYPE_xxx */
    bool is_valid;
    size_t len;
 } pf_lldp_chassis_id_t;
@@ -2519,7 +2519,7 @@ typedef struct pf_lldp_chassis_id
  */
 typedef struct pf_lldp_port_id
 {
-   char string[PNET_LLDP_PORT_ID_MAX_LEN + 1]; /**< Terminated string */
+   char string[PNET_LLDP_PORT_ID_MAX_SIZE]; /**< Terminated string */
    uint8_t subtype;
    bool is_valid;
    size_t len;
@@ -2571,7 +2571,7 @@ typedef struct pf_lldp_management_address
  */
 typedef struct pf_lldp_station_name
 {
-   char string[PNET_STATION_NAME_MAX_LEN + 1]; /* Terminated */
+   char string[PNET_STATION_NAME_MAX_SIZE]; /** Terminated string */
    size_t len;
 } pf_lldp_station_name_t;
 
@@ -2705,7 +2705,7 @@ typedef struct pf_port
 
 struct pnet
 {
-   char interface_name[PNET_MAX_INTERFACE_NAME_LENGTH]; /** Terminated */
+   char interface_name[PNET_INTERFACE_NAME_MAX_SIZE]; /** Terminated string */
    uint32_t pnal_buf_alloc_cnt;
    bool global_alarm_enable;
    os_mutex_t * cpm_buf_lock;

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2369,9 +2369,9 @@ typedef struct pf_port_data_check
 typedef struct pf_check_peer
 {
    uint8_t length_peer_port_name;
-   uint8_t peer_port_name[PNET_LLDP_PORT_ID_MAX_SIZE - 1]; /** No termination */
+   uint8_t peer_port_name[PNET_LLDP_PORT_ID_MAX_SIZE]; /** Terminated */
    uint8_t length_peer_station_name;
-   uint8_t peer_station_name[PNET_STATION_NAME_MAX_SIZE - 1]; /** No term */
+   uint8_t peer_station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated */
 } pf_check_peer_t;
 
 typedef struct pf_check_peers

--- a/src/pnal.h
+++ b/src/pnal.h
@@ -33,9 +33,11 @@ extern "C" {
 #define PNAL_MAKEU16(a, b)                                                     \
    (((uint16_t) ((a)&0xff) << 8) | (uint16_t) ((b)&0xff))
 
-#define PNAL_INET_ADDRSTRLEN 16
-#define PNAL_ETH_ADDRSTRLEN  18
-#define PNAL_HOST_NAME_MAX   64 /* Value from Linux */
+#define PNAL_INET_ADDRSTR_SIZE 16 /** Incl termination */
+#define PNAL_ETH_ADDRSTR_SIZE  18 /** Incl termination */
+#ifndef PNAL_HOSTNAME_MAX_SIZE
+#define PNAL_HOSTNAME_MAX_SIZE 64 /** Incl termination. Value from Linux. */
+#endif
 
 /** Set an IP address given by the four byte-parts */
 #define PNAL_IP4_ADDR_TO_U32(ipaddr, a, b, c, d)                               \
@@ -269,12 +271,13 @@ int pnal_snmp_init (pnet_t * net);
  * 1.0.0.0           0x01000000 = 16777216
  * 0.0.0.1           0x00000001 = 1
  *
- * @param interface_name      In: Ethernet interface name, for example eth0
- * @param p_ipaddr            Out: IPv4 address
- * @param p_netmask           Out: Netmask
- * @param p_gw                Out: Default gateway
- * @param hostname            Out: Host name, for example my_laptop_4. Existing
- *                            buffer should have length PNAL_HOST_NAME_MAX.
+ * @param interface_name   In:    Ethernet interface name, for example eth0
+ * @param p_ipaddr         Out:   IPv4 address
+ * @param p_netmask        Out:   Netmask
+ * @param p_gw             Out:   Default gateway
+ * @param hostname         Out:   Host name, for example my_laptop_4. Existing
+ *                                buffer should have size
+ *                                PNAL_HOSTNAME_MAX_SIZE.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */
@@ -332,8 +335,9 @@ int pnal_get_macaddress (const char * interface_name, pnal_ethaddr_t * p_mac);
 /**
  * Read the current host name
  *
- * @param hostname            Out: Host name, for example my_laptop_4. Existing
- * buffer should have length PNAL_HOST_NAME_MAX.
+ * @param hostname         Out:   Host name, for example my_laptop_4. Existing
+ *                                buffer should have size
+ *                                PNAL_HOSTNAME_MAX_SIZE.
  * @return 0 on success and
  *         -1 if an error occurred
  */

--- a/src/ports/linux/pnal.c
+++ b/src/ports/linux/pnal.c
@@ -211,15 +211,15 @@ uint8_t pnal_buf_header (pnal_buf_t * p, int16_t header_size_increment)
 
 /** @internal
  * Convert IPv4 address to string
- * @param ip               In: IP address
- * @param outputstring     Out: Resulting string. Should have length
- * PNAL_INET_ADDRSTRLEN.
+ * @param ip               In:    IP address
+ * @param outputstring     Out:   Resulting string. Should have size
+ *                                PNAL_INET_ADDRSTR_SIZE.
  */
 static void os_ip_to_string (pnal_ipaddr_t ip, char * outputstring)
 {
    snprintf (
       outputstring,
-      PNAL_INET_ADDRSTRLEN,
+      PNAL_INET_ADDRSTR_SIZE,
       "%u.%u.%u.%u",
       (uint8_t) ((ip >> 24) & 0xFF),
       (uint8_t) ((ip >> 16) & 0xFF),
@@ -235,9 +235,9 @@ int pnal_set_ip_suite (
    const char * hostname,
    bool permanent)
 {
-   char ip_string[PNAL_INET_ADDRSTRLEN];
-   char netmask_string[PNAL_INET_ADDRSTRLEN];
-   char gateway_string[PNAL_INET_ADDRSTRLEN];
+   char ip_string[PNAL_INET_ADDRSTR_SIZE];      /** Terminated string */
+   char netmask_string[PNAL_INET_ADDRSTR_SIZE]; /** Terminated string */
+   char gateway_string[PNAL_INET_ADDRSTR_SIZE]; /** Terminated string */
    const char * argv[8];
 
    os_ip_to_string (*p_ipaddr, ip_string);
@@ -326,8 +326,8 @@ int pnal_get_hostname (char * hostname)
 {
    int ret = -1;
 
-   ret = gethostname (hostname, PNAL_HOST_NAME_MAX);
-   hostname[PNAL_HOST_NAME_MAX - 1] = '\0';
+   ret = gethostname (hostname, PNAL_HOSTNAME_MAX_SIZE);
+   hostname[PNAL_HOSTNAME_MAX_SIZE - 1] = '\0';
 
    return ret;
 }

--- a/src/ports/linux/pnal_eth.c
+++ b/src/ports/linux/pnal_eth.c
@@ -39,12 +39,12 @@ static void os_eth_task (void * thread_arg)
    ssize_t readlen;
    int handled = 0;
 
-   pnal_buf_t * p = pnal_buf_alloc (OS_BUF_MAX_SIZE);
+   pnal_buf_t * p = pnal_buf_alloc (PNAL_BUF_MAX_SIZE);
    assert (p != NULL);
 
    while (1)
    {
-      readlen = recv (eth_handle->socket, p->payload, OS_BUF_MAX_SIZE, 0);
+      readlen = recv (eth_handle->socket, p->payload, PNAL_BUF_MAX_SIZE, 0);
       if (readlen == -1)
          continue;
       p->len = readlen;
@@ -60,7 +60,7 @@ static void os_eth_task (void * thread_arg)
 
       if (handled == 1)
       {
-         p = pnal_buf_alloc (OS_BUF_MAX_SIZE);
+         p = pnal_buf_alloc (PNAL_BUF_MAX_SIZE);
          assert (p != NULL);
       }
    }

--- a/src/ports/linux/pnal_filetools.c
+++ b/src/ports/linux/pnal_filetools.c
@@ -78,25 +78,36 @@ static int pnal_get_directory_of_binary (char * path, size_t size)
  *
  * @param path             Out:   Resulting path. Terminated string.
  *                                Might be modified also on failure.
- * @param size             In :   Size of the outputbuffer.
- *
+ * @param size             In :   Size of the outputbuffer. Should be
+ *                                sizeof(PNAL_DEFAULT_SEARCHPATH) +
+ *                                PNET_MAX_DIRECTORYPATH_SIZE
  * @return 0 on success.
  *         -1 if an error occured.
  */
 int pnal_create_searchpath (char * path, size_t size)
 {
    int written = 0;
-   char directory_of_binary
-      [PNET_MAX_DIRECTORYPATH_LENGTH + PNET_MAX_FILENAME_LENGTH] = {0};
 
-   if (pnal_get_directory_of_binary (
-      directory_of_binary,
-      sizeof (directory_of_binary)) != 0)
+   /** Should temporarily hold full path. Resulting size is
+    * PNET_MAX_DIRECTORYPATH_SIZE */
+   char
+      directory_of_binary[PNET_MAX_DIRECTORYPATH_SIZE + PNET_MAX_FILENAME_SIZE] =
+         {0};
+
+   if (
+      pnal_get_directory_of_binary (
+         directory_of_binary,
+         sizeof (directory_of_binary)) != 0)
    {
       return -1;
    }
 
-   written = snprintf(path, size, "%s:%s", PNAL_DEFAULT_SEARCHPATH, directory_of_binary);
+   written = snprintf (
+      path,
+      size,
+      "%s:%s",
+      PNAL_DEFAULT_SEARCHPATH,
+      directory_of_binary);
    if (written < 0 || (unsigned)written >= size)
    {
       return -1;
@@ -107,9 +118,9 @@ int pnal_create_searchpath (char * path, size_t size)
 
 int pnal_execute_script (const char * argv[])
 {
+   /** Terminated string, see pnal_create_searchpath() */
    char child_searchpath
-      [PNET_MAX_DIRECTORYPATH_LENGTH + sizeof (PNAL_DEFAULT_SEARCHPATH) + 1] = {
-         0};
+      [sizeof (PNAL_DEFAULT_SEARCHPATH) + PNET_MAX_DIRECTORYPATH_SIZE] = {0};
    int childstatus = 0;
    pid_t childpid;
    char * scriptenviron[] = {NULL};

--- a/src/ports/linux/pnal_sys.h
+++ b/src/ports/linux/pnal_sys.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #include <netinet/in.h>
 
-#define OS_BUF_MAX_SIZE 1522
+#define PNAL_BUF_MAX_SIZE 1522
 
 typedef struct os_buf
 {

--- a/src/ports/linux/sampleapp_main.c
+++ b/src/ports/linux/sampleapp_main.c
@@ -155,7 +155,7 @@ struct cmd_args parse_commandline_arguments (int argc, char * argv[])
          strcpy (output_arguments.station_name, optarg);
          break;
       case 'b':
-         if (strlen (optarg) + 1 > PNET_MAX_FILE_FULLPATH_LEN)
+         if (strlen (optarg) + 1 > PNET_MAX_FILE_FULLPATH_SIZE)
          {
             printf ("Error: The argument to -b is too long.\n");
             exit (EXIT_FAILURE);
@@ -163,7 +163,7 @@ struct cmd_args parse_commandline_arguments (int argc, char * argv[])
          strcpy (output_arguments.path_button1, optarg);
          break;
       case 'd':
-         if (strlen (optarg) + 1 > PNET_MAX_FILE_FULLPATH_LEN)
+         if (strlen (optarg) + 1 > PNET_MAX_FILE_FULLPATH_SIZE)
          {
             printf ("Error: The argument to -d is too long.\n");
             exit (EXIT_FAILURE);
@@ -171,7 +171,7 @@ struct cmd_args parse_commandline_arguments (int argc, char * argv[])
          strcpy (output_arguments.path_button2, optarg);
          break;
       case 'p':
-         if (strlen (optarg) + 1 > PNET_MAX_FILE_FULLPATH_LEN)
+         if (strlen (optarg) + 1 > PNET_MAX_FILE_FULLPATH_SIZE)
          {
             printf ("Error: The argument to -p is too long.\n");
             exit (EXIT_FAILURE);
@@ -197,7 +197,7 @@ struct cmd_args parse_commandline_arguments (int argc, char * argv[])
             sizeof (output_arguments.path_storage_directory)) == NULL)
       {
          printf ("Error: Could not read current working directory. Is "
-                 "PNET_MAX_DIRECTORYPATH_LENGTH too small?\n");
+                 "PNET_MAX_DIRECTORYPATH_SIZE too small?\n");
          exit (EXIT_FAILURE);
       }
    }
@@ -258,7 +258,7 @@ void app_get_button (const app_data_t * p_appdata, uint16_t id, bool * p_pressed
 
 int app_set_led (uint16_t id, bool led_state)
 {
-   char id_str[7] = {0};
+   char id_str[7] = {0}; /** Terminated string */
    const char * argv[4];
 
    sprintf (id_str, "%u", id);

--- a/src/ports/rt-kernel/pnal_sys.h
+++ b/src/ports/rt-kernel/pnal_sys.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <sys/socket.h> /* For htonl etc */
 #include <lwip/pbuf.h>
 
-#define OS_BUF_MAX_SIZE PBUF_POOL_BUFSIZE
+#define PNAL_BUF_MAX_SIZE PBUF_POOL_BUFSIZE
 
 /* Re-use lwIP pbuf for rt-kernel */
 typedef struct pbuf pnal_buf_t;

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -31,7 +31,7 @@ class FileUnitTest : public PnetUnitTest
 
 TEST_F (FileUnitTest, FileJoinDirectoryFilename)
 {
-   char outputstring[TEST_FILE_OUTPUTSTRING_SIZE] = {0};
+   char outputstring[TEST_FILE_OUTPUTSTRING_SIZE] = {0}; /** Terminated */
    int res = 0;
 
    /* Happy case */

--- a/test/test_lldp.cpp
+++ b/test/test_lldp.cpp
@@ -378,7 +378,7 @@ TEST_F (LldpTest, LldpInitTest)
 
 TEST_F (LldpTest, LldpGenerateAliasName)
 {
-   char alias[256];
+   char alias[256]; /** Terminated string */
    int err;
 
    err = pf_lldp_generate_alias_name (NULL, "dut", alias, 96);

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -490,7 +490,6 @@ void PnetIntegrationTestBase::cfg_init()
    pnet_default_cfg.oem_device_id.device_id_lo = 0xef;
 
    strcpy (pnet_default_cfg.station_name, "");
-   strcpy (pnet_default_cfg.manufacturer_specific_string, "PNET demo");
    strcpy (pnet_default_cfg.product_name, "PNET unit tests");
 
    strcpy (pnet_default_cfg.lldp_cfg.ports[0].port_id, "port-001");


### PR DESCRIPTION
Document which string length constants that include a terminator.
Remove redundant string `manufacturer_specific_string` from structs.
Renamed `OS_BUF_MAX_SIZE` to `PNAL_BUF_MAX_SIZE`