### PR TITLE
api: Remove link status from configuration

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1170,32 +1170,6 @@ typedef struct pnet_ethaddr
 #define PNET_LLDP_PORT_ID_MAX_SIZE                                             \
    (PNET_STATION_NAME_MAX_SIZE + PNET_PORT_ID_MAX_SIZE)
 
-/* LLDP Autonegotiation */
-#define PNET_LLDP_AUTONEG_SUPPORTED (1u << 0)
-#define PNET_LLDP_AUTONEG_ENABLED   (1u << 1)
-
-/* LLDP Autonegotiation capabilities (not exhaustive) */
-#define PNET_LLDP_AUTONEG_CAP_1000BaseT_FULL_DUPLEX (1ul << 0)
-#define PNET_LLDP_AUTONEG_CAP_1000BaseT_HALF_DUPLEX (1ul << 1)
-#define PNET_LLDP_AUTONEG_CAP_1000BaseX_FULL_DUPLEX (1ul << 2)
-#define PNET_LLDP_AUTONEG_CAP_1000BaseX_HALF_DUPLEX (1ul << 3)
-#define PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX (1ul << 10)
-#define PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX (1ul << 11)
-#define PNET_LLDP_AUTONEG_CAP_10BaseT_FULL_DUPLEX   (1ul << 13)
-#define PNET_LLDP_AUTONEG_CAP_10BaseT_HALF_DUPLEX   (1ul << 14)
-#define PNET_LLDP_AUTONEG_CAP_UNKNOWN               (1ul << 15)
-
-/* LLDP MAU type (not exhaustive). See Profinet 2.4, section 5.2.13.12 */
-#define PNET_MAU_RADIO                        0x0000
-#define PNET_MAU_COPPER_10BaseT               0x0005
-#define PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX 0x000F
-#define PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX 0x0010
-#define PNET_MAU_COPPER_1000BaseT_HALF_DUPLEX 0x001D
-#define PNET_MAU_COPPER_1000BaseT_FULL_DUPLEX 0x001E
-#define PNET_MAU_FIBER_100BaseFX_HALF_DUPLEX  0x0011
-#define PNET_MAU_FIBER_100BaseFX_FULL_DUPLEX  0x0012
-#define PNET_MAU_FIBER_1000BaseX_HALF_DUPLEX  0x0015
-#define PNET_MAU_FIBER_1000BaseX_FULL_DUPLEX  0x0016
 
 /**
  * LLDP configuration for a single port.
@@ -1206,9 +1180,6 @@ typedef struct pnet_lldp_port_cfg
    pnet_ethaddr_t port_addr;
    uint16_t rtclass_2_status;
    uint16_t rtclass_3_status;
-   uint8_t cap_aneg;  /**< Autonegotiation supported and enabled */
-   uint16_t cap_phy;  /**< Autonegotiation speeds */
-   uint16_t mau_type; /**< Cable MAU type */
 } pnet_lldp_port_cfg_t;
 
 /**

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -1359,13 +1359,6 @@ int app_adjust_stack_configuration (pnet_cfg_t * stack_config)
    strcpy (stack_config->lldp_cfg.ports[0].port_id, "port-001");
    stack_config->lldp_cfg.ports[0].rtclass_2_status = 0;
    stack_config->lldp_cfg.ports[0].rtclass_3_status = 0;
-   stack_config->lldp_cfg.ports[0].cap_aneg = PNET_LLDP_AUTONEG_SUPPORTED |
-                                              PNET_LLDP_AUTONEG_ENABLED;
-   stack_config->lldp_cfg.ports[0].cap_phy =
-      PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
-      PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX;
-   stack_config->lldp_cfg.ports[0].mau_type =
-      PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
 
    /* Network configuration */
    stack_config->send_hello = true;

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3698,7 +3698,7 @@ void pf_put_pdport_data_real (
        */
       switch (p_peer_info->phy_config.operational_mau_type)
       {
-      case PNET_MAU_RADIO:
+      case PNAL_ETH_MAU_RADIO:
          /* Radio */
          pf_put_uint32 (
             is_big_endian,
@@ -3707,11 +3707,11 @@ void pf_put_pdport_data_real (
             p_bytes,
             p_pos);
          break;
-      case PNET_MAU_COPPER_10BaseT:
-      case PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX:
-      case PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX:
-      case PNET_MAU_COPPER_1000BaseT_HALF_DUPLEX:
-      case PNET_MAU_COPPER_1000BaseT_FULL_DUPLEX:
+      case PNAL_ETH_MAU_COPPER_10BaseT:
+      case PNAL_ETH_MAU_COPPER_100BaseTX_HALF_DUPLEX:
+      case PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX:
+      case PNAL_ETH_MAU_COPPER_1000BaseT_HALF_DUPLEX:
+      case PNAL_ETH_MAU_COPPER_1000BaseT_FULL_DUPLEX:
          /* Copper */
          pf_put_uint32 (
             is_big_endian,
@@ -3720,10 +3720,10 @@ void pf_put_pdport_data_real (
             p_bytes,
             p_pos);
          break;
-      case PNET_MAU_FIBER_100BaseFX_HALF_DUPLEX:
-      case PNET_MAU_FIBER_100BaseFX_FULL_DUPLEX:
-      case PNET_MAU_FIBER_1000BaseX_HALF_DUPLEX:
-      case PNET_MAU_FIBER_1000BaseX_FULL_DUPLEX:
+      case PNAL_ETH_MAU_FIBER_100BaseFX_HALF_DUPLEX:
+      case PNAL_ETH_MAU_FIBER_100BaseFX_FULL_DUPLEX:
+      case PNAL_ETH_MAU_FIBER_1000BaseX_HALF_DUPLEX:
+      case PNAL_ETH_MAU_FIBER_1000BaseX_FULL_DUPLEX:
          /* Fiber */
          pf_put_uint32 (
             is_big_endian,

--- a/src/ports/linux/pnal_eth.c
+++ b/src/ports/linux/pnal_eth.c
@@ -140,3 +140,17 @@ int pnal_eth_send (pnal_eth_handle_t * handle, pnal_buf_t * buf)
 
    return ret;
 }
+
+void pnal_eth_get_status (
+   pnal_eth_handle_t * handle,
+   int loc_port_num,
+   pnal_eth_status_t * status)
+{
+   /* TODO: Read current status */
+   status->is_autonegotiation_supported = true;
+   status->is_autonegotiation_enabled = true;
+   status->autonegotiation_advertised_capabilities =
+      PNAL_ETH_AUTONEG_CAP_10BaseT_HALF_DUPLEX |
+      PNAL_ETH_AUTONEG_CAP_10BaseT_FULL_DUPLEX;
+   status->operational_mau_type = PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX;
+}

--- a/src/ports/rt-kernel/pnal_eth.c
+++ b/src/ports/rt-kernel/pnal_eth.c
@@ -104,3 +104,17 @@ int pnal_eth_send (pnal_eth_handle_t * handle, pnal_buf_t * buf)
    }
    return ret;
 }
+
+void pnal_eth_get_status (
+   pnal_eth_handle_t * handle,
+   int loc_port_num,
+   pnal_eth_status_t * status)
+{
+   /* TODO: Read current status */
+   status->is_autonegotiation_supported = true;
+   status->is_autonegotiation_enabled = true;
+   status->autonegotiation_advertised_capabilities =
+      PNAL_ETH_AUTONEG_CAP_10BaseT_HALF_DUPLEX |
+      PNAL_ETH_AUTONEG_CAP_10BaseT_FULL_DUPLEX;
+   status->operational_mau_type = PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX;
+}

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -58,6 +58,14 @@ pnal_eth_handle_t * mock_pnal_eth_init (
    return handle;
 }
 
+void mock_pnal_eth_get_status (
+   pnal_eth_handle_t * handle,
+   int loc_port_num,
+   pnal_eth_status_t * status)
+{
+   *status = mock_os_data.eth_status[loc_port_num];
+}
+
 int mock_pnal_get_ip_suite (
    const char * interface_name,
    pnal_ipaddr_t * p_ipaddr,

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -33,6 +33,12 @@ typedef struct mock_os_data_obj
    uint16_t eth_send_len;
    uint16_t eth_send_count;
 
+   /* Per port Ethernet link status.
+    * Note that port numbers start at 1. To simplify test cases, we add a
+    * dummy array element at index 0.
+    */
+   pnal_eth_status_t eth_status[PNET_MAX_PORT + 1];
+
    uint16_t udp_sendto_len;
    uint16_t udp_sendto_count;
 
@@ -78,6 +84,10 @@ pnal_eth_handle_t * mock_pnal_eth_init (
    pnal_eth_callback_t * callback,
    void * arg);
 int mock_pnal_eth_send (pnal_eth_handle_t * handle, pnal_buf_t * buf);
+void mock_pnal_eth_get_status (
+   pnal_eth_handle_t * handle,
+   int loc_port_num,
+   pnal_eth_status_t * status);
 void mock_os_cpy_mac_addr (uint8_t * mac_addr);
 int mock_pnal_udp_open (pnal_ipaddr_t addr, pnal_ipport_t port);
 int mock_pnal_udp_sendto (

--- a/test/test_lldp.cpp
+++ b/test/test_lldp.cpp
@@ -114,9 +114,10 @@ static pf_lldp_peer_info_t fake_peer_info (void)
    peer.phy_config.is_autonegotiation_supported = true;
    peer.phy_config.is_autonegotiation_enabled = true;
    peer.phy_config.autonegotiation_advertised_capabilities =
-      PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
-      PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX;
-   peer.phy_config.operational_mau_type = PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
+      PNAL_ETH_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
+      PNAL_ETH_AUTONEG_CAP_100BaseTX_FULL_DUPLEX;
+   peer.phy_config.operational_mau_type =
+      PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX;
    peer.phy_config.is_valid = true;
 
    peer.mac_address.addr[0] = 0xab;
@@ -675,6 +676,13 @@ TEST_F (LldpTest, LldpGetLinkStatus)
 {
    pf_lldp_link_status_t link_status;
 
+   mock_os_data.eth_status[LOCAL_PORT].is_autonegotiation_supported = true;
+   mock_os_data.eth_status[LOCAL_PORT].is_autonegotiation_enabled = true;
+   mock_os_data.eth_status[LOCAL_PORT].autonegotiation_advertised_capabilities =
+      PNAL_ETH_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
+      PNAL_ETH_AUTONEG_CAP_100BaseTX_FULL_DUPLEX;
+   mock_os_data.eth_status[LOCAL_PORT].operational_mau_type =
+      PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX;
    memset (&link_status, 0xff, sizeof (link_status));
 
    pf_lldp_get_link_status (net, LOCAL_PORT, &link_status);
@@ -682,11 +690,32 @@ TEST_F (LldpTest, LldpGetLinkStatus)
    EXPECT_EQ (link_status.is_autonegotiation_enabled, true);
    EXPECT_EQ (
       link_status.autonegotiation_advertised_capabilities,
-      PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
-         PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX);
+      PNAL_ETH_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
+         PNAL_ETH_AUTONEG_CAP_100BaseTX_FULL_DUPLEX);
    EXPECT_EQ (
       link_status.operational_mau_type,
-      PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
+      PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX);
+}
+
+TEST_F (LldpTest, LldpGetLinkStatusGivenAutonegotiationDisabled)
+{
+   pf_lldp_link_status_t link_status;
+
+   mock_os_data.eth_status[LOCAL_PORT].is_autonegotiation_supported = false;
+   mock_os_data.eth_status[LOCAL_PORT].is_autonegotiation_enabled = false;
+   mock_os_data.eth_status[LOCAL_PORT].autonegotiation_advertised_capabilities =
+      0x0000;
+   mock_os_data.eth_status[LOCAL_PORT].operational_mau_type =
+      PNAL_ETH_MAU_COPPER_100BaseTX_HALF_DUPLEX;
+   memset (&link_status, 0xff, sizeof (link_status));
+
+   pf_lldp_get_link_status (net, LOCAL_PORT, &link_status);
+   EXPECT_EQ (link_status.is_autonegotiation_supported, false);
+   EXPECT_EQ (link_status.is_autonegotiation_enabled, false);
+   EXPECT_EQ (link_status.autonegotiation_advertised_capabilities, 0x0000);
+   EXPECT_EQ (
+      link_status.operational_mau_type,
+      PNAL_ETH_MAU_COPPER_100BaseTX_HALF_DUPLEX);
 }
 
 TEST_F (LldpTest, LldpGetPeerTimestamp)

--- a/test/test_snmp.cpp
+++ b/test/test_snmp.cpp
@@ -100,14 +100,14 @@ TEST_F (SnmpTest, SnmpGetLinkStatus)
    mock_lldp_data.link_status.is_autonegotiation_enabled = true;
    mock_lldp_data.link_status.autonegotiation_advertised_capabilities = 0xF00F;
    mock_lldp_data.link_status.operational_mau_type =
-      PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
+      PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX;
 
    pf_snmp_get_link_status (net, LOCAL_PORT, &status);
    EXPECT_EQ (status.auto_neg_supported, 1); /* true */
    EXPECT_EQ (status.auto_neg_enabled, 1);   /* true */
    EXPECT_EQ (status.auto_neg_advertised_cap[0], 0xF0);
    EXPECT_EQ (status.auto_neg_advertised_cap[1], 0x0F);
-   EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
+   EXPECT_EQ (status.oper_mau_type, PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX);
 
    memset (&status, 0xff, sizeof (status));
    mock_lldp_data.link_status.is_autonegotiation_supported = true;
@@ -115,14 +115,14 @@ TEST_F (SnmpTest, SnmpGetLinkStatus)
    mock_lldp_data.link_status.autonegotiation_advertised_capabilities =
       BIT (5 + 0) | BIT (3 + 0) | BIT (6 + 8) | BIT (0 + 8);
    mock_lldp_data.link_status.operational_mau_type =
-      PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX;
+      PNAL_ETH_MAU_COPPER_100BaseTX_HALF_DUPLEX;
 
    pf_snmp_get_link_status (net, LOCAL_PORT, &status);
    EXPECT_EQ (status.auto_neg_supported, 1); /* true */
    EXPECT_EQ (status.auto_neg_enabled, 2);   /* false */
    EXPECT_EQ (status.auto_neg_advertised_cap[0], BIT (2) | BIT (4));
    EXPECT_EQ (status.auto_neg_advertised_cap[1], BIT (1) | BIT (7));
-   EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX);
+   EXPECT_EQ (status.oper_mau_type, PNAL_ETH_MAU_COPPER_100BaseTX_HALF_DUPLEX);
 }
 
 TEST_F (SnmpTest, SnmpGetPeerLinkStatus)
@@ -136,7 +136,7 @@ TEST_F (SnmpTest, SnmpGetPeerLinkStatus)
    mock_lldp_data.peer_link_status.autonegotiation_advertised_capabilities =
       0xF00F;
    mock_lldp_data.peer_link_status.operational_mau_type =
-      PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
+      PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX;
    mock_lldp_data.error = 0;
 
    error = pf_snmp_get_peer_link_status (net, LOCAL_PORT, &status);
@@ -145,7 +145,7 @@ TEST_F (SnmpTest, SnmpGetPeerLinkStatus)
    EXPECT_EQ (status.auto_neg_enabled, 1);   /* true */
    EXPECT_EQ (status.auto_neg_advertised_cap[0], 0xF0);
    EXPECT_EQ (status.auto_neg_advertised_cap[1], 0x0F);
-   EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX);
+   EXPECT_EQ (status.oper_mau_type, PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX);
 
    memset (&status, 0xff, sizeof (status));
    mock_lldp_data.peer_link_status.is_autonegotiation_supported = true;
@@ -153,7 +153,7 @@ TEST_F (SnmpTest, SnmpGetPeerLinkStatus)
    mock_lldp_data.peer_link_status.autonegotiation_advertised_capabilities =
       BIT (5 + 0) | BIT (3 + 0) | BIT (6 + 8) | BIT (0 + 8);
    mock_lldp_data.peer_link_status.operational_mau_type =
-      PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX;
+      PNAL_ETH_MAU_COPPER_100BaseTX_HALF_DUPLEX;
    mock_lldp_data.error = 0;
 
    error = pf_snmp_get_peer_link_status (net, LOCAL_PORT, &status);
@@ -162,7 +162,7 @@ TEST_F (SnmpTest, SnmpGetPeerLinkStatus)
    EXPECT_EQ (status.auto_neg_enabled, 2);   /* false */
    EXPECT_EQ (status.auto_neg_advertised_cap[0], BIT (2) | BIT (4));
    EXPECT_EQ (status.auto_neg_advertised_cap[1], BIT (1) | BIT (7));
-   EXPECT_EQ (status.oper_mau_type, PNET_MAU_COPPER_100BaseTX_HALF_DUPLEX);
+   EXPECT_EQ (status.oper_mau_type, PNAL_ETH_MAU_COPPER_100BaseTX_HALF_DUPLEX);
 
    mock_lldp_data.error = -1;
    error = pf_snmp_get_peer_link_status (net, LOCAL_PORT, &status);

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -495,13 +495,6 @@ void PnetIntegrationTestBase::cfg_init()
    strcpy (pnet_default_cfg.lldp_cfg.ports[0].port_id, "port-001");
    pnet_default_cfg.lldp_cfg.ports[0].rtclass_2_status = 0;
    pnet_default_cfg.lldp_cfg.ports[0].rtclass_3_status = 0;
-   pnet_default_cfg.lldp_cfg.ports[0].cap_aneg = PNET_LLDP_AUTONEG_SUPPORTED |
-                                                 PNET_LLDP_AUTONEG_ENABLED;
-   pnet_default_cfg.lldp_cfg.ports[0].cap_phy =
-      PNET_LLDP_AUTONEG_CAP_100BaseTX_HALF_DUPLEX |
-      PNET_LLDP_AUTONEG_CAP_100BaseTX_FULL_DUPLEX;
-   pnet_default_cfg.lldp_cfg.ports[0].mau_type =
-      PNET_MAU_COPPER_100BaseTX_FULL_DUPLEX;
 
    /* Timing */
    pnet_default_cfg.min_device_interval = 32; /* Corresponds to 1 ms */


### PR DESCRIPTION
Three fields were removed from the configuration
struct pnet_lldp_port_cfg_t related to the current
link status of an Ethernet port.

A new pnal function is introduced to retrieve
this information from the Ethernet driver.
The new functions are only stubs at the moment.