### PR TITLE
Expose low-level diagnostics functionality

### DIFF
--- a/doc/api_documentation.rst
+++ b/doc/api_documentation.rst
@@ -11,6 +11,7 @@ the instructions given on the page "Additional Linux Details".
 
 Study the sample_app to get more information on how to use the API.
 
+
 General
 -------
 All functions return either ``0`` (zero) for a successful call or ``-1`` for an
@@ -63,6 +64,17 @@ Alarms and diagnostics
 .. doxygenfunction:: pnet_diag_usi_add
 .. doxygenfunction:: pnet_diag_usi_update
 .. doxygenfunction:: pnet_diag_usi_remove
+
+
+Low-level diagnostic functions
+------------------------------
+These are used internally in the functions above for handling diagnosis in
+standard or in USI format. However they can be useful in situations where
+detailed control is required.
+
+.. doxygenfunction:: pnet_diag_add
+.. doxygenfunction:: pnet_diag_update
+.. doxygenfunction:: pnet_diag_remove
 
 
 Callbacks
@@ -124,3 +136,4 @@ sending LLDP frames.
 .. doxygenstruct:: pnet_cfg_t
 .. doxygenstruct:: pnet_alarm_spec_t
 .. doxygenstruct:: pnet_alarm_argument_t
+.. doxygenstruct:: pnet_diag_source_t

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -1364,6 +1364,11 @@ int app_adjust_stack_configuration (pnet_cfg_t * stack_config)
    stack_config->send_hello = true;
    stack_config->dhcp_enable = false;
 
+   /* Diagnosis mechanism */
+   /* Use "Extended channel diagnosis" instead of "Qualified channel diagnosis"
+      format on the wire, as this is better supported by Wireshark. */
+   stack_config->use_qualified_diagnosis = false;
+
    return 0;
 }
 

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -1297,11 +1297,12 @@ void pf_cmdev_diag_show (const pnet_t * net)
          {
             printf (
                "  Channel: 0x%04X  Ch.error: 0x%04X  Ext.error 0x%04X  "
-               "Add.value 0x%08" PRIX32 "\n",
+               "Add.value 0x%08" PRIX32 " Qualifier 0x%08" PRIX32 "\n",
                p_diag->fmt.std.ch_nbr,
                p_diag->fmt.std.ch_error_type,
                p_diag->fmt.std.ext_ch_error_type,
-               p_diag->fmt.std.ext_ch_add_value);
+               p_diag->fmt.std.ext_ch_add_value,
+               p_diag->fmt.std.qual_ch_qualifier);
          }
          else
          {

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -498,6 +498,67 @@ int pnet_alarm_send_ack (
    return ret;
 }
 
+/************************** Low-level diagnosis functions*********************/
+
+int pnet_diag_add (
+   pnet_t * net,
+   const pnet_diag_source_t * p_diag_source,
+   pnet_diag_ch_prop_type_values_t ch_bits,
+   pnet_diag_ch_prop_maint_values_t severity,
+   uint16_t ch_error_type,
+   uint16_t ext_ch_error_type,
+   uint32_t ext_ch_add_value,
+   uint32_t qual_ch_qualifier,
+   uint16_t usi,
+   const uint8_t * p_manuf_data)
+{
+   return pf_diag_add (
+      net,
+      p_diag_source,
+      ch_bits,
+      severity,
+      ch_error_type,
+      ext_ch_error_type,
+      ext_ch_add_value,
+      qual_ch_qualifier,
+      usi,
+      p_manuf_data);
+}
+
+int pnet_diag_update (
+   pnet_t * net,
+   const pnet_diag_source_t * p_diag_source,
+   uint16_t ch_error_type,
+   uint16_t ext_ch_error_type,
+   uint32_t ext_ch_add_value,
+   uint16_t usi,
+   const uint8_t * p_manuf_data)
+{
+   return pf_diag_update (
+      net,
+      p_diag_source,
+      ch_error_type,
+      ext_ch_error_type,
+      ext_ch_add_value,
+      usi,
+      p_manuf_data);
+}
+
+int pnet_diag_remove (
+   pnet_t * net,
+   const pnet_diag_source_t * p_diag_source,
+   uint16_t ch_error_type,
+   uint16_t ext_ch_error_type,
+   uint16_t usi)
+{
+   return pf_diag_remove (
+      net,
+      p_diag_source,
+      ch_error_type,
+      ext_ch_error_type,
+      usi);
+}
+
 /************************** Diagnosis in standard format *********************/
 
 int pnet_diag_std_add (

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -90,7 +90,8 @@ static inline uint32_t atomic_fetch_sub (atomic_int * p, uint32_t v)
 /** Qualifier 6..3 */
 #define PF_DIAG_QUALIFIER_MASK_ADVICE 0x00000078
 
-/* Mask and position of bit fields and values within ch_properties */
+/* ch_properties channel size in bits
+   See also pnet_diag_ch_prop_type_values_t */
 #define PF_DIAG_CH_PROP_TYPE_MASK 0x00ff
 #define PF_DIAG_CH_PROP_TYPE_POS  0
 #define PF_DIAG_CH_PROP_TYPE_GET(x)                                            \
@@ -102,6 +103,8 @@ static inline uint32_t atomic_fetch_sub (atomic_int * p, uint32_t v)
       (x) |= (v) << PF_DIAG_CH_PROP_TYPE_POS;                                  \
    } while (0)
 
+/* ch_properties channel group or individual channel
+   See also pnet_diag_ch_group_values_t */
 #define PF_DIAG_CH_PROP_ACC_MASK 0x0100
 #define PF_DIAG_CH_PROP_ACC_POS  8
 #define PF_DIAG_CH_PROP_ACC_GET(x)                                             \
@@ -113,6 +116,8 @@ static inline uint32_t atomic_fetch_sub (atomic_int * p, uint32_t v)
       (x) |= (v) << PF_DIAG_CH_PROP_ACC_POS;                                   \
    } while (0)
 
+/* ch_properties diagnosis severity
+   See also pnet_diag_ch_prop_maint_values_t */
 #define PF_DIAG_CH_PROP_MAINT_MASK 0x0600
 #define PF_DIAG_CH_PROP_MAINT_POS  9
 #define PF_DIAG_CH_PROP_MAINT_GET(x)                                           \
@@ -124,6 +129,7 @@ static inline uint32_t atomic_fetch_sub (atomic_int * p, uint32_t v)
       (x) |= (v) << PF_DIAG_CH_PROP_MAINT_POS;                                 \
    } while (0)
 
+/* ch_properties appears or disappers */
 #define PF_DIAG_CH_PROP_SPEC_MASK 0x1800
 #define PF_DIAG_CH_PROP_SPEC_POS  11
 #define PF_DIAG_CH_PROP_SPEC_GET(x)                                            \
@@ -143,6 +149,8 @@ typedef enum pf_diag_ch_prop_spec_values
    PF_DIAG_CH_PROP_SPEC_DIS_OTHERS_REMAIN = 3,
 } pf_diag_ch_prop_spec_values_t;
 
+/* ch_properties direction
+   See also pnet_diag_ch_prop_dir_values_t */
 #define PF_DIAG_CH_PROP_DIR_MASK 0xe000
 #define PF_DIAG_CH_PROP_DIR_POS  13
 #define PF_DIAG_CH_PROP_DIR_GET(x)                                             \
@@ -951,8 +959,9 @@ typedef struct pf_alarm_queue
 #define PF_CMINA_FS_HELLO_INTERVAL                                             \
    (3 * 1000)                            /* milliseconds. Default is 30 ms */
 #define PF_LLDP_SEND_INTERVAL (5 * 1000) /* milliseconds */
-#define PF_LLDP_INITIAL_PEER_TIMEOUT ((2 * PF_LLDP_SEND_INTERVAL) / 1000) /* seconds */
-#define PF_LLDP_TTL 20 /* seconds */
+#define PF_LLDP_INITIAL_PEER_TIMEOUT                                           \
+   ((2 * PF_LLDP_SEND_INTERVAL) / 1000) /* seconds */
+#define PF_LLDP_TTL 20                  /* seconds */
 
 typedef enum pf_cmina_state_values
 {
@@ -1420,9 +1429,8 @@ typedef struct pf_prm_server
    uint16_t cm_initiator_activity_timeout_factor;                /** res: 100ms,
                                                                     allowed 1..1000 */
    uint16_t parameter_server_station_name_len;
-   char
-      parameter_server_station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated
-                                                                    string */
+   char parameter_server_station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated
+                                                                      string */
 } pf_prm_server_t;
 
 typedef struct pf_address_resolution_properties

--- a/test/test_diag.cpp
+++ b/test/test_diag.cpp
@@ -573,7 +573,7 @@ TEST_F (DiagTest, DiagRunTest)
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
       TEST_DIAG_USI_CUSTOM,
-      (uint8_t *)"Bjarne");
+      (uint8_t *)"ABCD");
    EXPECT_EQ (ret, 0);
 
    TEST_TRACE ("Update data for a manufacturer specific USI, via add()\n");
@@ -583,7 +583,7 @@ TEST_F (DiagTest, DiagRunTest)
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
       TEST_DIAG_USI_CUSTOM,
-      (uint8_t *)"Bjarn1");
+      (uint8_t *)"ABC1");
    EXPECT_EQ (ret, 0);
 
    TEST_TRACE ("Update data for a manufacturer specific USI, via update()\n");
@@ -640,7 +640,7 @@ TEST_F (DiagTest, DiagRunTest)
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_NONEXIST_IDENT,
       TEST_DIAG_USI_CUSTOM,
-      (uint8_t *)"Bjarne");
+      (uint8_t *)"ABCD");
    EXPECT_EQ (ret, -1);
 
    TEST_TRACE ("Add, update and remove diagnosis for invalid USI\n");
@@ -650,7 +650,7 @@ TEST_F (DiagTest, DiagRunTest)
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
       TEST_DIAG_USI_INVALID,
-      (uint8_t *)"Bjarne");
+      (uint8_t *)"ABCD");
    EXPECT_EQ (ret, -1);
 
    ret = pnet_diag_usi_update (
@@ -668,6 +668,371 @@ TEST_F (DiagTest, DiagRunTest)
       TEST_SLOT_IDENT,
       TEST_SUBSLOT_IDENT,
       TEST_DIAG_USI_INVALID);
+   EXPECT_EQ (ret, -1);
+
+   TEST_TRACE ("\nUse low-level functionality. Create a standard diag entry, "
+               "with QUALIFIED and FAULT. Then update it and finally "
+               "remove it.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      TEST_CHANNEL_NUMBER_OF_BITS,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER_NOTSET,
+      0x8003, /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+      NULL);
+   EXPECT_EQ (ret, 0);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE_B,
+      0x8003, /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+      NULL);
+   EXPECT_EQ (ret, 0);
+
+   ret = pnet_diag_remove (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      0x8003 /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+   );
+   EXPECT_EQ (ret, 0);
+
+   TEST_TRACE ("\nUse low-level functionality. Create a standard diag entry, "
+               "with QUALIFIED. Then update it and finally "
+               "remove it.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      TEST_CHANNEL_NUMBER_OF_BITS,
+      PNET_DIAG_CH_PROP_MAINT_QUALIFIED,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER,
+      0x8003, /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+      NULL);
+   EXPECT_EQ (ret, 0);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE_B,
+      0x8003, /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+      NULL);
+   EXPECT_EQ (ret, 0);
+
+   ret = pnet_diag_remove (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      0x8003 /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+   );
+   EXPECT_EQ (ret, 0);
+
+   TEST_TRACE ("\nUse low-level functionality. Create a standard diag entry, "
+               "with EXTENDED. Then update it and finally "
+               "remove it.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      TEST_CHANNEL_NUMBER_OF_BITS,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER_NOTSET,
+      0x8002, /* PF_USI_EXTENDED_CHANNEL_DIAGNOSIS */
+      NULL);
+   EXPECT_EQ (ret, 0);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE_B,
+      0x8002, /* PF_USI_EXTENDED_CHANNEL_DIAGNOSIS */
+      NULL);
+   EXPECT_EQ (ret, 0);
+
+   ret = pnet_diag_remove (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      0x8002 /* PF_USI_EXTENDED_CHANNEL_DIAGNOSIS */
+   );
+   EXPECT_EQ (ret, 0);
+
+   TEST_TRACE ("\nUse low-level functionality. Create a USI diag entry. Then "
+               "update it and finally "
+               "remove it.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      0, /* Channel error type */
+      0, /* Ext channel error type */
+      0, /* Add value */
+      0, /* Qualifier */
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABCD");
+   EXPECT_EQ (ret, 0);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      0, /* Channel error type */
+      0, /* Ext channel error type */
+      0, /* Add value */
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABC2");
+   EXPECT_EQ (ret, 0);
+
+   ret = pnet_diag_remove (
+      net,
+      &diag_source,
+      0, /* Channel error type */
+      0, /* Ext channel error type */
+      TEST_DIAG_USI_CUSTOM);
+   EXPECT_EQ (ret, 0);
+
+   TEST_TRACE ("\nError checking for low-level functionality. Invalid USI.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      TEST_CHANNEL_NUMBER_OF_BITS,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER_NOTSET,
+      0x8001, /* Invalid */
+      NULL);
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      TEST_CHANNEL_NUMBER_OF_BITS,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER_NOTSET,
+      0x8004, /* Invalid */
+      NULL);
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE_B,
+      0x8001, /* Invalid */
+      NULL);
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_remove (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      0x8001 /* Invalid */
+   );
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE_B,
+      0x8004, /* Invalid */
+      NULL);
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_remove (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      0x8004 /* Invalid */
+   );
+   EXPECT_EQ (ret, -1);
+
+   TEST_TRACE ("\nError checking for low-level functionality. Channel error "
+               "type given for custom USI.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      TEST_CHANNEL_ERRORTYPE,
+      0, /* Ext channel error type */
+      0, /* Add value */
+      TEST_DIAG_QUALIFIER_NOTSET,
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABCD");
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      0, /* Extended hannel error type */
+      0, /* Add value */
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABCD");
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_remove (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      0, /* Ext channel error type */
+      TEST_DIAG_USI_CUSTOM);
+   EXPECT_EQ (ret, -1);
+
+   TEST_TRACE ("\nError checking for low-level functionality. Ext channel "
+               "error type given for custom USI.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      0, /* Channel error type */
+      TEST_DIAG_EXT_ERRTYPE,
+      0, /* Add value */
+      TEST_DIAG_QUALIFIER_NOTSET,
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABCD");
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      0, /* Channel error type */
+      TEST_DIAG_EXT_ERRTYPE,
+      0, /* Add value */
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABC2");
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_remove (
+      net,
+      &diag_source,
+      0, /* Channel error type */
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_USI_CUSTOM);
+   EXPECT_EQ (ret, -1);
+
+   TEST_TRACE ("\nError checking for low-level functionality. Channel "
+               "additional value given for custom USI.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      0, /* Channel error type */
+      0, /* Ext channel error type */
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER_NOTSET,
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABCD");
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      0, /* Channel error type */
+      0, /* Ext channel error type */
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABC2");
+   EXPECT_EQ (ret, -1);
+
+   TEST_TRACE ("\nError checking for low-level functionality. Qualifier given "
+               "for custom USI.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      PNET_DIAG_CH_PROP_TYPE_UNSPECIFIED,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      0, /* Channel error type */
+      0, /* Ext channel error type */
+      0, /* Add value */
+      TEST_DIAG_QUALIFIER,
+      TEST_DIAG_USI_CUSTOM,
+      (uint8_t *)"ABCD");
+   EXPECT_EQ (ret, -1);
+
+   TEST_TRACE ("\nError checking for low-level functionality. Manufacturer "
+               "data given for standard USI.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      TEST_CHANNEL_NUMBER_OF_BITS,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER_NOTSET,
+      0x8003, /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+      (uint8_t *)"ABCD");
+   EXPECT_EQ (ret, -1);
+
+   ret = pnet_diag_update (
+      net,
+      &diag_source,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE_B,
+      0x8003, /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+      (uint8_t *)"ABCD");
+   EXPECT_EQ (ret, -1);
+
+   TEST_TRACE ("\nError checking for low-level functionality. Qualifier given "
+               "for non-qualifyer USI.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      TEST_CHANNEL_NUMBER_OF_BITS,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER,
+      0x8002, /* PF_USI_EXTENDED_CHANNEL_DIAGNOSIS */
+      NULL);
+   EXPECT_EQ (ret, -1);
+
+   TEST_TRACE ("\nError checking for low-level functionality. Qualifier given "
+               "for wrong severity.\n");
+   ret = pnet_diag_add (
+      net,
+      &diag_source,
+      TEST_CHANNEL_NUMBER_OF_BITS,
+      PNET_DIAG_CH_PROP_MAINT_FAULT,
+      TEST_CHANNEL_ERRORTYPE,
+      TEST_DIAG_EXT_ERRTYPE,
+      TEST_DIAG_EXT_ADDVALUE,
+      TEST_DIAG_QUALIFIER,
+      0x8003, /* PF_USI_QUALIFIED_CHANNEL_DIAGNOSIS */
+      NULL);
    EXPECT_EQ (ret, -1);
 
    TEST_TRACE ("\nGenerating mock release request\n");

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -547,6 +547,9 @@ void PnetIntegrationTestBase::cfg_init()
 
    /* Storage */
    strcpy (pnet_default_cfg.file_directory, "/disk1");
+
+   /* Diagnosis */
+   pnet_default_cfg.use_qualified_diagnosis = true;
 }
 
 void PnetIntegrationTestBase::run_stack (int us)


### PR DESCRIPTION
This is requested by users that use p-net for testing of
IO-controller applications.

Add configuration flag for default diagnosis mechanism
Also improve argument validation to diagnosis functions.