### PR TITLE
Update rt-kernel patch file

### DIFF
--- a/src/ports/rt-kernel/0001-rtkernel-for-Profinet.patch
+++ b/src/ports/rt-kernel/0001-rtkernel-for-Profinet.patch
@@ -1,4 +1,4 @@
-From 9b158e79a2e7183fbfebce9fee53347714009e35 Mon Sep 17 00:00:00 2001
+From 99e92d1aa8c248abf0a6484c16f7aaea81ef0387 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fredrik=20M=C3=B6ller?= <fredrik.moller@rt-labs.com>
 Date: Tue, 15 Sep 2020 18:22:53 +0200
 Subject: [PATCH] rtkernel for Profinet
@@ -6,25 +6,32 @@ Subject: [PATCH] rtkernel for Profinet
 Changes made to rt-kernel tree from rt-collab
 Toolbox 2020.1 as to support the p-net Profinet
 stack:
-- lwip: Build SNMP server. Discard invalid UDP
-  packets. VLAN tag support.
-- bsp/xmc48relax: Static IP addressing. Increase
-  stack sizes for main() and Ethernet driver
-  tasks. Put .bss in different memory section.
+- lwip:
+  - Build SNMP server.
+  - Fix SNMP ifDescr in ifTable.
+  - Discard invalid UDP packets.
+  - VLAN tag support.
+- bsp/xmc48relax:
+  - Static IP addressing.
+  - Increase stack size for main task.
+  - Increase stack size for Ethernet driver task.
+  - Put .bss and heap in 256kB memory section.
 ---
- bsp/xmc48relax/include/config.h  | 10 +++++-----
- bsp/xmc48relax/src/lwip.c        |  2 +-
- bsp/xmc48relax/xmc48relax.ld     |  2 +-
- lwip/src/apps/Makefile           | 12 ++++++++++++
- lwip/src/apps/snmp/Makefile      | 16 ++++++++++++++++
- lwip/src/core/udp.c              | 12 ++++++++++++
- lwip/src/include/lwip/lwipopts.h | 23 ++++++++++++++++++++++-
- 7 files changed, 69 insertions(+), 8 deletions(-)
+ bsp/xmc48relax/include/config.h           | 10 ++++-----
+ bsp/xmc48relax/src/lwip.c                 |  2 +-
+ bsp/xmc48relax/xmc48relax.ld              | 26 +++++++++++++----------
+ kern/arch/xmc4/hal.h                      |  2 +-
+ lwip/src/apps/Makefile                    | 12 +++++++++++
+ lwip/src/apps/snmp/Makefile               | 16 ++++++++++++++
+ lwip/src/apps/snmp/snmp_mib2_interfaces.c |  6 ++++--
+ lwip/src/core/udp.c                       | 12 +++++++++++
+ lwip/src/include/lwip/lwipopts.h          | 23 +++++++++++++++++++-
+ 9 files changed, 88 insertions(+), 21 deletions(-)
  create mode 100644 lwip/src/apps/Makefile
  create mode 100644 lwip/src/apps/snmp/Makefile
 
 diff --git a/bsp/xmc48relax/include/config.h b/bsp/xmc48relax/include/config.h
-index 850ce674..de1e7de7 100644
+index 850ce674..07d80b1e 100644
 --- a/bsp/xmc48relax/include/config.h
 +++ b/bsp/xmc48relax/include/config.h
 @@ -53,14 +53,14 @@
@@ -37,11 +44,11 @@ index 850ce674..de1e7de7 100644
     #define CFG_LWIP_HOSTNAME       "xmc48relax"
  #else
 -   #define CFG_LWIP_IPADDR()       IP4_ADDR (&ipaddr, 192, 168, 10, 171)
-+   #define CFG_LWIP_IPADDR()       IP4_ADDR (&ipaddr, 192, 168, 137, 4)
++   #define CFG_LWIP_IPADDR()       IP4_ADDR (&ipaddr, 192, 168, 0, 50)
     #define CFG_LWIP_NETMASK()      IP4_ADDR (&netmask, 255, 255, 255, 0)
 -   #define CFG_LWIP_GATEWAY()      IP4_ADDR (&gw, 192, 168, 10, 1)
 -   #define CFG_LWIP_NAMESERVER()   IP4_ADDR (&nameserver, 192, 168, 10, 4)
-+   #define CFG_LWIP_GATEWAY()      IP4_ADDR (&gw, 192, 168, 137, 1)
++   #define CFG_LWIP_GATEWAY()      IP4_ADDR (&gw, 192, 168, 0, 1)
 +   #define CFG_LWIP_NAMESERVER()   IP4_ADDR (&nameserver, 0, 0, 0, 0)
  #endif
  
@@ -56,7 +63,7 @@ index 850ce674..de1e7de7 100644
  /* Configure the priority of the main task. */
  #define CFG_MAIN_PRIORITY       10
 diff --git a/bsp/xmc48relax/src/lwip.c b/bsp/xmc48relax/src/lwip.c
-index f8b7d94a..49780cc4 100644
+index f8b7d94a..accb0f7d 100644
 --- a/bsp/xmc48relax/src/lwip.c
 +++ b/bsp/xmc48relax/src/lwip.c
 @@ -95,7 +95,7 @@ err_t bsp_eth_init (struct netif * netif)
@@ -64,23 +71,92 @@ index f8b7d94a..49780cc4 100644
        .tx_buffers    = 5,
        .rx_task_prio  = TCPIP_THREAD_PRIO - 1,
 -      .rx_task_stack = 1100,
-+      .rx_task_stack = 4000,
++      .rx_task_stack = 6000,
        .mac_address   = CFG_LWIP_MAC_ADDRESS,
     };
  #ifdef CFG_RTC_INIT
 diff --git a/bsp/xmc48relax/xmc48relax.ld b/bsp/xmc48relax/xmc48relax.ld
-index e59a5939..a338c463 100644
+index e59a5939..bf075030 100644
 --- a/bsp/xmc48relax/xmc48relax.ld
 +++ b/bsp/xmc48relax/xmc48relax.ld
-@@ -97,7 +97,7 @@ SECTIONS
-         event_start = .;
-         KEEP (*(.event));
-         event_end = .;
+@@ -18,6 +18,7 @@ EXTERN(vectors)
+  * sram: The Code RAM is intended for user code or Operating System data storage. The
+  * memory is accessed via the Bus Matrix and provides zero-wait-state access for the CPU
+  * for code execution or data access.
++ * NOTE: May not be used by USB and ETH modules.
+  *
+  * sdsram: The System RAM is intended for general user data storage. The System RAM is
+  * accessed via the Bus Matrix and provides zero-wait-state access for data.
+@@ -30,8 +31,7 @@ MEMORY
+ {
+    flash : org = 0x08000000, len = 2M
+    sram  : org = 0x1FFE8000, len = 96K
+-   sdsram : org = 0x20000000, len = 128K
+-   cdsram : org = 0x20020000, len = 128K
++   ram   : org = 0x20000000, len = 256K /* sdsram + cdsram */
+ }
+ 
+ SECTIONS
+@@ -85,19 +85,23 @@ SECTIONS
+ 
+    /* Put the IRQ-stack at the start of RAM as to
+     * provoke CPU exception upon overflow. */
+-   .bss :
++   .os_stuff :
+    {
+         KEEP (*(.irqstack));
+         irq_stack_top = .;
++        event_start = .;
++        KEEP (*(.event));
++        event_end = .;
++   } > sram
++
++   .bss :
++   {
+         bss_start = .;
+         *(.bss*)
+         *(COMMON)
+         . = ALIGN(4);
+         bss_end = .;
+-        event_start = .;
+-        KEEP (*(.event));
+-        event_end = .;
 -   } > sram
-+   } > cdsram
++   } > ram
  
     .data : AT (data_start_rom)
     {
+@@ -106,13 +110,13 @@ SECTIONS
+         *(.data*)
+         . = ALIGN(4);
+         data_end_ram = .;
+-   } > sram
++   } > ram
+ 
+    .heap :
+    {
+-    	heap_start = .;
+-   } > sdsram
++      heap_start = .;
++   } > ram
+    
+-   heap_end = ORIGIN(sdsram) + LENGTH(sdsram);
++   heap_end = ORIGIN(ram) + LENGTH(ram);
+    heap_size = heap_end - heap_start;
+ }
+diff --git a/kern/arch/xmc4/hal.h b/kern/arch/xmc4/hal.h
+index 8508b3cf..8cda1255 100644
+--- a/kern/arch/xmc4/hal.h
++++ b/kern/arch/xmc4/hal.h
+@@ -18,7 +18,7 @@
+ 
+ /* Set the maximum allocation size in bytes per malloc.
+  * Maximum size is 2^HAL_MAXIMUM_ALLOCATION_SIZE_POWER bytes */
+-#define HAL_MAXIMUM_ALLOCATION_SIZE_POWER 17 /* 128 kB */
++#define HAL_MAXIMUM_ALLOCATION_SIZE_POWER 18 /* 256 kB */
+ 
+ /* This macro enables interrupts globally. */
+ #define HAL_INTERRUPT_UNLOCK()                  \
 diff --git a/lwip/src/apps/Makefile b/lwip/src/apps/Makefile
 new file mode 100644
 index 00000000..e92bb4ee
@@ -121,6 +197,30 @@ index 00000000..e1383bfe
 +override EXTRA_CFLAGS += -Wno-enum-compare
 +
 +include $(PRJ_ROOT)/make/subdir.mk
+diff --git a/lwip/src/apps/snmp/snmp_mib2_interfaces.c b/lwip/src/apps/snmp/snmp_mib2_interfaces.c
+index 979b5073..e38d79a1 100644
+--- a/lwip/src/apps/snmp/snmp_mib2_interfaces.c
++++ b/lwip/src/apps/snmp/snmp_mib2_interfaces.c
+@@ -165,6 +165,7 @@ interfaces_Table_get_value(struct snmp_node_instance* instance, void* value)
+   struct netif *netif = (struct netif*)instance->reference.ptr;
+   u32_t* value_u32 = (u32_t*)value;
+   s32_t* value_s32 = (s32_t*)value;
++  char* value_string = (char*)value;
+   u16_t value_len;
+ 
+   switch (SNMP_TABLE_GET_COLUMN_FROM_OID(instance->instance_oid.id))
+@@ -174,8 +175,9 @@ interfaces_Table_get_value(struct snmp_node_instance* instance, void* value)
+     value_len = sizeof(*value_s32);
+     break;
+   case 2: /* ifDescr */
+-    value_len = sizeof(netif->name);
+-    MEMCPY(value, netif->name, value_len);
++    value_len = sizeof(netif->name) + 1;
++    MEMCPY(value_string, netif->name, sizeof(netif->name));
++    value_string[sizeof(netif->name)] = '0' + netif->num;
+     break;
+   case 3: /* ifType */
+     *value_s32 = netif->link_type;
 diff --git a/lwip/src/core/udp.c b/lwip/src/core/udp.c
 index ce2e3d29..7946cb05 100644
 --- a/lwip/src/core/udp.c


### PR DESCRIPTION
* Fix a defect in SNMP where wrong interface
  name (ifDescr) would be returned.
* Change IP address to 192.168.0.50 as to align
  with documentation.
* Put all RAM in a single memory section as to
  allow for a larger heap. This enables the full
  unit test program to run.
* Increase stack size for the Ethernet receive
  task as to avoid overflow when running
  ART Tester.