### PR TITLE
PD Interface Adjust / LLPD name Of station mode

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1161,14 +1161,14 @@ typedef struct pnet_ethaddr
 #define PNET_STATION_NAME_MAX_SIZE (241)
 
 /* Including termination. Standard says 14 (without termination) */
-#define PNET_PORT_ID_MAX_SIZE (15)
+#define PNET_PORT_NAME_MAX_SIZE (15)
 
 /** Including termination */
 #define PNET_LLDP_CHASSIS_ID_MAX_SIZE (PNET_CHASSIS_ID_MAX_SIZE)
 
 /** Including termination */
 #define PNET_LLDP_PORT_ID_MAX_SIZE                                             \
-   (PNET_STATION_NAME_MAX_SIZE + PNET_PORT_ID_MAX_SIZE)
+   (PNET_STATION_NAME_MAX_SIZE + PNET_PORT_NAME_MAX_SIZE)
 
 /**
  * Network interface
@@ -1185,7 +1185,7 @@ typedef struct pnet_netif
 typedef struct pnet_port_cfg
 {
    pnet_netif_t phy_port;
-   char port_id[PNET_LLDP_PORT_ID_MAX_SIZE]; /**< Terminated string */
+   char port_name[PNET_PORT_NAME_MAX_SIZE]; /**< Terminated string */
    uint16_t rtclass_2_status;
    uint16_t rtclass_3_status;
 } pnet_port_cfg_t;
@@ -1214,7 +1214,7 @@ typedef struct pnet_ip_cfg
 typedef struct pnet_if_cfg
 {
    pnet_netif_t main_port; /**< Main (DAP) network interface. */
-   pnet_ip_cfg_t ip_cfg; /**< IP Settings for main network interface */
+   pnet_ip_cfg_t ip_cfg;   /**< IP Settings for main network interface */
 
    pnet_port_cfg_t ports[PNET_MAX_PORT]; /**< Physical ports (DAP ports) */
 } pnet_if_cfg_t;

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -1395,8 +1395,8 @@ int app_pnet_cfg_init_default (pnet_cfg_t * stack_config)
    for (i = 0; i < PNET_MAX_PORT; i++)
    {
       snprintf (
-         stack_config->if_cfg.ports[i].port_id,
-         PNET_LLDP_PORT_ID_MAX_SIZE,
+         stack_config->if_cfg.ports[i].port_name,
+         sizeof (stack_config->if_cfg.ports[i].port_name),
          "port-%03d",
          i + 1);
       stack_config->if_cfg.ports[i].rtclass_2_status = 0;

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -19,6 +19,9 @@
 #define pnal_eth_get_status         mock_pnal_eth_get_status
 #endif
 
+#define STRINGIFY(s)   STRINGIFIED (s)
+#define STRINGIFIED(s) #s
+
 /**
  * @file
  * @brief Implements Link Layer Discovery Protocol (LLDP), for neighbourhood
@@ -280,27 +283,23 @@ static void pf_lldp_add_chassis_id_tlv (
 /**
  * @internal
  * Insert the mandatory port_id TLV into a buffer.
- * @param p_port_cfg       In:    LLDP configuration for this port
+ * @param p_port_id        In:    Port Id
  * @param p_buf            InOut: The buffer.
  * @param p_pos            InOut: The position in the buffer.
  */
 static void pf_lldp_add_port_id_tlv (
-   const pnet_port_cfg_t * p_port_cfg,
+   const pf_lldp_port_id_t * p_port_id,
    uint8_t * p_buf,
    uint16_t * p_pos)
 {
-   uint16_t len;
-
-   len = (uint16_t)strlen (p_port_cfg->port_id);
-
-   pf_lldp_add_tlv_header (p_buf, p_pos, LLDP_TYPE_PORT_ID, 1 + len);
-
-   pf_put_byte (
-      PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED,
+   pf_lldp_add_tlv_header (p_buf, p_pos, LLDP_TYPE_PORT_ID, 1 + p_port_id->len);
+   pf_put_byte (p_port_id->subtype, PF_FRAME_BUFFER_SIZE, p_buf, p_pos);
+   pf_put_mem (
+      p_port_id->string,
+      p_port_id->len,
       PF_FRAME_BUFFER_SIZE,
       p_buf,
       p_pos);
-   pf_put_mem (p_port_cfg->port_id, len, PF_FRAME_BUFFER_SIZE, p_buf, p_pos);
 }
 
 /**
@@ -575,34 +574,42 @@ void pf_lldp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id)
       pf_cmina_get_device_macaddr (net);
    char station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated */
 
-   /* Try to use NameOfStation as Chassis ID.
-    *
-    * FIXME: Use of pf_cmina_get_station_name() is not thread-safe.
-    * Fix this, e.g. using a mutex.
-    *
-    * TODO: Add option to use SystemIdentification as Chassis ID.
-    * See IEC61158-6-10 table 361.
-    */
-   pf_cmina_get_station_name (net, station_name);
+   if (net->interface.name_of_device_mode == PF_LLDP_NAME_OF_DEVICE_MODE_LEGACY)
+   {
+      /*
+       * FIXME: Use of pf_cmina_get_station_name() is not thread-safe.
+       * Fix this, e.g. using a mutex.
+       */
+      pf_cmina_get_station_name (net, station_name);
+      p_chassis_id->len = strlen (station_name);
 
-   p_chassis_id->len = strlen (station_name);
-   if (p_chassis_id->len == 0 || p_chassis_id->len >= PNET_LLDP_CHASSIS_ID_MAX_SIZE)
-   {
-      /* Use the device MAC address */
-      p_chassis_id->subtype = PF_LLDP_SUBTYPE_MAC;
-      p_chassis_id->len = sizeof (pnet_ethaddr_t);
-      memcpy (
-         p_chassis_id->string,
-         device_mac_address->addr,
-         sizeof (pnet_ethaddr_t));
+      if (
+         p_chassis_id->len == 0 ||
+         p_chassis_id->len >= PNET_LLDP_CHASSIS_ID_MAX_SIZE)
+      {
+         /* Use the device MAC address */
+         p_chassis_id->subtype = PF_LLDP_SUBTYPE_MAC;
+         p_chassis_id->len = sizeof (pnet_ethaddr_t);
+         memcpy (
+            p_chassis_id->string,
+            device_mac_address->addr,
+            sizeof (pnet_ethaddr_t));
+      }
+      else
+      {
+         /* Use the station name (NameOfStation/NameOfInterface) */
+         p_chassis_id->subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
+         memcpy (p_chassis_id->string, station_name, p_chassis_id->len);
+      }
    }
-   else
+   else /* PF_LLDP_NAME_OF_DEVICE_MODE_STANDARD */
    {
-      /* Use the locally assigned chassis ID name */
       p_chassis_id->subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
-      memcpy (p_chassis_id->string, station_name, p_chassis_id->len);
+      p_chassis_id->len = pf_lldp_get_system_description (
+         net,
+         p_chassis_id->string,
+         sizeof (p_chassis_id->string));
    }
-
    p_chassis_id->string[p_chassis_id->len] = '\0';
    p_chassis_id->is_valid = true;
 }
@@ -627,12 +634,35 @@ void pf_lldp_get_port_id (
    pf_lldp_port_id_t * p_port_id)
 {
    const pnet_port_cfg_t * p_port_cfg = pf_port_get_config (net, loc_port_num);
+   char station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated */
 
-   snprintf (
-      p_port_id->string,
-      sizeof (p_port_id->string),
-      "%s",
-      p_port_cfg->port_id);
+   if (net->interface.name_of_device_mode == PF_LLDP_NAME_OF_DEVICE_MODE_LEGACY)
+   {
+      snprintf (
+         p_port_id->string,
+         sizeof (p_port_id->string),
+         "%s",
+         p_port_cfg->port_name);
+   }
+   else /* PF_LLDP_NAME_OF_DEVICE_MODE_STANDARD */
+   {
+      pf_cmina_get_station_name (net, station_name);
+      if (strlen (station_name) == 0)
+      {
+         pf_lldp_mac_address_to_string (
+            p_port_cfg->phy_port.eth_addr.addr,
+            station_name,
+            sizeof (station_name));
+      }
+
+      snprintf (
+         p_port_id->string,
+         sizeof (p_port_id->string),
+         "%s.%s",
+         p_port_cfg->port_name,
+         station_name);
+   }
+
    p_port_id->subtype = PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED;
    p_port_id->len = strlen (p_port_id->string);
    p_port_id->is_valid = true;
@@ -719,26 +749,100 @@ int pf_lldp_get_peer_station_name (
    int loc_port_num,
    pf_lldp_station_name_t * p_station_name)
 {
-   bool is_received;
+   pf_lldp_chassis_id_t chassis_id;
+   pf_lldp_port_id_t port_id;
+   char * p;
+   bool found = false;
+
    const pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
+   memset (p_station_name, 0, sizeof (*p_station_name));
 
    os_mutex_lock (net->lldp_mutex);
-
-   /* Assume that peer's NameOfStation is the same as its ChassisId.
-    * TODO: Find out the correct way to choose what value to return.
-    * Value should be part of either received Chassis ID or Port ID.
-    */
-   memset (p_station_name, 0, sizeof (*p_station_name));
-   snprintf (
-      p_station_name->string,
-      sizeof (p_station_name->string),
-      "%s",
-      p_port_data->lldp.peer_info.chassis_id.string);
-   p_station_name->len = strlen (p_station_name->string);
-   is_received = p_port_data->lldp.peer_info.chassis_id.is_valid;
-
+   port_id = p_port_data->lldp.peer_info.port_id;
+   chassis_id = p_port_data->lldp.peer_info.chassis_id;
    os_mutex_unlock (net->lldp_mutex);
-   return is_received ? 0 : -1;
+
+   if (port_id.is_valid)
+   {
+      p = strchr (port_id.string, '.');
+      if (p != NULL)
+      {
+         /* PF_LLDP_NAME_OF_DEVICE_MODE_STANDARD
+          * Example: port-001.dut
+          */
+         snprintf (
+            p_station_name->string,
+            sizeof (p_station_name->string),
+            "%s",
+            p + 1);
+         found = true;
+      }
+   }
+
+   if (!found && chassis_id.is_valid)
+   {
+      /* PF_LLDP_NAME_OF_DEVICE_MODE_LEGACY */
+      if (chassis_id.subtype != PF_LLDP_SUBTYPE_MAC)
+      {
+         snprintf (
+            p_station_name->string,
+            sizeof (p_station_name->string),
+            "%s",
+            chassis_id.string);
+      }
+      else
+      {
+         pf_lldp_mac_address_to_string (
+            (uint8_t *)chassis_id.string,
+            p_station_name->string,
+            sizeof (p_station_name->string));
+      }
+      found = true;
+   }
+
+   /* Do not use peer mac address here since its status is unknown. */
+
+   p_station_name->len = strlen (p_station_name->string);
+
+   return p_station_name->len ? 0 : -1;
+}
+
+int pf_lldp_get_peer_port_name (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_port_name_t * p_port_name)
+{
+   pf_lldp_port_id_t port_id;
+   uint16_t i;
+   const pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
+   memset (p_port_name, 0, sizeof (*p_port_name));
+
+   os_mutex_lock (net->lldp_mutex);
+   port_id = p_port_data->lldp.peer_info.port_id;
+   os_mutex_unlock (net->lldp_mutex);
+
+   if (port_id.is_valid)
+   {
+      for (i = 0; (i < port_id.len) && (port_id.string[i] != '\0') &&
+                  (i < (sizeof (p_port_name->string) - 1));
+           i++)
+      {
+         if (port_id.string[i] == '.')
+         {
+            /* PF_LLDP_NAME_OF_DEVICE_MODE_STANDARD */
+            break;
+         }
+         p_port_name->string[i] = port_id.string[i];
+      }
+
+      p_port_name->len = strlen (p_port_name->string);
+   }
+   else
+   {
+      return -1;
+   }
+
+   return p_port_name->len ? 0 : -1;
 }
 
 void pf_lldp_get_signal_delays (
@@ -812,6 +916,48 @@ int pf_lldp_get_peer_link_status (
    return p_link_status->is_valid ? 0 : -1;
 }
 
+size_t pf_lldp_get_system_description (
+   const pnet_t * net,
+   char * system_description,
+   size_t system_description_max_len)
+{
+   return snprintf (
+      system_description,
+      system_description_max_len,
+      /* clang-format off */
+      "%-" STRINGIFY (PNET_PRODUCT_NAME_MAX_LEN) "s "
+      "%-" STRINGIFY (PNET_ORDER_ID_MAX_LEN) "s "
+      "%-" STRINGIFY (PNET_SERIAL_NUMBER_MAX_LEN) "s "
+      "%5u "
+      "%c%3u%3u%3u",
+      /* clang-format on */
+      net->fspm_cfg.product_name,
+      net->fspm_cfg.im_0_data.im_order_id,
+      net->fspm_cfg.im_0_data.im_serial_number,
+      net->fspm_cfg.im_0_data.im_hardware_revision,
+      net->fspm_cfg.im_0_data.im_sw_revision_prefix,
+      net->fspm_cfg.im_0_data.im_sw_revision_functional_enhancement,
+      net->fspm_cfg.im_0_data.im_sw_revision_bug_fix,
+      net->fspm_cfg.im_0_data.im_sw_revision_internal_change);
+}
+
+void pf_lldp_mac_address_to_string (
+   const uint8_t * mac,
+   char * mac_str,
+   size_t mac_str_max_len)
+{
+   snprintf (
+      mac_str,
+      mac_str_max_len,
+      "%02X-%02X-%02X-%02X-%02X-%02X",
+      mac[0],
+      mac[1],
+      mac[2],
+      mac[3],
+      mac[4],
+      mac[5]);
+}
+
 /**
  * Construct Ethernet frame containing LLDP PDU as payload
  *
@@ -830,6 +976,7 @@ size_t pf_lldp_construct_frame (pnet_t * net, int loc_port_num, uint8_t buf[])
       pf_cmina_get_device_macaddr (net);
    pf_lldp_link_status_t link_status;
    pf_lldp_chassis_id_t chassis_id;
+   pf_lldp_port_id_t port_id;
    pf_lldp_management_address_t man_address;
    const pnet_port_cfg_t * p_port_cfg = pf_port_get_config (net, loc_port_num);
 
@@ -838,7 +985,9 @@ size_t pf_lldp_construct_frame (pnet_t * net, int loc_port_num, uint8_t buf[])
    char ip_string[PNAL_INET_ADDRSTR_SIZE] = {0}; /** Terminated string */
    const char * chassis_id_description = "<MAC address>";
 #endif
+
    pf_lldp_get_chassis_id (net, &chassis_id);
+   pf_lldp_get_port_id (net, loc_port_num, &port_id);
    pf_lldp_get_link_status (net, loc_port_num, &link_status);
    pf_lldp_get_management_address (net, &man_address);
 #if LOG_DEBUG_ENABLED(PF_LLDP_LOG)
@@ -862,7 +1011,7 @@ size_t pf_lldp_construct_frame (pnet_t * net, int loc_port_num, uint8_t buf[])
       device_mac_address->addr[5],
       ip_string,
       chassis_id_description,
-      p_port_cfg->port_id);
+      port_id.string);
 #endif
 
    pos = 0;
@@ -875,7 +1024,7 @@ size_t pf_lldp_construct_frame (pnet_t * net, int loc_port_num, uint8_t buf[])
 
    /* Add mandatory parts */
    pf_lldp_add_chassis_id_tlv (&chassis_id, buf, &pos);
-   pf_lldp_add_port_id_tlv (p_port_cfg, buf, &pos);
+   pf_lldp_add_port_id_tlv (&port_id, buf, &pos);
    pf_lldp_add_ttl_tlv (buf, &pos);
 
    /* Add optional parts */

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -220,6 +220,30 @@ int pf_lldp_get_peer_station_name (
    pf_lldp_station_name_t * p_station_name);
 
 /**
+ * Get port name for remote port connected to local port.
+ *
+ * The port name is typically a string "port-001" or "port-001-00000"
+ *
+ * Note that the remote device may have multiple ports. Only the remote
+ * port connected to the local port is relevant here.
+ *
+ * See Profinet 2.4 Protocol 4.3.1.4.17 "Coding of the field NameOfPort"
+ *
+ * @param net              In:    The p-net stack instance.
+ * @param loc_port_num     In:    Local port number for port directly
+ *                                connected to the remote device.
+ *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                See pf_port_get_list_of_ports().
+ * @param p_port_name      Out:   Port name of remote port.
+ * @return  0 if the operation succeeded.
+ *         -1 if an error occurred (no info from remote device received).
+ */
+int pf_lldp_get_peer_port_name (
+   pnet_t * net,
+   int loc_port_num,
+   pf_lldp_port_name_t * p_port_name);
+
+/**
  * Get measured signal delays on local port.
  *
  * If a signal delay was not measured, its value is zero.
@@ -292,6 +316,40 @@ int pf_lldp_get_peer_link_status (
    pnet_t * net,
    int loc_port_num,
    pf_lldp_link_status_t * p_link_status);
+
+/**
+ * Get formatted system description
+ *
+ * Encode as per Profinet specification:
+ * DeviceType, Blank, OrderID, Blank, IM_Serial_Number, Blank, HWRevision,
+ * Blank, SWRevisionPrefix, SWRevision.
+ *
+ * See IEC CDV 61158-6-10 (PN-AL-Protocol) ch. 5.1.2 "APDU abstract syntax",
+ * field "SystemIdentification".
+ *
+ * @param net                           In:    The p-net stack instance.
+ * @param system_description            Out:   System description. Terminated
+ *                                             string.
+ * @param system_description_max_len    In:    Size of buffer.
+ * return Length of resulting string.
+ */
+size_t pf_lldp_get_system_description (
+   const pnet_t * net,
+   char * system_description,
+   size_t system_description_max_len);
+
+/**
+ * Generate a string from a byte array representing
+ * a mac address. Format: "%02X-%02X-%02X-%02X-%02X-%02X".
+ *
+ * @param mac              In:  Mac address pointer.
+ * @param mac_str          Out: Formatted MAC address string, null-terminated.
+ * @param mac_str_max_len  In:  Max length of mac_str buffer.
+ */
+void pf_lldp_mac_address_to_string (
+   const uint8_t * mac,
+   char * mac_str,
+   size_t mac_str_max_len);
 
 /**
  * Initialize the LLDP component.

--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -354,31 +354,10 @@ void pf_snmp_get_system_description (
    pnet_t * net,
    pf_snmp_system_description_t * description)
 {
-   /* Encode as per Profinet specification:
-    * DeviceType, Blank, OrderID, Blank, IM_Serial_Number, Blank, HWRevision,
-    * Blank, SWRevisionPrefix, SWRevision.
-    *
-    * See IEC CDV 61158-6-10 (PN-AL-Protocol) ch. 5.1.2 "APDU abstract syntax",
-    * field "SystemIdentification".
-    */
-   snprintf (
+   (void)pf_lldp_get_system_description (
+      net,
       description->string,
-      sizeof (description->string),
-      /* clang-format off */
-      "%-" STRINGIFY (PNET_PRODUCT_NAME_MAX_LEN) "s "
-      "%-" STRINGIFY (PNET_ORDER_ID_MAX_LEN) "s "
-      "%-" STRINGIFY (PNET_SERIAL_NUMBER_MAX_LEN) "s "
-      "%5u "
-      "%c%3u%3u%3u",
-      /* clang-format on */
-      net->fspm_cfg.product_name,
-      net->fspm_cfg.im_0_data.im_order_id,
-      net->fspm_cfg.im_0_data.im_serial_number,
-      net->fspm_cfg.im_0_data.im_hardware_revision,
-      net->fspm_cfg.im_0_data.im_sw_revision_prefix,
-      net->fspm_cfg.im_0_data.im_sw_revision_functional_enhancement,
-      net->fspm_cfg.im_0_data.im_sw_revision_bug_fix,
-      net->fspm_cfg.im_0_data.im_sw_revision_internal_change);
+      sizeof (description->string));
 }
 
 void pf_snmp_get_port_list (pnet_t * net, pf_lldp_port_list_t * p_list)

--- a/src/device/pf_block_reader.c
+++ b/src/device/pf_block_reader.c
@@ -1012,3 +1012,17 @@ void pf_get_port_data_adjust_peer_to_peer_boundary (
 
    p_boundary->adjust_properties = pf_get_uint16 (p_info, p_pos);
 }
+
+void pf_get_interface_adjust (
+   pf_get_info_t * p_info,
+   uint16_t * p_pos,
+   pf_lldp_name_of_device_mode_t * name_of_device_mode)
+{
+   uint8_t dummy[2];
+   uint32_t temp;
+
+   pf_get_mem (p_info, p_pos, 2, dummy); /* Padding */
+
+   temp = pf_get_uint32 (p_info, p_pos);
+   *name_of_device_mode = pf_get_bits (temp, 0, 1);
+}

--- a/src/device/pf_block_reader.h
+++ b/src/device/pf_block_reader.h
@@ -368,6 +368,18 @@ void pf_get_port_data_adjust_peer_to_peer_boundary (
    uint16_t * p_pos,
    pf_adjust_peer_to_peer_boundary_t * boundary);
 
+/**
+ * Extract a pd interface adjust block from a buffer.
+ *
+ * @param p_info           InOut: The parser information.
+ * @param p_pos            InOut: The current parsing position.
+ * @param mode             Out:   Multiple interface mode.
+ */
+void pf_get_interface_adjust (
+   pf_get_info_t * p_info,
+   uint16_t * p_pos,
+   pf_lldp_name_of_device_mode_t * name_of_device_mode);
+
 /************ Internal functions, made available for unit testing ************/
 
 uint32_t pf_get_bits (uint32_t bits, uint8_t pos, uint8_t len);

--- a/src/device/pf_block_writer.h
+++ b/src/device/pf_block_writer.h
@@ -739,6 +739,26 @@ void pf_put_pdport_data_adj (
    uint16_t * p_pos);
 
 /**
+ * Insert pd interface adjust block into a buffer.
+ * @param mode             In:    Multiple interface mode.
+ *                                (name of device mode)
+ * @param subslot          In:    DAP subslot identifying the interface
+ * @param is_big_endian    In:    Endianness of the destination buffer.
+ * @param p_res            In:    Read result
+ * @param res_len          In:    Size of destination buffer.
+ * @param p_bytes          Out:   Destination buffer.
+ * @param p_pos            InOut: Position in destination buffer.
+ */
+void pf_put_pd_interface_adj (
+   pf_lldp_name_of_device_mode_t name_of_device_mode,
+   uint16_t subslot,
+   bool is_big_endian,
+   const pf_iod_read_result_t * p_res,
+   uint16_t res_len,
+   uint8_t * p_bytes,
+   uint16_t * p_pos);
+
+/**
  * Insert pd port real data block into a buffer.
  *
  * Includes peer chassis ID, peer MAC address and peer MAU type.

--- a/src/device/pf_cmrdr.c
+++ b/src/device/pf_cmrdr.c
@@ -846,6 +846,7 @@ int pf_cmrdr_rm_read_ind (
       case PF_IDX_DEV_PDREAL_DATA:
       case PF_IDX_DEV_PDEXP_DATA:
       case PF_IDX_SUB_PDPORT_STATISTIC:
+      case PF_IDX_SUB_PDINTF_ADJUST:
          ret = pf_pdport_read_ind (
             net,
             p_ar,
@@ -875,17 +876,6 @@ int pf_cmrdr_rm_read_ind (
          else
          {
             ret = -1;
-         }
-         break;
-      case PF_IDX_SUB_PDINTF_ADJUST:
-         /* Only check if this is the port subslot */
-         if (
-            (p_read_request->slot_number == PNET_SLOT_DAP_IDENT) &&
-            (p_read_request->subslot_number ==
-             PNET_SUBSLOT_DAP_INTERFACE_1_IDENT))
-         {
-            /* return ok */
-            ret = 0;
          }
          break;
       default:

--- a/src/device/pf_cmwrr.c
+++ b/src/device/pf_cmwrr.c
@@ -214,6 +214,7 @@ static int pf_cmwrr_write (
       {
       case PF_IDX_SUB_PDPORT_DATA_CHECK:
       case PF_IDX_SUB_PDPORT_DATA_ADJ:
+      case PF_IDX_SUB_PDINTF_ADJUST:
          ret = pf_pdport_write_req (
             net,
             p_ar,

--- a/src/device/pf_port.c
+++ b/src/device/pf_port.c
@@ -89,7 +89,7 @@ int pf_port_get_next (pf_port_iterator_t * p_iterator)
 pf_port_t * pf_port_get_state (pnet_t * net, int loc_port_num)
 {
    CC_ASSERT (loc_port_num > 0 && loc_port_num <= PNET_MAX_PORT);
-   return &net->port[loc_port_num - 1];
+   return &net->interface.port[loc_port_num - 1];
 }
 
 const pnet_port_cfg_t * pf_port_get_config (pnet_t * net, int loc_port_num)
@@ -132,7 +132,7 @@ int pf_port_get_port_number (pnet_t * net, pnal_eth_handle_t * eth_handle)
 
    for (loc_port_num = 1; loc_port_num <= PNET_MAX_PORT; loc_port_num++)
    {
-      if (net->port[loc_port_num - 1].eth_handle == eth_handle)
+      if (net->interface.port[loc_port_num - 1].eth_handle == eth_handle)
       {
          return loc_port_num;
       }

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -54,6 +54,7 @@ int pnet_init_only (pnet_t * net, const pnet_cfg_t * p_cfg)
    pf_dcp_exit (net); /* Prepare for re-init. */
    pf_dcp_init (net); /* Start DCP */
    pf_port_init (net);
+   net->interface.name_of_device_mode = PF_LLDP_NAME_OF_DEVICE_MODE_STANDARD;
    pf_lldp_init (net);
    pf_pdport_init (net);
 

--- a/test/test_lldp.cpp
+++ b/test/test_lldp.cpp
@@ -757,18 +757,16 @@ TEST_F (LldpTest, LldpGetChassisId)
 
    memset (&chassis_id, 0xff, sizeof (chassis_id));
 
-   /* Currently, the MAC address is used as Chassis ID */
    pf_lldp_get_chassis_id (net, &chassis_id);
-   EXPECT_EQ (chassis_id.subtype, PF_LLDP_SUBTYPE_MAC);
-   EXPECT_EQ (chassis_id.string[0], 0x12);
-   EXPECT_EQ (chassis_id.string[1], 0x34);
-   EXPECT_EQ (chassis_id.string[2], 0x00);
-   EXPECT_EQ (chassis_id.string[3], 0x78);
-   EXPECT_EQ (chassis_id.string[4], (char)0x90);
-   EXPECT_EQ (chassis_id.string[5], (char)0xab);
-   EXPECT_EQ (chassis_id.len, 6u);
-
-   /* TODO: Add test case for locally assigned Chassis ID */
+   EXPECT_EQ (chassis_id.subtype, PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED);
+   EXPECT_STREQ (
+      chassis_id.string,
+      "PNET unit tests           <orderid>            <serial nbr>         1 P "
+      " 0  0  0");
+   EXPECT_EQ (
+      chassis_id.len,
+      strlen ("PNET unit tests           <orderid>            <serial nbr>     "
+              "    1 P  0  0  0"));
 }
 
 TEST_F (LldpTest, LldpGetPortId)
@@ -779,8 +777,8 @@ TEST_F (LldpTest, LldpGetPortId)
 
    pf_lldp_get_port_id (net, LOCAL_PORT, &port_id);
    EXPECT_EQ (port_id.subtype, PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED);
-   EXPECT_STREQ (port_id.string, "port-001");
-   EXPECT_EQ (port_id.len, strlen ("port-001"));
+   EXPECT_STREQ (port_id.string, "port-001.12-34-00-78-90-AB");
+   EXPECT_EQ (port_id.len, strlen ("port-001.12-34-00-78-90-AB"));
 }
 
 TEST_F (LldpTest, LldpGetPortDescription)

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -496,7 +496,7 @@ void PnetIntegrationTestBase::cfg_init()
    strcpy (
       pnet_default_cfg.if_cfg.ports[0].phy_port.if_name,
       TEST_INTERFACE_NAME);
-   strcpy (pnet_default_cfg.if_cfg.ports[0].port_id, "port-001");
+   strcpy (pnet_default_cfg.if_cfg.ports[0].port_name, "port-001");
    pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[0] = 0x12;
    pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[1] = 0x34;
    pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[2] = 0x00;


### PR DESCRIPTION
Add PD Interface Adjust

- Handle lldp name of station mode
- Default name of station mode set to standard
- In lldp replace zero-len station name with mac
- Update tests