### PR TITLE
snmp: Don't return cached values on rt-kernel

### DIFF
--- a/cmake/rt-kernel.cmake
+++ b/cmake/rt-kernel.cmake
@@ -24,6 +24,7 @@ target_sources(profinet
   src/ports/rt-kernel/pnal_eth.c
   src/ports/rt-kernel/pnal_udp.c
   src/ports/rt-kernel/pnal_snmp.c
+  src/ports/rt-kernel/mib2_system.c
   src/ports/rt-kernel/lldp-mib.c
   src/ports/rt-kernel/lldp-ext-pno-mib.c
   src/ports/rt-kernel/lldp-ext-dot3-mib.c

--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -284,7 +284,7 @@ void pf_snmp_get_system_contact (
       contact->string[0] = '\0';
    }
    contact->string[sizeof (contact->string) - 1] = '\0';
-   pf_snmp_log_loaded_variable (error, "syContact", contact->string);
+   pf_snmp_log_loaded_variable (error, "sysContact", contact->string);
 }
 
 int pf_snmp_set_system_contact (

--- a/src/ports/rt-kernel/0001-rtkernel-for-Profinet.patch
+++ b/src/ports/rt-kernel/0001-rtkernel-for-Profinet.patch
@@ -1,4 +1,4 @@
-From 99e92d1aa8c248abf0a6484c16f7aaea81ef0387 Mon Sep 17 00:00:00 2001
+From 337d268fa4701e10cec14bedb9732d049ff3e387 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fredrik=20M=C3=B6ller?= <fredrik.moller@rt-labs.com>
 Date: Tue, 15 Sep 2020 18:22:53 +0200
 Subject: [PATCH] rtkernel for Profinet
@@ -8,6 +8,7 @@ Toolbox 2020.1 as to support the p-net Profinet
 stack:
 - lwip:
   - Build SNMP server.
+  - Add SNMP callbacks for MIB-II system variables.
   - Fix SNMP ifDescr in ifTable.
   - Discard invalid UDP packets.
   - VLAN tag support.
@@ -17,16 +18,18 @@ stack:
   - Increase stack size for Ethernet driver task.
   - Put .bss and heap in 256kB memory section.
 ---
- bsp/xmc48relax/include/config.h           | 10 ++++-----
- bsp/xmc48relax/src/lwip.c                 |  2 +-
- bsp/xmc48relax/xmc48relax.ld              | 26 +++++++++++++----------
- kern/arch/xmc4/hal.h                      |  2 +-
- lwip/src/apps/Makefile                    | 12 +++++++++++
- lwip/src/apps/snmp/Makefile               | 16 ++++++++++++++
- lwip/src/apps/snmp/snmp_mib2_interfaces.c |  6 ++++--
- lwip/src/core/udp.c                       | 12 +++++++++++
- lwip/src/include/lwip/lwipopts.h          | 23 +++++++++++++++++++-
- 9 files changed, 88 insertions(+), 21 deletions(-)
+ bsp/xmc48relax/include/config.h           |  10 +-
+ bsp/xmc48relax/src/lwip.c                 |   2 +-
+ bsp/xmc48relax/xmc48relax.ld              |  26 +-
+ kern/arch/xmc4/hal.h                      |   2 +-
+ lwip/src/apps/Makefile                    |  12 +
+ lwip/src/apps/snmp/Makefile               |  16 ++
+ lwip/src/apps/snmp/snmp_mib2_interfaces.c |   6 +-
+ lwip/src/apps/snmp/snmp_mib2_system.c     | 309 ++--------------------
+ lwip/src/core/udp.c                       |  12 +
+ lwip/src/include/lwip/apps/snmp_mib2.h    |  24 +-
+ lwip/src/include/lwip/lwipopts.h          |  23 +-
+ 11 files changed, 133 insertions(+), 309 deletions(-)
  create mode 100644 lwip/src/apps/Makefile
  create mode 100644 lwip/src/apps/snmp/Makefile
 
@@ -221,6 +224,349 @@ index 979b5073..e38d79a1 100644
      break;
    case 3: /* ifType */
      *value_s32 = netif->link_type;
+diff --git a/lwip/src/apps/snmp/snmp_mib2_system.c b/lwip/src/apps/snmp/snmp_mib2_system.c
+index 90e57805..0242ce5c 100644
+--- a/lwip/src/apps/snmp/snmp_mib2_system.c
++++ b/lwip/src/apps/snmp/snmp_mib2_system.c
+@@ -56,310 +56,57 @@
+ 
+ /* --- system .1.3.6.1.2.1.1 ----------------------------------------------------- */
+ 
+-/** mib-2.system.sysDescr */
+-static const u8_t   sysdescr_default[] = SNMP_LWIP_MIB2_SYSDESC;
+-static const u8_t*  sysdescr           = sysdescr_default;
+-static const u16_t* sysdescr_len       = NULL; /* use strlen for determining len */
+-
+-/** mib-2.system.sysContact */
+-static const u8_t   syscontact_default[]     = SNMP_LWIP_MIB2_SYSCONTACT;
+-static const u8_t*  syscontact               = syscontact_default;
+-static const u16_t* syscontact_len           = NULL; /* use strlen for determining len */
+-static u8_t*        syscontact_wr            = NULL; /* if writable, points to the same buffer as syscontact (required for correct constness) */
+-static u16_t*       syscontact_wr_len        = NULL; /* if writable, points to the same buffer as syscontact_len (required for correct constness) */
+-static u16_t        syscontact_bufsize       = 0;    /* 0=not writable */
+-
+-/** mib-2.system.sysName */
+-static const u8_t   sysname_default[]        = SNMP_LWIP_MIB2_SYSNAME;
+-static const u8_t*  sysname                  = sysname_default;
+-static const u16_t* sysname_len              = NULL; /* use strlen for determining len */
+-static u8_t*        sysname_wr               = NULL; /* if writable, points to the same buffer as sysname (required for correct constness) */
+-static u16_t*       sysname_wr_len           = NULL; /* if writable, points to the same buffer as sysname_len (required for correct constness) */
+-static u16_t        sysname_bufsize          = 0;    /* 0=not writable */
+-
+-/** mib-2.system.sysLocation */
+-static const u8_t   syslocation_default[]    = SNMP_LWIP_MIB2_SYSLOCATION;
+-static const u8_t*  syslocation              = syslocation_default;
+-static const u16_t* syslocation_len           = NULL; /* use strlen for determining len */
+-static u8_t*        syslocation_wr            = NULL; /* if writable, points to the same buffer as syslocation (required for correct constness) */
+-static u16_t*       syslocation_wr_len        = NULL; /* if writable, points to the same buffer as syslocation_len (required for correct constness) */
+-static u16_t        syslocation_bufsize       = 0;    /* 0=not writable */
+-
+-/**
+- * @ingroup snmp_mib2
+- * Initializes sysDescr pointers.
+- *
+- * @param str if non-NULL then copy str pointer
+- * @param len points to string length, excluding zero terminator
+- */
+-void
+-snmp_mib2_set_sysdescr(const u8_t *str, const u16_t *len)
+-{
+-  if (str != NULL) {
+-    sysdescr     = str;
+-    sysdescr_len = len;
+-  }
+-}
+-
+-/**
+- * @ingroup snmp_mib2
+- * Initializes sysContact pointers
+- *
+- * @param ocstr if non-NULL then copy str pointer
+- * @param ocstrlen points to string length, excluding zero terminator.
+- *        if set to NULL it is assumed that ocstr is NULL-terminated.
+- * @param bufsize size of the buffer in bytes.
+- *        (this is required because the buffer can be overwritten by snmp-set)
+- *        if ocstrlen is NULL buffer needs space for terminating 0 byte.
+- *        otherwise complete buffer is used for string.
+- *        if bufsize is set to 0, the value is regarded as read-only.
+- */
+-void
+-snmp_mib2_set_syscontact(u8_t *ocstr, u16_t *ocstrlen, u16_t bufsize)
+-{
+-  if (ocstr != NULL) {
+-    syscontact         = ocstr;
+-    syscontact_wr      = ocstr;
+-    syscontact_len     = ocstrlen;
+-    syscontact_wr_len  = ocstrlen;
+-    syscontact_bufsize = bufsize;
+-  }
+-}
+-
+-/**
+- * @ingroup snmp_mib2
+- * see \ref snmp_mib2_set_syscontact but set pointer to readonly memory
+- */
+-void
+-snmp_mib2_set_syscontact_readonly(const u8_t *ocstr, const u16_t *ocstrlen)
+-{
+-  if (ocstr != NULL) {
+-    syscontact         = ocstr;
+-    syscontact_len     = ocstrlen;
+-    syscontact_wr      = NULL;
+-    syscontact_wr_len  = NULL;
+-    syscontact_bufsize = 0;
+-  }
+-}
+-
+-
+-/**
+- * @ingroup snmp_mib2
+- * Initializes sysName pointers
+- *
+- * @param ocstr if non-NULL then copy str pointer
+- * @param ocstrlen points to string length, excluding zero terminator.
+- *        if set to NULL it is assumed that ocstr is NULL-terminated.
+- * @param bufsize size of the buffer in bytes.
+- *        (this is required because the buffer can be overwritten by snmp-set)
+- *        if ocstrlen is NULL buffer needs space for terminating 0 byte.
+- *        otherwise complete buffer is used for string.
+- *        if bufsize is set to 0, the value is regarded as read-only.
+- */
+-void
+-snmp_mib2_set_sysname(u8_t *ocstr, u16_t *ocstrlen, u16_t bufsize)
+-{
+-  if (ocstr != NULL) {
+-    sysname         = ocstr;
+-    sysname_wr      = ocstr;
+-    sysname_len     = ocstrlen;
+-    sysname_wr_len  = ocstrlen;
+-    sysname_bufsize = bufsize;
+-  }
+-}
+-
+-/**
+- * @ingroup snmp_mib2
+- * see \ref snmp_mib2_set_sysname but set pointer to readonly memory
+- */
+-void
+-snmp_mib2_set_sysname_readonly(const u8_t *ocstr, const u16_t *ocstrlen)
+-{
+-  if (ocstr != NULL) {
+-    sysname         = ocstr;
+-    sysname_len     = ocstrlen;
+-    sysname_wr      = NULL;
+-    sysname_wr_len  = NULL;
+-    sysname_bufsize = 0;
+-  }
+-}
+-
+-/**
+- * @ingroup snmp_mib2
+- * Initializes sysLocation pointers
+- *
+- * @param ocstr if non-NULL then copy str pointer
+- * @param ocstrlen points to string length, excluding zero terminator.
+- *        if set to NULL it is assumed that ocstr is NULL-terminated.
+- * @param bufsize size of the buffer in bytes.
+- *        (this is required because the buffer can be overwritten by snmp-set)
+- *        if ocstrlen is NULL buffer needs space for terminating 0 byte.
+- *        otherwise complete buffer is used for string.
+- *        if bufsize is set to 0, the value is regarded as read-only.
+- */
+-void
+-snmp_mib2_set_syslocation(u8_t *ocstr, u16_t *ocstrlen, u16_t bufsize)
+-{
+-  if (ocstr != NULL) {
+-    syslocation         = ocstr;
+-    syslocation_wr      = ocstr;
+-    syslocation_len     = ocstrlen;
+-    syslocation_wr_len  = ocstrlen;
+-    syslocation_bufsize = bufsize;
+-  }
+-}
+-
+-/**
+- * @ingroup snmp_mib2
+- * see \ref snmp_mib2_set_syslocation but set pointer to readonly memory
+- */
+-void
+-snmp_mib2_set_syslocation_readonly(const u8_t *ocstr, const u16_t *ocstrlen)
++static snmp_mib2_get_callback_fct snmp_mib2_system_get;
++static snmp_mib2_test_set_callback_fct snmp_mib2_system_test_set;
++static snmp_mib2_set_callback_fct snmp_mib2_system_set;
++
++void snmp_mib2_system_set_callbacks(
++  snmp_mib2_get_callback_fct get, 
++  snmp_mib2_test_set_callback_fct test_set,
++  snmp_mib2_set_callback_fct set)
+ {
+-  if (ocstr != NULL) {
+-    syslocation         = ocstr;
+-    syslocation_len     = ocstrlen;
+-    syslocation_wr      = NULL;
+-    syslocation_wr_len  = NULL;
+-    syslocation_bufsize = 0;
+-  }
++  snmp_mib2_system_get = get;
++  snmp_mib2_system_test_set = test_set;
++  snmp_mib2_system_set = set;
+ }
+ 
+-
+ static s16_t
+ system_get_value(const struct snmp_scalar_array_node_def *node, void *value)
+ {
+-  const u8_t*  var = NULL;
+-  const s16_t* var_len;
+-  u16_t result;
+-
+-  switch (node->oid) {
+-  case 1: /* sysDescr */
+-    var     = sysdescr;
+-    var_len = (const s16_t*)sysdescr_len;
+-    break;
+-  case 2: /* sysObjectID */
+-    {
+-      const struct snmp_obj_id* dev_enterprise_oid = snmp_get_device_enterprise_oid();
+-      MEMCPY(value, dev_enterprise_oid->id, dev_enterprise_oid->len * sizeof(u32_t));
+-      return dev_enterprise_oid->len * sizeof(u32_t);
+-    }
+-  case 3: /* sysUpTime */
+-    MIB2_COPY_SYSUPTIME_TO((u32_t*)value);
+-    return sizeof(u32_t);
+-  case 4: /* sysContact */
+-    var     = syscontact;
+-    var_len = (const s16_t*)syscontact_len;
+-    break;
+-  case 5: /* sysName */
+-    var     = sysname;
+-    var_len = (const s16_t*)sysname_len;
+-    break;
+-  case 6: /* sysLocation */
+-    var     = syslocation;
+-    var_len = (const s16_t*)syslocation_len;
+-    break;
+-  case 7: /* sysServices */
+-    *(s32_t*)value = SNMP_SYSSERVICES;
+-    return sizeof(s32_t);
+-  default:
+-    LWIP_DEBUGF(SNMP_MIB_DEBUG,("system_get_value(): unknown id: %"S32_F"\n", node->oid));
+-    return 0;
++  if (snmp_mib2_system_get == NULL)
++  {
++    return SNMP_ERR_GENERROR;
+   }
+-
+-  /* handle string values (OID 1,4,5 and 6) */
+-  LWIP_ASSERT("", (value != NULL));
+-  if (var_len == NULL) {
+-    result = (s16_t)strlen((const char*)var);
+-  } else {
+-    result = *var_len;
++  else
++  {
++    return snmp_mib2_system_get(node->oid, value, SNMP_MAX_VALUE_SIZE);
+   }
+-  MEMCPY(value, var, result);
+-  return result;
+ }
+ 
+ static snmp_err_t
+ system_set_test(const struct snmp_scalar_array_node_def *node, u16_t len, void *value)
+ {
+-  snmp_err_t ret = SNMP_ERR_WRONGVALUE;
+-  const u16_t* var_bufsize  = NULL;
+-  const u16_t* var_wr_len;
+-
+-  LWIP_UNUSED_ARG(value);
+-
+-  switch (node->oid) {
+-  case 4: /* sysContact */
+-    var_bufsize  = &syscontact_bufsize;
+-    var_wr_len   = syscontact_wr_len;
+-    break;
+-  case 5: /* sysName */
+-    var_bufsize  = &sysname_bufsize;
+-    var_wr_len   = sysname_wr_len;
+-    break;
+-  case 6: /* sysLocation */
+-    var_bufsize  = &syslocation_bufsize;
+-    var_wr_len   = syslocation_wr_len;
+-    break;
+-  default:
+-    LWIP_DEBUGF(SNMP_MIB_DEBUG,("system_set_test(): unknown id: %"S32_F"\n", node->oid));
+-    return ret;
++  if (snmp_mib2_system_test_set == NULL)
++  {
++    return SNMP_ERR_GENERROR;
+   }
+-
+-  /* check if value is writable at all */
+-  if (*var_bufsize > 0) {
+-    if (var_wr_len == NULL) {
+-      /* we have to take the terminating 0 into account */
+-      if (len < *var_bufsize) {
+-        ret = SNMP_ERR_NOERROR;
+-      }
+-    } else {
+-      if (len <= *var_bufsize) {
+-        ret = SNMP_ERR_NOERROR;
+-      }
+-    }
+-  } else {
+-    ret = SNMP_ERR_NOTWRITABLE;
++  else
++  {
++    return snmp_mib2_system_test_set(node->oid, value, len);
+   }
+-
+-  return ret;
+ }
+ 
+ static snmp_err_t
+ system_set_value(const struct snmp_scalar_array_node_def *node, u16_t len, void *value)
+ {
+-  u8_t*  var_wr = NULL;
+-  u16_t* var_wr_len;
+-
+-  switch (node->oid) {
+-  case 4: /* sysContact */
+-    var_wr     = syscontact_wr;
+-    var_wr_len = syscontact_wr_len;
+-    break;
+-  case 5: /* sysName */
+-    var_wr     = sysname_wr;
+-    var_wr_len = sysname_wr_len;
+-    break;
+-  case 6: /* sysLocation */
+-    var_wr     = syslocation_wr;
+-    var_wr_len = syslocation_wr_len;
+-    break;
+-  default:
+-    LWIP_DEBUGF(SNMP_MIB_DEBUG,("system_set_value(): unknown id: %"S32_F"\n", node->oid));
++  if (snmp_mib2_system_set == NULL)
++  {
+     return SNMP_ERR_GENERROR;
+   }
+-
+-  /* no need to check size of target buffer, this was already done in set_test method */
+-  LWIP_ASSERT("", var_wr != NULL);
+-  MEMCPY(var_wr, value, len);
+-  
+-  if (var_wr_len == NULL) {
+-    /* add terminating 0 */
+-    var_wr[len] = 0;
+-  } else {
+-    *var_wr_len = len;
++  else
++  {
++    return snmp_mib2_system_set(node->oid, value, len);
+   }
+-
+-  return SNMP_ERR_NOERROR;
+ }
+ 
+ static const struct snmp_scalar_array_node_def system_nodes[] = {
 diff --git a/lwip/src/core/udp.c b/lwip/src/core/udp.c
 index ce2e3d29..7946cb05 100644
 --- a/lwip/src/core/udp.c
@@ -244,8 +590,43 @@ index ce2e3d29..7946cb05 100644
      if (pcb != NULL) {
        MIB2_STATS_INC(mib2.udpindatagrams);
  #if SO_REUSE && SO_REUSE_RXTOALL
+diff --git a/lwip/src/include/lwip/apps/snmp_mib2.h b/lwip/src/include/lwip/apps/snmp_mib2.h
+index 2f4a6893..1df6bb0d 100644
+--- a/lwip/src/include/lwip/apps/snmp_mib2.h
++++ b/lwip/src/include/lwip/apps/snmp_mib2.h
+@@ -60,13 +60,23 @@ extern struct snmp_threadsync_instance snmp_mib2_lwip_locks;
+ #define SNMP_SYSSERVICES ((1 << 6) | (1 << 3) | ((IP_FORWARD) << 2))
+ #endif
+ 
+-void snmp_mib2_set_sysdescr(const u8_t* str, const u16_t* len); /* read-only be defintion */
+-void snmp_mib2_set_syscontact(u8_t *ocstr, u16_t *ocstrlen, u16_t bufsize);
+-void snmp_mib2_set_syscontact_readonly(const u8_t *ocstr, const u16_t *ocstrlen);
+-void snmp_mib2_set_sysname(u8_t *ocstr, u16_t *ocstrlen, u16_t bufsize);
+-void snmp_mib2_set_sysname_readonly(const u8_t *ocstr, const u16_t *ocstrlen);
+-void snmp_mib2_set_syslocation(u8_t *ocstr, u16_t *ocstrlen, u16_t bufsize);
+-void snmp_mib2_set_syslocation_readonly(const u8_t *ocstr, const u16_t *ocstrlen);
++typedef s16_t(*snmp_mib2_get_callback_fct)(
++   u32_t column,
++   void *value,
++   size_t size);
++typedef snmp_err_t(*snmp_mib2_test_set_callback_fct)(
++   u32_t column,
++   const void *value,
++   size_t size);
++typedef snmp_err_t(*snmp_mib2_set_callback_fct)(
++   u32_t column,
++   const void *value,
++   size_t size);
++
++void snmp_mib2_system_set_callbacks(
++  snmp_mib2_get_callback_fct get, 
++  snmp_mib2_test_set_callback_fct test_set,
++  snmp_mib2_set_callback_fct set);
+ 
+ #endif /* SNMP_LWIP_MIB2 */
+ #endif /* LWIP_SNMP */
 diff --git a/lwip/src/include/lwip/lwipopts.h b/lwip/src/include/lwip/lwipopts.h
-index c48a69b7..15141e15 100644
+index c48a69b7..941e6f9c 100644
 --- a/lwip/src/include/lwip/lwipopts.h
 +++ b/lwip/src/include/lwip/lwipopts.h
 @@ -49,7 +49,12 @@
@@ -285,7 +666,7 @@ index c48a69b7..15141e15 100644
  /* Stack sizes */
  #define DEFAULT_THREAD_STACKSIZE    1024
  #define TCPIP_THREAD_STACKSIZE      1768
-+#define SNMP_STACK_SIZE             3000
++#define SNMP_STACK_SIZE             4000
  
  /* TCPIP thread priority */
  #define TCPIP_THREAD_PRIO           5

--- a/src/ports/rt-kernel/mib2_system.c
+++ b/src/ports/rt-kernel/mib2_system.c
@@ -1,0 +1,418 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2021 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+/**
+ * @file
+ * @brief Functions for reading and writing SNMP MIB-II system variables
+ */
+
+#include "mib2_system.h"
+
+#include "options.h"
+#include "pnet_api.h"
+#include "osal.h"
+#include "osal_log.h"
+#include "pnal.h"
+#include "pf_types.h"
+#include "pf_snmp.h"
+#include "pnal_snmp.h"
+
+#include <string.h>
+
+/**
+ * Get value of sysDescr variable
+ *
+ * @param value            Out:   Buffer where value will be stored.
+ * @param max_size         In:    Size of buffer in bytes.
+ * @return Size of retrieved value (in bytes) if successful,
+ *         SNMP_ERR_GENERROR if buffer was too small.
+ */
+static s16_t system_get_description (void * value, size_t max_size)
+{
+   size_t size;
+   pf_snmp_system_description_t description;
+
+   pf_snmp_get_system_description (pnal_snmp.net, &description);
+
+   size = strlen (description.string);
+   if (size > max_size)
+   {
+      return SNMP_ERR_GENERROR;
+   }
+
+   memcpy (value, description.string, size);
+   return size;
+}
+
+/**
+ * Get value of sysObjectID variable
+ *
+ * @param value            Out:   Buffer where value will be stored.
+ * @param max_size         In:    Size of buffer in bytes.
+ * @return Size of retrieved value (in bytes) if successful,
+ *         SNMP_ERR_GENERROR if buffer was too small.
+ */
+static s16_t system_get_object_id (void * value, size_t max_size)
+{
+   size_t size;
+   const struct snmp_obj_id * dev_enterprise_oid =
+      snmp_get_device_enterprise_oid();
+
+   size = dev_enterprise_oid->len * sizeof (u32_t);
+   if (size > max_size)
+   {
+      return SNMP_ERR_GENERROR;
+   }
+
+   memcpy (value, dev_enterprise_oid->id, size);
+   return size;
+}
+
+/**
+ * Get value of sysUpTime variable
+ *
+ * @param value            Out:   Buffer where value will be stored.
+ * @param max_size         In:    Size of buffer in bytes.
+ * @return Size of retrieved value (in bytes) if successful,
+ *         SNMP_ERR_GENERROR if buffer was too small.
+ */
+static s16_t system_get_uptime (void * value, size_t max_size)
+{
+   u32_t * uptime = value;
+
+   *uptime = pnal_get_system_uptime_10ms();
+   return sizeof (*uptime);
+}
+
+/**
+ * Get value of sysContact variable
+ *
+ * @param value            Out:   Buffer where value will be stored.
+ * @param max_size         In:    Size of buffer in bytes.
+ * @return Size of retrieved value (in bytes) if successful,
+ *         SNMP_ERR_GENERROR if buffer was too small.
+ */
+static s16_t system_get_contact (void * value, size_t max_size)
+{
+   size_t size;
+   pf_snmp_system_contact_t contact;
+
+   pf_snmp_get_system_contact (pnal_snmp.net, &contact);
+
+   size = strlen (contact.string);
+   if (size > max_size)
+   {
+      return SNMP_ERR_GENERROR;
+   }
+
+   memcpy (value, contact.string, size);
+   return size;
+}
+
+/**
+ * Test if value could be set for sysContact variable
+ *
+ * @param value            In:    Buffer containing new value.
+ *                                Not null-terminated.
+ * @param size             In:    Size of \a value in bytes.
+ * @return SNMP_ERR_NOERROR if successful,
+ *         SNMP_ERR_WRONGVALUE if \a size is too large.
+ */
+static snmp_err_t system_test_contact (const void * value, size_t size)
+{
+   pf_snmp_system_contact_t contact;
+
+   if (size >= sizeof (contact.string))
+   {
+      return SNMP_ERR_WRONGVALUE;
+   }
+   else
+   {
+      return SNMP_ERR_NOERROR;
+   }
+}
+
+/**
+ * Set new value for sysContact variable
+ *
+ * Note that it has already been verified that \a size is not too large.
+ *
+ * @param value            In:    Buffer containing new value.
+ *                                Not null-terminated.
+ * @param size             In:    Size of \a value in bytes.
+ * @return SNMP_ERR_NOERROR if successful,
+ *         SNMP_ERR_GENERROR on error.
+ */
+static snmp_err_t system_set_contact (const void * value, size_t size)
+{
+   pf_snmp_system_contact_t contact;
+   int error;
+
+   memset (contact.string, '\0', sizeof (contact.string));
+   memcpy (contact.string, value, size);
+
+   error = pf_snmp_set_system_contact (pnal_snmp.net, &contact);
+   if (error)
+   {
+      return SNMP_ERR_GENERROR;
+   }
+   else
+   {
+      return SNMP_ERR_NOERROR;
+   }
+}
+
+/**
+ * Get value of sysName variable
+ *
+ * @param value            Out:   Buffer where value will be stored.
+ * @param max_size         In:    Size of buffer in bytes.
+ * @return Size of retrieved value (in bytes) if successful,
+ *         SNMP_ERR_GENERROR if buffer was too small.
+ */
+static s16_t system_get_name (void * value, size_t max_size)
+{
+   size_t size;
+   pf_snmp_system_name_t name;
+
+   pf_snmp_get_system_name (pnal_snmp.net, &name);
+
+   size = strlen (name.string);
+   if (size > max_size)
+   {
+      return SNMP_ERR_GENERROR;
+   }
+
+   memcpy (value, name.string, size);
+   return size;
+}
+
+/**
+ * Test if value could be set for sysName variable
+ *
+ * @param value            In:    Buffer containing new value.
+ *                                Not null-terminated.
+ * @param size             In:    Size of \a value in bytes.
+ * @return SNMP_ERR_NOERROR if successful,
+ *         SNMP_ERR_WRONGVALUE if \a size is too large.
+ */
+static snmp_err_t system_test_name (const void * value, size_t size)
+{
+   pf_snmp_system_name_t name;
+
+   if (size >= sizeof (name.string))
+   {
+      return SNMP_ERR_WRONGVALUE;
+   }
+   else
+   {
+      return SNMP_ERR_NOERROR;
+   }
+}
+
+/**
+ * Set new value for sysName variable
+ *
+ * Note that it has already been verified that \a size is not too large.
+ *
+ * @param value            In:    Buffer containing new value.
+ *                                Not null-terminated.
+ * @param size             In:    Size of \a value in bytes.
+ * @return SNMP_ERR_NOERROR if successful,
+ *         SNMP_ERR_GENERROR on error.
+ */
+static snmp_err_t system_set_name (const void * value, size_t size)
+{
+   pf_snmp_system_name_t name;
+   int error;
+
+   memset (name.string, '\0', sizeof (name.string));
+   memcpy (name.string, value, size);
+
+   error = pf_snmp_set_system_name (pnal_snmp.net, &name);
+   if (error)
+   {
+      return SNMP_ERR_GENERROR;
+   }
+   else
+   {
+      return SNMP_ERR_NOERROR;
+   }
+}
+
+/**
+ * Get value of sysLocation variable
+ *
+ * @param value            Out:   Buffer where value will be stored.
+ * @param max_size         In:    Size of buffer in bytes.
+ * @return Size of retrieved value (in bytes) if successful,
+ *         SNMP_ERR_GENERROR if buffer was too small.
+ */
+static s16_t system_get_location (void * value, size_t max_size)
+{
+   size_t size;
+   pf_snmp_system_location_t location;
+
+   pf_snmp_get_system_location (pnal_snmp.net, &location);
+
+   size = strlen (location.string);
+   if (size > max_size)
+   {
+      return SNMP_ERR_GENERROR;
+   }
+
+   memcpy (value, location.string, size);
+   return size;
+}
+
+/**
+ * Test if value could be set for sysLocation variable
+ *
+ * @param value            In:    Buffer containing new value.
+ *                                Not null-terminated.
+ * @param size             In:    Size of \a value in bytes.
+ * @return SNMP_ERR_NOERROR if successful,
+ *         SNMP_ERR_WRONGVALUE if \a size is too large.
+ */
+static snmp_err_t system_test_location (const void * value, size_t size)
+{
+   pf_snmp_system_location_t location;
+
+   if (size >= sizeof (location.string))
+   {
+      return SNMP_ERR_WRONGVALUE;
+   }
+   else
+   {
+      return SNMP_ERR_NOERROR;
+   }
+}
+
+/**
+ * Set new value for sysLocation variable
+ *
+ * Note that it has already been verified that \a size is not too large.
+ *
+ * @param value            In:    Buffer containing new value.
+ *                                Not null-terminated.
+ * @param size             In:    Size of \a value in bytes.
+ * @return SNMP_ERR_NOERROR if successful,
+ *         SNMP_ERR_GENERROR on error.
+ */
+static snmp_err_t system_set_location (const void * value, size_t size)
+{
+   pf_snmp_system_location_t location;
+   int error;
+
+   memset (location.string, '\0', sizeof (location.string));
+   memcpy (location.string, value, size);
+
+   error = pf_snmp_set_system_location (pnal_snmp.net, &location);
+   if (error)
+   {
+      return SNMP_ERR_GENERROR;
+   }
+   else
+   {
+      return SNMP_ERR_NOERROR;
+   }
+}
+
+/**
+ * Get value of sysServices variable
+ *
+ * @param value            Out:   Buffer where value will be stored.
+ * @param max_size         In:    Size of buffer in bytes.
+ * @return Size of retrieved value (in bytes) if successful,
+ *         SNMP_ERR_GENERROR if buffer was too small.
+ */
+static s16_t system_get_services (void * value, size_t max_size)
+{
+   s32_t * services = value;
+
+   *services = SNMP_SYSSERVICES;
+   return sizeof (*services);
+}
+
+s16_t mib2_system_get_value (u32_t column, void * value, size_t max_size)
+{
+   switch (column)
+   {
+   case 1: /* sysDescr */
+      return system_get_description (value, max_size);
+   case 2: /* sysObjectID */
+      return system_get_object_id (value, max_size);
+   case 3: /* sysUpTime */
+      return system_get_uptime (value, max_size);
+   case 4: /* sysContact */
+      return system_get_contact (value, max_size);
+   case 5: /* sysName */
+      return system_get_name (value, max_size);
+   case 6: /* sysLocation */
+      return system_get_location (value, max_size);
+   case 7: /* sysServices */
+      return system_get_services (value, max_size);
+   default:
+      LOG_ERROR (
+         PF_SNMP_LOG,
+         "MIB2.system(%d): Unknown column: %" PRIu32 ".\n",
+         __LINE__,
+         column);
+      return SNMP_ERR_GENERROR;
+   }
+}
+
+snmp_err_t mib2_system_test_set_value (
+   u32_t column,
+   const void * value,
+   size_t size)
+{
+   switch (column)
+   {
+   case 4: /* sysContact */
+      return system_test_contact (value, size);
+   case 5: /* sysName */
+      return system_test_name (value, size);
+   case 6: /* sysLocation */
+      return system_test_location (value, size);
+   default:
+      LOG_ERROR (
+         PF_SNMP_LOG,
+         "MIB2.system(%d): Unknown column: %" PRIu32 ".\n",
+         __LINE__,
+         column);
+      return SNMP_ERR_WRONGVALUE;
+   }
+}
+
+snmp_err_t mib2_system_set_value (u32_t column, const void * value, size_t size)
+{
+   switch (column)
+   {
+   case 4: /* sysContact */
+      return system_set_contact (value, size);
+   case 5: /* sysName */
+      return system_set_name (value, size);
+   case 6: /* sysLocation */
+      return system_set_location (value, size);
+   default:
+      LOG_ERROR (
+         PF_SNMP_LOG,
+         "MIB2.system(%d): Unknown column: %" PRIu32 ".\n",
+         __LINE__,
+         column);
+      return SNMP_ERR_GENERROR;
+   }
+}

--- a/src/ports/rt-kernel/mib2_system.h
+++ b/src/ports/rt-kernel/mib2_system.h
@@ -1,0 +1,91 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2021 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+/**
+ * @file
+ * @brief Functions for reading and writing SNMP MIB-II system variables
+ *
+ * These functions should be used as callback functions to be called from the
+ * lwip stack when SNMP Get/GetNext or Set requests are received for variables
+ * in the system group (OID 1.3.6.1.2.1.1). The appropriate functions in
+ * the p-net stack will be called as needed. For configuringlwip to use these,
+ * functions, call snmp_mib2_system_set_callbacks().
+ *
+ * Note that it is assumed that a patched version of lwip is used.
+ * The original version of lwip does not provide callback functions to read
+ * variables in SNMP Get/GetNext requests.
+ */
+
+#ifndef MIB2_SYSTEM_H
+#define MIB2_SYSTEM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <lwip/apps/snmp.h>
+
+/**
+ * Get value of system variable
+ *
+ * This function should be called when an SNMP Get or GetNext request
+ * is received.
+ *
+ * @param column           In:    Column index for system variable.
+ * @param value            Out:   Buffer where value will be stored.
+ * @param max_size         In:    Size of buffer in bytes.
+ * @return Size of retrieved value if successful,
+ *         SNMP_ERR_GENERROR if an error occurred.
+ */
+s16_t mib2_system_get_value (u32_t column, void * value, size_t max_size);
+
+/**
+ * Test if value could be set for system variable
+ *
+ * This function should be called when an SNMP Set request is received.
+ *
+ * @param column           In:    Column index for system variable.
+ * @param value            In:    Buffer containing the new value.
+ *                                Is not null-terminated.
+ * @param size             In:    Size of \a value in bytes.
+ * @return SNMP_ERR_NOERROR if successful,
+ *         SNMP_ERR_WRONGVALUE if \a len is too large.
+ */
+snmp_err_t mib2_system_test_set_value (
+   u32_t column,
+   const void * value,
+   size_t size);
+
+/**
+ * Set new value for system variable
+ *
+ * This function should be called when an SNMP Set request is received
+ * after first calling mib2_system_test_set_value() to verify
+ * that \a size is not too large.
+ *
+ * @param column           In:    Column index for system variable.
+ * @param value            In:    Buffer containing the new value.
+ *                                Is not null-terminated.
+ * @param size             In:    Size of \a value in bytes.
+ * @return SNMP_ERR_NOERROR if successful,
+ *         SNMP_ERR_GENERROR on error.
+ */
+snmp_err_t mib2_system_set_value (u32_t column, const void * value, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MIB2_SYSTEM_H */

--- a/src/ports/rt-kernel/pnal_snmp.h
+++ b/src/ports/rt-kernel/pnal_snmp.h
@@ -17,7 +17,7 @@
  * @file
  * @brief SNMP server for rt-kernel
  *
- * Uses the SNMP server implementation supplied by lwip.
+ * Uses (a patched version of) the SNMP server implementation supplied by lwip.
  * Access to Profinet stack is done through the platform-independent internal
  * API, pf_snmp.h. Supported MIBs:
  * - MIB-II,
@@ -61,11 +61,6 @@ typedef struct pnal_snmp
     * Used for accessing variables in the stack, such as LLDP variables.
     */
    pnet_t * net;
-
-   pf_snmp_system_name_t sysname;
-   pf_snmp_system_contact_t syscontact;
-   pf_snmp_system_location_t syslocation;
-   pf_snmp_system_description_t sysdescr;
 
    pnal_snmp_response_t response;
 } pnal_snmp_t;


### PR DESCRIPTION
Previously, SNMP Get/GetNext requests for MIB-II
system variables were handled by lwip by either
returning values read at startup or the values
later set in SNMP Set requests. This did not allow
for the case that system variables were changes by
other means than SNMP.

To solve this, the lwip handling of MIB-II system
variables is replaced with a custom version.

Stack size for SNMP thread was also increased as
pf_snmp_get_*() functions are now called by the
SNMP thread instead of main thread, plus that use
of some static variables were eliminated.