### PR TITLE
Simplify usage of the scheduler

### DIFF
--- a/doc/sampleapp_details.rst
+++ b/doc/sampleapp_details.rst
@@ -10,7 +10,7 @@ data every millisecond. Note that the sample application does not read
 the GSDML file, the file just describes the hard coded value used
 in the sample application.
 
-The sample application timer uses ``TICK_INTERVAL_US`` which is
+The sample application timer uses ``APP_TICK_INTERVAL_US`` which is
 1000 microseconds = 1 millisecond. To be able to tell this information to
 others, the value ``32`` is given in the ``min_device_interval`` field of the
 device configuration.

--- a/src/common/pf_dcp.c
+++ b/src/common/pf_dcp.c
@@ -119,10 +119,6 @@ static const pnet_ethaddr_t dcp_mc_addr_hello = {
 
 static const pnet_ethaddr_t mac_nil = PF_MAC_NIL;
 
-static const char * dcp_led_sync_name = "dcp_led";
-static const char * dcp_sam_sync_name = "dcp_sam";
-static const char * dcp_identresp_sync_name = "dcp_identresp";
-
 /*
  * A list of options that we can get/set/filter.
  * Use in identify filter and identify response.
@@ -175,14 +171,13 @@ static const pf_dcp_opt_sub_t device_options[] = {
  * @param arg              In:    DCP responder data. Should be pnal_buf_t.
  * @param current_time     In:    The current system time, in microseconds,
  *                                when the scheduler is started to execute
- *                                stored tasks.
- *                                Not used here.
+ *                                stored tasks. Not used here.
  */
 static void pf_dcp_responder (pnet_t * net, void * arg, uint32_t current_time)
 {
    pnal_buf_t * p_buf = (pnal_buf_t *)arg;
 
-   net->dcp_identresp_timeout = 0;
+   pf_scheduler_reset_handle (&net->dcp_identresp_timeout);
 
    if (p_buf != NULL)
    {
@@ -222,7 +217,7 @@ static void pf_dcp_clear_sam (pnet_t * net, void * arg, uint32_t current_time)
       "DCP(%d): SAM timeout. Clear stored remote MAC address.\n",
       __LINE__);
    net->dcp_sam = mac_nil;
-   net->dcp_sam_timeout = 0;
+   pf_scheduler_reset_handle (&net->dcp_sam_timeout);
 }
 
 /**
@@ -244,15 +239,9 @@ static void pf_dcp_restart_sam_timeout (pnet_t * net, const pnet_ethaddr_t * mac
       __LINE__);
 
    memcpy (&net->dcp_sam, mac, sizeof (net->dcp_sam));
-   if (net->dcp_sam_timeout != 0)
-   {
-      (void)pf_scheduler_remove (net, dcp_sam_sync_name, net->dcp_sam_timeout);
-      net->dcp_sam_timeout = 0;
-   }
-   (void)pf_scheduler_add (
+   (void)pf_scheduler_restart (
       net,
       PF_DCP_SAM_TIMEOUT,
-      dcp_sam_sync_name,
       pf_dcp_clear_sam,
       NULL,
       &net->dcp_sam_timeout);
@@ -639,17 +628,16 @@ static void pf_dcp_control_signal_led (
       state--;
 
       /* Schedule another round */
-      pf_scheduler_add (
+      (void)pf_scheduler_add (
          net,
          PF_DCP_SIGNAL_LED_HALF_INTERVAL,
-         dcp_led_sync_name,
          pf_dcp_control_signal_led,
          (void *)(uintptr_t)state,
          &net->dcp_led_timeout);
    }
    else
    {
-      net->dcp_led_timeout = 0;
+      pf_scheduler_reset_handle (&net->dcp_led_timeout);
    }
 }
 
@@ -665,16 +653,15 @@ static void pf_dcp_control_signal_led (
  */
 int pf_dcp_trigger_signal_led (pnet_t * net)
 {
-   if (net->dcp_led_timeout == 0)
+   if (pf_scheduler_is_running (&net->dcp_led_timeout) == false)
    {
       LOG_INFO (
          PF_DCP_LOG,
          "DCP(%d): Received request to flash LED\n",
          __LINE__);
-      pf_scheduler_add (
+      (void)pf_scheduler_add (
          net,
          PF_DCP_SIGNAL_LED_HALF_INTERVAL,
-         dcp_led_sync_name,
          pf_dcp_control_signal_led,
          (void *)(2 * PF_DCP_SIGNAL_LED_NUMBER_OF_FLASHES - 1),
          &net->dcp_led_timeout);
@@ -1928,10 +1915,9 @@ static int pf_dcp_identify_req (
             ntohl (p_src_dcphdr->xid));
 #endif
 
-         pf_scheduler_add (
+         (void)pf_scheduler_add (
             net,
             response_delay,
-            dcp_identresp_sync_name,
             pf_dcp_responder,
             p_rsp,
             &net->dcp_identresp_timeout);
@@ -1982,10 +1968,10 @@ void pf_dcp_init (pnet_t * net)
 {
    net->dcp_global_block_qualifier = 0;
    net->dcp_delayed_response_waiting = false;
-   net->dcp_sam_timeout = 0;
-   net->dcp_led_timeout = 0;
-   net->dcp_identresp_timeout = 0;
    net->dcp_sam = mac_nil;
+   pf_scheduler_init_handle (&net->dcp_sam_timeout, "dcp_sam");
+   pf_scheduler_init_handle (&net->dcp_led_timeout, "dcp_led");
+   pf_scheduler_init_handle (&net->dcp_identresp_timeout, "dcp_identresp");
 
    LOG_DEBUG (
       PF_DCP_LOG,

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -94,9 +94,6 @@ typedef struct pf_lldp_org_header
 static const char org_id_pnio[] = {0x00, 0x0e, 0xcf};
 static const char org_id_ieee_8023[] = {0x00, 0x12, 0x0f};
 
-static const char * shed_tag_tx = "lldp_tx";
-static const char * shed_tag_rx = "lldp_rx";
-
 typedef enum lldp_pnio_subtype_values
 {
    LLDP_PNIO_SUBTYPE_RESERVED = 0,
@@ -494,7 +491,7 @@ static void pf_lldp_receive_timeout (
 {
    pf_port_t * p_port_data = (pf_port_t *)arg;
 
-   p_port_data->lldp.rx_timeout = 0;
+   pf_scheduler_reset_handle (&p_port_data->lldp.rx_timeout);
    LOG_INFO (
       PF_LLDP_LOG,
       "LLDP(%d): Port %d, receive timeout expired\n",
@@ -512,11 +509,7 @@ void pf_lldp_restart_peer_timeout (
 {
    pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
 
-   if (p_port_data->lldp.rx_timeout != 0)
-   {
-      pf_scheduler_remove (net, shed_tag_rx, p_port_data->lldp.rx_timeout);
-      p_port_data->lldp.rx_timeout = 0;
-   }
+   pf_scheduler_remove_if_running (net, &p_port_data->lldp.rx_timeout);
 
    /*
     *  Profinet states that the time to live shall be 20 seconds,
@@ -534,7 +527,6 @@ void pf_lldp_restart_peer_timeout (
          pf_scheduler_add (
             net,
             timeout_in_secs * 1000000,
-            shed_tag_rx,
             pf_lldp_receive_timeout,
             p_port_data,
             &p_port_data->lldp.rx_timeout) != 0)
@@ -551,11 +543,7 @@ void pf_lldp_stop_peer_timeout (pnet_t * net, int loc_port_num)
 {
    pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
 
-   if (p_port_data->lldp.rx_timeout != 0)
-   {
-      pf_scheduler_remove (net, shed_tag_rx, p_port_data->lldp.rx_timeout);
-      p_port_data->lldp.rx_timeout = 0;
-   }
+   pf_scheduler_remove_if_running (net, &p_port_data->lldp.rx_timeout);
 }
 
 /**
@@ -1120,7 +1108,6 @@ static void pf_lldp_trigger_sending (
       pf_scheduler_add (
          net,
          PF_LLDP_SEND_INTERVAL * 1000,
-         shed_tag_tx,
          pf_lldp_trigger_sending,
          p_port_data,
          &p_port_data->lldp.tx_timeout) != 0)
@@ -1145,17 +1132,10 @@ static void pf_lldp_tx_restart (pnet_t * net, int loc_port_num, bool send)
 {
    pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
 
-   if (p_port_data->lldp.tx_timeout != 0)
-   {
-      pf_scheduler_remove (net, shed_tag_tx, p_port_data->lldp.tx_timeout);
-      p_port_data->lldp.tx_timeout = 0;
-   }
-
    if (
-      pf_scheduler_add (
+      pf_scheduler_restart (
          net,
          PF_LLDP_SEND_INTERVAL * 1000,
-         shed_tag_tx,
          pf_lldp_trigger_sending,
          p_port_data,
          &p_port_data->lldp.tx_timeout) != 0)
@@ -1184,7 +1164,10 @@ void pf_lldp_init (pnet_t * net)
    while (port != 0)
    {
       p_port_data = pf_port_get_state (net, port);
+
       memset (&p_port_data->lldp, 0, sizeof (p_port_data->lldp));
+      pf_scheduler_init_handle (&p_port_data->lldp.rx_timeout, "lldp_rx");
+      pf_scheduler_init_handle (&p_port_data->lldp.tx_timeout, "lldp_tx");
 
       port = pf_port_get_next (&port_iterator);
    }
@@ -1205,17 +1188,14 @@ void pf_lldp_send_enable (pnet_t * net, int loc_port_num)
 
 void pf_lldp_send_disable (pnet_t * net, int loc_port_num)
 {
+   pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
+
    LOG_DEBUG (
       PF_LLDP_LOG,
       "LLDP(%d): Disabling LLDP transmission for port %d\n",
       __LINE__,
       loc_port_num);
-   pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
-   if (p_port_data->lldp.tx_timeout != 0)
-   {
-      pf_scheduler_remove (net, shed_tag_tx, p_port_data->lldp.tx_timeout);
-      p_port_data->lldp.tx_timeout = 0;
-   }
+   pf_scheduler_remove_if_running (net, &p_port_data->lldp.tx_timeout);
 }
 
 /**

--- a/src/common/pf_scheduler.h
+++ b/src/common/pf_scheduler.h
@@ -31,37 +31,124 @@ extern "C" {
 void pf_scheduler_init (pnet_t * net, uint32_t tick_interval);
 
 /**
+ * Initialize a timeout handle.
+ * @param handle           Out:   Timeout handle.
+ * @param name             In:    Descriptive name for debugging. Not NULL.
+ */
+void pf_scheduler_init_handle (
+   pf_scheduler_handle_t * handle,
+   const char * name);
+
+/**
+ * Reset the value inside the timeout handle to indicate that it's not running.
+ *
+ * May be used inside the callback (which is executed by the scheduler).
+ *
+ * To unschedule a callback, use \a pf_scheduler_remove() or
+ * \a pf_scheduler_remove_if_running() instead.
+ *
+ * @param handle           Out:   Timeout handle.
+ */
+void pf_scheduler_reset_handle (pf_scheduler_handle_t * handle);
+
+/**
+ * Report whether the timeout is running (=scheduled)
+ *
+ * @param handle           InOut: Timeout handle.
+ * @return  true if it is running
+ *          false otherwise
+ */
+bool pf_scheduler_is_running (const pf_scheduler_handle_t * handle);
+
+/**
+ * Report the internal value of a timeout handle.
+ *
+ * Intended for debugging and testing.
+ *
+ * The value is an index into the timers, and is 0 < x <= PF_MAX_TIMEOUTS when
+ * the timer is running. The value is UINT32_MAX when it is stopped.
+ *
+ * @param handle           InOut: Timeout handle.
+ * @return the internal value (related to index in array of timeouts)
+ */
+uint32_t pf_scheduler_get_value (const pf_scheduler_handle_t * handle);
+
+/**
+ * Report the name of a timeout handle.
+ *
+ * Intended for debugging and testing.
+ *
+ * @param handle           InOut: Timeout handle.
+ * @return the name given at initialization.
+ */
+const char * pf_scheduler_get_name (const pf_scheduler_handle_t * handle);
+
+/**
  * Schedule a call-back at a specific time.
+ *
+ * The callback must update the internal state stored in the handle. That is
+ * done by calling \a pf_scheduler_reset_handle() or again calling
+ * \ pf_scheduler_add().
  *
  * @param net              InOut: The p-net stack instance
  * @param delay            In:    The delay until the function shall be called,
  *                                in microseconds. Max
  *                                PF_SCHEDULER_MAX_DELAY_US.
- * @param p_name           In:    Caller/owner (for removal and debugging).
  * @param cb               In:    The call-back.
  * @param arg              In:    Argument to the call-back.
- * @param p_timeout        Out:   The timeout instance (used to remove if
- *                                necessary).
+ * @param handle           InOut: Timeout handle.
  * @return  0  if the call-back was scheduled.
  *          -1 if an error occurred.
  */
 int pf_scheduler_add (
    pnet_t * net,
    uint32_t delay,
-   const char * p_name,
    pf_scheduler_timeout_ftn_t cb,
    void * arg,
-   uint32_t * p_timeout);
+   pf_scheduler_handle_t * handle);
 
 /**
- * Stop a timeout. If it is not scheduled then ignore.
+ * Re-schedule a call-back at a specific time.
+ *
+ * Removes the already scheduled instance, if existing.
+ *
+ * Do not use in a scheduler callback.
+ *
  * @param net              InOut: The p-net stack instance
- * @param p_name           In:    Must be exactly the same address as in the
- *                                pf_scheduler_add().
- * @param timeout          In:    Time instance to remove
- *                                (see pf_scheduler_add)
+ * @param delay            In:    The delay until the function shall be called,
+ *                                in microseconds. Max
+ *                                PF_SCHEDULER_MAX_DELAY_US.
+ * @param cb               In:    The call-back.
+ * @param arg              In:    Argument to the call-back.
+ * @param handle           InOut: Timeout handle.
+ * @return  0  if the call-back was scheduled.
+ *          -1 if an error occurred.
  */
-void pf_scheduler_remove (pnet_t * net, const char * p_name, uint32_t timeout);
+int pf_scheduler_restart (
+   pnet_t * net,
+   uint32_t delay,
+   pf_scheduler_timeout_ftn_t cb,
+   void * arg,
+   pf_scheduler_handle_t * handle);
+
+/**
+ * Stop a timeout, if it is running.
+ *
+ * Silently ignoring the timeout if not running.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param handle           InOut: Timeout handle.
+ */
+void pf_scheduler_remove_if_running (
+   pnet_t * net,
+   pf_scheduler_handle_t * handle);
+
+/**
+ * Stop a timeout.
+ * @param net              InOut: The p-net stack instance
+ * @param handle           InOut: Timeout handle.
+ */
+void pf_scheduler_remove (pnet_t * net, pf_scheduler_handle_t * handle);
 
 /**
  * Check if it is time to call a scheduled call-back.

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -28,8 +28,6 @@
  * @brief Management Physical Device Port (PD Port) data
  */
 
-static const char * shed_tag_linkmonitor = "linkmonitor";
-
 /**
  * Get configuration file name for one port
  *
@@ -1027,7 +1025,6 @@ static void pf_lldp_trigger_linkmonitor (
       pf_scheduler_add (
          net,
          PF_LINK_MONITOR_INTERVAL,
-         shed_tag_linkmonitor,
          pf_lldp_trigger_linkmonitor,
          NULL,
          &net->pf_interface.link_monitor_timeout) != 0)
@@ -1045,7 +1042,6 @@ void pf_pdport_start_linkmonitor (pnet_t * net)
       pf_scheduler_add (
          net,
          PF_LINK_MONITOR_INTERVAL,
-         shed_tag_linkmonitor,
          pf_lldp_trigger_linkmonitor,
          NULL,
          &net->pf_interface.link_monitor_timeout) != 0)

--- a/src/device/pf_port.c
+++ b/src/device/pf_port.c
@@ -70,7 +70,9 @@ void pf_port_main_interface_init (pnet_t * net)
    pf_port_init_iterator_over_ports (
       net,
       &net->pf_interface.link_monitor_iterator);
-   net->pf_interface.link_monitor_timeout = UINT32_MAX;
+   pf_scheduler_init_handle (
+      &net->pf_interface.link_monitor_timeout,
+      "link_monitor");
    pf_pdport_start_linkmonitor (net);
 }
 

--- a/test/test_scheduler.cpp
+++ b/test/test_scheduler.cpp
@@ -28,6 +28,22 @@ class SchedulerUnitTest : public PnetUnitTest
 {
 };
 
+void test_scheduler_callback_a (pnet_t * net, void * arg, uint32_t current_time)
+{
+   app_data_for_testing_t * appdata = (app_data_for_testing_t *)arg;
+
+   appdata->call_counters.scheduler_callback_a_calls += 1;
+   pf_scheduler_reset_handle (&appdata->scheduler_handle_a);
+}
+
+void test_scheduler_callback_b (pnet_t * net, void * arg, uint32_t current_time)
+{
+   app_data_for_testing_t * appdata = (app_data_for_testing_t *)arg;
+
+   appdata->call_counters.scheduler_callback_b_calls += 1;
+   pf_scheduler_reset_handle (&appdata->scheduler_handle_b);
+}
+
 TEST_F (SchedulerUnitTest, SchedulerSanitizeDelayTest)
 {
    const uint32_t cycle_len = 1000;
@@ -117,4 +133,402 @@ TEST_F (SchedulerUnitTest, SchedulerSanitizeDelayTest)
    ASSERT_NEAR (result, 500, margin);
    result = pf_scheduler_sanitize_delay (input_delay, cycle_len, false);
    ASSERT_NEAR (result, 1000, margin);
+}
+
+TEST_F (SchedulerTest, SchedulerAddRemove)
+{
+   int ret;
+   pf_scheduler_handle_t * p_a = &appdata.scheduler_handle_a;
+   pf_scheduler_handle_t * p_b = &appdata.scheduler_handle_b;
+   const char scheduler_name_a[] = "testhandle_a";
+   const char scheduler_name_b[] = "testhandle_b";
+   const char * resulting_name = NULL;
+   uint32_t value;
+   bool is_scheduled;
+
+   pf_scheduler_init (net, TEST_TICK_INTERVAL_US);
+   run_stack (TEST_SCHEDULER_RUNTIME);
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 0);
+
+   /* Initialize and verify handle */
+   pf_scheduler_init_handle (p_a, scheduler_name_a);
+   pf_scheduler_init_handle (p_b, scheduler_name_b);
+
+   resulting_name = pf_scheduler_get_name (p_a);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_a), 0);
+   resulting_name = pf_scheduler_get_name (p_b);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_b), 0);
+
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Reset non-running handle */
+   pf_scheduler_reset_handle (p_a);
+
+   resulting_name = pf_scheduler_get_name (p_a);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_a), 0);
+
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Schedule callback A */
+   ret = pf_scheduler_add (
+      net,
+      TEST_SCHEDULER_CALLBACK_DELAY,
+      test_scheduler_callback_a,
+      &appdata,
+      p_a);
+   EXPECT_EQ (ret, 0);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 0);
+   resulting_name = pf_scheduler_get_name (p_a);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_a), 0);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 1UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 0);
+   resulting_name = pf_scheduler_get_name (p_b);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_b), 0);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Verify that it not is triggered */
+   run_stack (TEST_TICK_INTERVAL_US);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 0);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 1UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 0);
+   resulting_name = pf_scheduler_get_name (p_b);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_b), 0);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Verify that callback A is triggered */
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 1);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 0);
+   resulting_name = pf_scheduler_get_name (p_b);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_b), 0);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Schedule both callbacks */
+   ret = pf_scheduler_add (
+      net,
+      TEST_SCHEDULER_CALLBACK_DELAY,
+      test_scheduler_callback_a,
+      &appdata,
+      p_a);
+   EXPECT_EQ (ret, 0);
+   ret = pf_scheduler_add (
+      net,
+      TEST_SCHEDULER_RUNTIME + TEST_SCHEDULER_CALLBACK_DELAY,
+      test_scheduler_callback_b,
+      &appdata,
+      p_b);
+   EXPECT_EQ (ret, 0);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 1);
+   resulting_name = pf_scheduler_get_name (p_a);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_a), 0);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 1UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 0);
+   resulting_name = pf_scheduler_get_name (p_b);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_b), 0);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_TRUE (is_scheduled);
+
+   /* Verify that they not are triggered */
+   run_stack (TEST_TICK_INTERVAL_US);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 1);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 1UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 0);
+   resulting_name = pf_scheduler_get_name (p_b);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_b), 0);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_TRUE (is_scheduled);
+
+   /* Verify that callback A (but not B) is triggered */
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 0);
+   resulting_name = pf_scheduler_get_name (p_b);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_b), 0);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_TRUE (is_scheduled);
+
+   /* Verify that both callbacks have been triggered */
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   resulting_name = pf_scheduler_get_name (p_b);
+   EXPECT_EQ (strcmp (resulting_name, scheduler_name_b), 0);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Remove non-scheduled event */
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   pf_scheduler_remove_if_running (net, p_a);
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   pf_scheduler_remove (net, p_a); /* Will log error message */
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Remove scheduled event */
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   ret = pf_scheduler_add (
+      net,
+      TEST_SCHEDULER_CALLBACK_DELAY,
+      test_scheduler_callback_a,
+      &appdata,
+      p_a);
+   EXPECT_EQ (ret, 0);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   run_stack (TEST_TICK_INTERVAL_US);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   pf_scheduler_remove (net, p_a);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Remove scheduled event, using utility function */
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   ret = pf_scheduler_add (
+      net,
+      TEST_SCHEDULER_CALLBACK_DELAY,
+      test_scheduler_callback_a,
+      &appdata,
+      p_a);
+   EXPECT_EQ (ret, 0);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */ // TODO
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   run_stack (TEST_TICK_INTERVAL_US);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   pf_scheduler_remove_if_running (net, p_a);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   value = pf_scheduler_get_value (p_b);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   /* Shedule and restart */
+   ret = pf_scheduler_add (
+      net,
+      TEST_SCHEDULER_CALLBACK_DELAY,
+      test_scheduler_callback_a,
+      &appdata,
+      p_a);
+   EXPECT_EQ (ret, 0);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   run_stack (TEST_TICK_INTERVAL_US);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   ret = pf_scheduler_restart (
+      net,
+      TEST_SCHEDULER_RUNTIME + TEST_SCHEDULER_CALLBACK_DELAY,
+      test_scheduler_callback_a,
+      &appdata,
+      p_a);
+
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 2);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, 2UL); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_TRUE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
+
+   run_stack (TEST_SCHEDULER_RUNTIME);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_a_calls, 3);
+   value = pf_scheduler_get_value (p_a);
+   EXPECT_EQ (value, UINT32_MAX); /* Implementation detail */
+   is_scheduled = pf_scheduler_is_running (p_a);
+   EXPECT_FALSE (is_scheduled);
+
+   EXPECT_EQ (appdata.call_counters.scheduler_callback_b_calls, 1);
+   is_scheduled = pf_scheduler_is_running (p_b);
+   EXPECT_FALSE (is_scheduled);
 }

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -463,7 +463,7 @@ void PnetIntegrationTestBase::available_modules_and_submodules_init()
 
 void PnetIntegrationTestBase::cfg_init()
 {
-   pnet_default_cfg.tick_us = TICK_INTERVAL_US;
+   pnet_default_cfg.tick_us = TEST_TICK_INTERVAL_US;
    pnet_default_cfg.state_cb = my_state_ind;
    pnet_default_cfg.connect_cb = my_connect_ind;
    pnet_default_cfg.release_cb = my_release_ind;
@@ -552,7 +552,7 @@ void PnetIntegrationTestBase::run_stack (int us)
 {
    uint16_t slot = 0;
 
-   for (int tmr = 0; tmr < us / TICK_INTERVAL_US; tmr++)
+   for (int tmr = 0; tmr < us / TEST_TICK_INTERVAL_US; tmr++)
    {
       /* Set new output data every 10 ticks */
       appdata.tick_ctr++;
@@ -580,7 +580,7 @@ void PnetIntegrationTestBase::run_stack (int us)
 
       /* Run stack functionality every tick */
       pnet_handle_periodic (net);
-      mock_os_data.current_time_us += TICK_INTERVAL_US;
+      mock_os_data.current_time_us += TEST_TICK_INTERVAL_US;
    }
 }
 

--- a/test/utils_for_testing.h
+++ b/test/utils_for_testing.h
@@ -31,10 +31,12 @@ extern "C" {
 #define TEST_TRACE(...)
 #endif
 
-#define TEST_UDP_DELAY     (500 * 1000)      /* us */
-#define TEST_DATA_DELAY    (2 * 1000)        /* us */
-#define TEST_TIMEOUT_DELAY (3 * 1000 * 1000) /* us */
-#define TICK_INTERVAL_US   1000              /* us */
+#define TEST_UDP_DELAY                (500 * 1000)                 /* us */
+#define TEST_TICK_INTERVAL_US         1000                         /* us */
+#define TEST_DATA_DELAY               (2 * TEST_TICK_INTERVAL_US)  /* us */
+#define TEST_TIMEOUT_DELAY            (3 * 1000 * 1000)            /* us */
+#define TEST_SCHEDULER_CALLBACK_DELAY (4 * TEST_TICK_INTERVAL_US)  /* us */
+#define TEST_SCHEDULER_RUNTIME        (10 * TEST_TICK_INTERVAL_US) /* us */
 
 #define TEST_API_IDENT                            0
 #define TEST_API_NONEXIST_IDENT                   2
@@ -98,6 +100,8 @@ typedef struct call_counters_obj
    uint16_t write_calls;
    uint16_t led_on_calls;
    uint16_t led_off_calls;
+   uint16_t scheduler_callback_a_calls;
+   uint16_t scheduler_callback_b_calls;
 } call_counters_t;
 
 typedef struct app_data_for_testing_obj
@@ -121,6 +125,8 @@ typedef struct app_data_for_testing_obj
    bool init_done;
    uint16_t read_fails;
    call_counters_t call_counters;
+   pf_scheduler_handle_t scheduler_handle_a;
+   pf_scheduler_handle_t scheduler_handle_b;
 } app_data_for_testing_t;
 
 /******************** Callbacks defined by p-net *****************************/


### PR DESCRIPTION
Introduce a handle object, and do some of the bookkeeping internally
in the scheduler functions.

Implement convenience functions for frequently used operations,
for example pf_scheduler_remove_if_runnning().