### PR TITLE
Handle lldp rx timeout

### DIFF
--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3583,7 +3583,7 @@ void pf_put_pdport_data_real (
    const pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
    const pf_lldp_peer_info_t * p_peer_info = &p_port_data->lldp.peer_info;
 
-   num_peers = p_peer_info->ttl ? 1 : 0;
+   num_peers = p_port_data->lldp.is_peer_info_received ? 1 : 0;
 
    if (pnal_eth_get_status (p_port_config->phy_port.if_name, &eth_status) != 0)
    {

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2675,13 +2675,8 @@ typedef struct pf_lldp_peer_info
    pf_lldp_signal_delay_t port_delay;
    uint8_t port_status[4];
    pnet_ethaddr_t mac_address;
-   uint16_t media_type;
    uint32_t line_delay;
-   uint32_t domain_boundary;
-   uint32_t multicast_boundary;
-   uint8_t link_state_port;
    pf_lldp_link_status_t phy_config;
-   pf_lldp_peer_to_peer_boundary_t peer_boundary;
 } pf_lldp_peer_info_t;
 
 typedef struct pf_pdport


### PR DESCRIPTION
Mark lldp peer as invalid on lldp timeout.

Needs to be verified in the setup problem was originally reported.
Does implementation work with the snmp integration?
