### PR TITLE
Soft mac filtering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,12 @@ set(PNET_MAX_CR                 2
 set(PNET_MAX_SLOTS            5
   CACHE STRING "Per API. Should be > 1 to allow at least one I/O module")
 set(PNET_MAX_SUBSLOTS         3
-  CACHE STRING "Per slot (DAP requires 2 + PNET_MAX_PORT)")
+  CACHE STRING "Per slot (DAP requires 2 + PNET_NUMBER_OF_PHYSICAL_PORTS)")
 set(PNET_MAX_CHANNELS           1
   CACHE STRING "Per sub-slot. Used for diagnosis")
 set(PNET_MAX_DFP_IOCR           2
   CACHE STRING "Allowed values are 0 (zero) or 2")
-set(PNET_MAX_PORT               1
+set(PNET_NUMBER_OF_PHYSICAL_PORTS          1
   CACHE STRING "Number of physical ports")
 set(PNET_MAX_LOG_BOOK_ENTRIES   16
   CACHE STRING "")

--- a/doc/multiple_ports.rst
+++ b/doc/multiple_ports.rst
@@ -99,10 +99,10 @@ To run p-net and the sample application with multiple ports a couple
 of things need to be done. Note that the settings described in the 
 following sections are changed by running ``ccmake .`` in the build folder.
 ``options.h`` will be regenerated. Another way to set the options is to 
-set them on the cmake command line (-DPNET_MAX_PORT=2 -DPNET_MAX_SUBSLOTS=4).
+set them on the cmake command line (-DPNET_NUMBER_OF_PHYSICAL_PORTS=2 -DPNET_MAX_SUBSLOTS=4).
 
-Reconfigure setting ``PNET_MAX_PORT`` to the actual number of physical ports available in the system.
-For this example ``PNET_MAX_PORT`` shall be set to 2. 
+Reconfigure setting ``PNET_NUMBER_OF_PHYSICAL_PORTS`` to the actual number of physical ports available in the system.
+For this example ``PNET_NUMBER_OF_PHYSICAL_PORTS`` shall be set to 2. 
 
 Reconfigure setting ``PNET_MAX_SUBSLOTS``. Each additional port will require an additional subslot.
 For this example the ``PNET_MAX_SUBSLOTS`` should be be set to 4.

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1171,23 +1171,11 @@ typedef struct pnet_ethaddr
    (PNET_STATION_NAME_MAX_SIZE + PNET_PORT_NAME_MAX_SIZE)
 
 /**
- * Network interface
- */
-typedef struct pnet_netif
-{
-   char if_name[PNET_INTERFACE_NAME_MAX_SIZE]; /**< Terminated string */
-   pnet_ethaddr_t eth_addr;                    /**< Interface MAC address */
-} pnet_netif_t;
-
-/**
  * Physical Port Configuration
  */
 typedef struct pnet_port_cfg
 {
-   pnet_netif_t phy_port;
-   char port_name[PNET_PORT_NAME_MAX_SIZE]; /**< Terminated string */
-   uint16_t rtclass_2_status;
-   uint16_t rtclass_3_status;
+   const char * netif_name;
 } pnet_port_cfg_t;
 
 /**
@@ -1213,10 +1201,10 @@ typedef struct pnet_ip_cfg
  */
 typedef struct pnet_if_cfg
 {
-   pnet_netif_t main_port; /**< Main (DAP) network interface. */
+   const char * main_netif_name; /**< Main (DAP) network interface. */
    pnet_ip_cfg_t ip_cfg;   /**< IP Settings for main network interface */
 
-   pnet_port_cfg_t ports[PNET_MAX_PORT]; /**< Physical ports (DAP ports) */
+   pnet_port_cfg_t physical_ports[PNET_MAX_PORT];
 } pnet_if_cfg_t;
 
 /**

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1204,7 +1204,7 @@ typedef struct pnet_if_cfg
    const char * main_netif_name; /**< Main (DAP) network interface. */
    pnet_ip_cfg_t ip_cfg;   /**< IP Settings for main network interface */
 
-   pnet_port_cfg_t physical_ports[PNET_MAX_PORT];
+   pnet_port_cfg_t physical_ports[PNET_NUMBER_OF_PHYSICAL_PORTS];
 } pnet_if_cfg_t;
 
 /**

--- a/options.h.in
+++ b/options.h.in
@@ -112,9 +112,9 @@
 #define PNET_MAX_DFP_IOCR         @PNET_MAX_DFP_IOCR@
 #endif
 
-#if !defined (PNET_MAX_PORT)
+#if !defined (PNET_NUMBER_OF_PHYSICAL_PORTS)
 /** 2 for media redundancy. Currently only 1 is supported. */
-#define PNET_MAX_PORT             @PNET_MAX_PORT@
+#define PNET_NUMBER_OF_PHYSICAL_PORTS        @PNET_NUMBER_OF_PHYSICAL_PORTS@
 #endif
 
 #if !defined (PNET_MAX_LOG_BOOK_ENTRIES)

--- a/sample_app/GSDML-V2.4-RT-Labs-P-Net-Sample-App-20210202.xml
+++ b/sample_app/GSDML-V2.4-RT-Labs-P-Net-Sample-App-20210202.xml
@@ -66,7 +66,7 @@ Current list works for Raspberry Pi, Linksys usb/ethernet dongle and xmc sample 
                      </MAUTypeList>
                   </PortSubmoduleItem>
 <!-- 
-Enable to support additional port. (PNET_MAX_PORT == 2)
+Enable to support additional port. (PNET_NUMBER_OF_PHYSICAL_PORTS == 2)
 Add additional PortSubmoduleItems to support additional ports
 -->
 <!--

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -1276,7 +1276,7 @@ void app_plug_dap (pnet_t * net, void * arg)
       PNET_SUBMOD_DAP_INTERFACE_1_PORT_1_IDENT,
       &cfg_dap_data);
 
-#if PNET_MAX_PORT >= 2
+#if PNET_MAX_PHY_PORTS >= 2
    app_exp_submodule_ind (
       net,
       arg,
@@ -1288,7 +1288,7 @@ void app_plug_dap (pnet_t * net, void * arg)
       &cfg_dap_data);
 #endif
 
-#if PNET_MAX_PORT >= 3
+#if PNET_MAX_PHY_PORTS >= 3
    app_exp_submodule_ind (
       net,
       arg,
@@ -1300,7 +1300,7 @@ void app_plug_dap (pnet_t * net, void * arg)
       &cfg_dap_data);
 #endif
 
-#if PNET_MAX_PORT >= 4
+#if PNET_MAX_PHY_PORTS >= 4
    app_exp_submodule_ind (
       net,
       arg,
@@ -1481,7 +1481,10 @@ int app_pnet_cfg_init_netifs (
    pnal_ipaddr_t netmask;
    pnal_ipaddr_t gateway;
 
-   ret = app_get_netif_namelist (netif_list_str, if_list, PNET_MAX_PORT);
+   ret = app_get_netif_namelist (
+      netif_list_str,
+      if_list,
+      PNET_NUMBER_OF_PHYSICAL_PORTS);
    if (ret != 0)
    {
       return ret;
@@ -1493,7 +1496,7 @@ int app_pnet_cfg_init_netifs (
       printf ("Management port:      %s\n", p_cfg->if_cfg.main_netif_name);
    }
 
-   for (i = 1; i <= PNET_MAX_PORT; i++)
+   for (i = 1; i <= PNET_NUMBER_OF_PHYSICAL_PORTS; i++)
    {
       p_cfg->if_cfg.physical_ports[i - 1].netif_name = if_list->netif[i].name;
       if (verbosity > 0)

--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -131,7 +131,7 @@ static const cfg_submodule_type_t cfg_available_submodule_types[] = {
     PNET_DIR_NO_IO,
     0,
     0},
-#if PNET_MAX_PORT >= 2
+#if PNET_NUMBER_OF_PHYSICAL_PORTS >= 2
    {"DAP Port 2",
     APP_API,
     PNET_MOD_DAP_IDENT,
@@ -140,7 +140,7 @@ static const cfg_submodule_type_t cfg_available_submodule_types[] = {
     0,
     0},
 #endif
-#if PNET_MAX_PORT >= 3
+#if PNET_NUMBER_OF_PHYSICAL_PORTS >= 3
    {"DAP Port 3",
     APP_API,
     PNET_MOD_DAP_IDENT,
@@ -149,7 +149,7 @@ static const cfg_submodule_type_t cfg_available_submodule_types[] = {
     0,
     0},
 #endif
-#if PNET_MAX_PORT >= 4
+#if PNET_NUMBER_OF_PHYSICAL_PORTS >= 4
    {"DAP Port 4",
     APP_API,
     PNET_MOD_DAP_IDENT,
@@ -190,8 +190,8 @@ struct cmd_args
    char path_storage_directory[PNET_MAX_DIRECTORYPATH_SIZE]; /** Terminated */
    char station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated string */
    char eth_interfaces
-      [PNET_INTERFACE_NAME_MAX_SIZE * (PNET_MAX_PORT + 1) +
-       PNET_MAX_PORT]; /** Terminated string */
+      [PNET_INTERFACE_NAME_MAX_SIZE * (PNET_NUMBER_OF_PHYSICAL_PORTS + 1) +
+       PNET_NUMBER_OF_PHYSICAL_PORTS]; /** Terminated string */
    int verbosity;
    int show;
    bool factory_reset;
@@ -205,7 +205,7 @@ typedef struct app_netif_name
 
 typedef struct app_netif_namelist
 {
-   app_netif_name_t netif[PNET_MAX_PORT + 1];
+   app_netif_name_t netif[PNET_NUMBER_OF_PHYSICAL_PORTS + 1];
 } app_netif_namelist_t;
 
 typedef struct app_subslot
@@ -321,19 +321,17 @@ int app_pnet_cfg_init_netifs (
 
 /**
  * Parse a comma separated list of network interfaces and check
- * that the number of interfaces match the PNET_MAX_PORT configuration.
- * Examples:
- * PNET_MAX_PORT     arg_str                 status
- * 1                 "eth0"                  ok
- * 1                 "eth0,eth1"             err
- * 2                 "br0,eth0,eth1"         ok
- * 2                 "br0,eth0,"             err
+ * that the number of interfaces match the PNET_NUMBER_OF_PHYSICAL_PORTS
+ * configuration. Examples: PNET_NUMBER_OF_PHYSICAL_PORTS     arg_str status 1
+ * "eth0"                  ok 1                 "eth0,eth1"             err 2
+ * "br0,eth0,eth1"         ok 2                 "br0,eth0,"             err
  *
  * @param arg_str    In:   Network interface list as comma separated,
  *                         terminated string. For example "eth0" or
  *                         "br0,eth0,eth1".
  * @param p_if_list  Out:  List of network interfaces
- * @param max_port   In:   PNET_MAX_PORT, passed as argument to allow test
+ * @param max_port   In:   PNET_NUMBER_OF_PHYSICAL_PORTS, passed as argument to
+ *                         allow test
  * @return  0  if network interface list matches configuration
  *         -1  on error
  */

--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -242,6 +242,7 @@ typedef struct app_data_obj
    bool alarm_allowed;
    pnet_alarm_argument_t alarm_arg;
    struct cmd_args arguments;
+   app_netif_namelist_t if_list;
    uint32_t app_param_1;
    uint32_t app_param_2;
    uint8_t inputdata[APP_DATASIZE_INPUT];
@@ -276,7 +277,7 @@ typedef enum app_demo_state
  * @param outputstring     Out:   Resulting string buffer. Should have size
  *                                PNAL_ETH_ADDRSTR_SIZE.
  */
-void app_mac_to_string (pnal_ethaddr_t mac, char * outputstring);
+void app_mac_to_string (pnet_ethaddr_t mac, char * outputstring);
 
 /**
  * Print out current IP address, netmask and default gateway.
@@ -306,6 +307,7 @@ int app_pnet_cfg_init_default (pnet_cfg_t * stack_config);
  *
  * @param netif_list_str   In:    Comma separated list of network interfaces.
  *                                Terminated string.
+ * @param if_list          Out:   Network interface string storage.
  * @param p_cfg            InOut: p-net configuration
  * @param verbosity        In:    Verbosity
  * @return  0  on success
@@ -313,6 +315,7 @@ int app_pnet_cfg_init_default (pnet_cfg_t * stack_config);
  */
 int app_pnet_cfg_init_netifs (
    const char * netif_list_str,
+   app_netif_namelist_t * if_list,
    pnet_cfg_t * p_cfg,
    int verbosity);
 

--- a/src/common/pf_cpm.c
+++ b/src/common/pf_cpm.c
@@ -578,7 +578,7 @@ int pf_cpm_activate_req (pnet_t * net, pf_ar_t * p_ar, uint32_t crep)
           (uint32_t)p_iocr->param.reduction_ratio * 1000U) /
          32U; /* us */
 
-      for (ix = 0; ix < PNET_MAX_PORT; ix++)
+      for (ix = 0; ix < PNET_NUMBER_OF_PHYSICAL_PORTS; ix++)
       {
          p_cpm->rxa[ix][0] = -1; /* "invalid" cycle counter */
          p_cpm->rxa[ix][1] = -1;

--- a/src/common/pf_dcp.c
+++ b/src/common/pf_dcp.c
@@ -187,7 +187,7 @@ static void pf_dcp_responder (pnet_t * net, void * arg, uint32_t current_time)
    {
       if (net->dcp_delayed_response_waiting == true)
       {
-         if (pf_eth_send (net, net->eth_handle, p_buf) > 0)
+         if (pf_eth_send (net, net->pf_interface.main_port.handle, p_buf) > 0)
          {
             LOG_DEBUG (
                PNET_LOG,
@@ -1091,7 +1091,7 @@ static int pf_dcp_get_set (
          p_dst_dcphdr->data_length = htons (dst_pos - dst_start);
          p_rsp->len = dst_pos;
 
-         if (pf_eth_send (net, net->eth_handle, p_rsp) > 0)
+         if (pf_eth_send (net, net->pf_interface.main_port.handle, p_rsp) > 0)
          {
             LOG_DEBUG (
                PF_DCP_LOG,
@@ -1366,7 +1366,7 @@ int pf_dcp_hello_req (pnet_t * net)
          p_dcphdr->data_length = htons (dst_pos - dst_start_pos);
          p_buf->len = dst_pos;
 
-         (void)pf_eth_send (net, net->eth_handle, p_buf);
+         (void)pf_eth_send (net, net->pf_interface.main_port.handle, p_buf);
       }
       pnal_buf_free (p_buf);
    }

--- a/src/common/pf_eth.c
+++ b/src/common/pf_eth.c
@@ -152,6 +152,18 @@ int pf_eth_recv (pnal_eth_handle_t * eth_handle, void * arg, pnal_buf_t * p_buf)
    uint16_t ix = 0;
    pnet_t * net = (pnet_t *)arg;
 
+#ifndef UNIT_TEST
+   /* Reject unicast packets with destination not matching
+    * mac address of management interface.
+    */
+   if (
+      (((uint8_t *)p_buf->payload)[0] != 1) &&
+      (memcmp (p_buf->payload, net->pf_interface.main_port.mac.addr, 6) != 0))
+   {
+      return 0;
+   }
+#endif
+
    /* Skip ALL VLAN tags */
    p_data = (uint16_t *)(&((uint8_t *)p_buf->payload)[eth_type_pos]);
    eth_type = ntohs (p_data[0]);

--- a/src/common/pf_eth.c
+++ b/src/common/pf_eth.c
@@ -33,17 +33,6 @@
 #include <string.h>
 #include "pf_includes.h"
 
-/**
- * Init network interface.
- * Set name, read mac address, register receive callback.
- *
- * @param net              InOut: The p-net stack instance
- * @param netif_name       In:    Network interface name
- * @param eth_receive_type In:    Ethernet frame types that shall be received
- *                                by the network interface / port.
- * @param netif            Out:   Initialized network interface.
- * @return
- */
 static int pf_eth_init_netif (
    pnet_t * net,
    const char * netif_name,
@@ -83,13 +72,13 @@ int pf_eth_init (pnet_t * net, const pnet_cfg_t * p_cfg)
    pf_port_iterator_t port_iterator;
    pf_port_t * p_port_data;
    pnal_ethertype_t main_port_receive_type;
-#if PNET_MAX_PORT > 1
+#if PNET_NUMBER_OF_PHYSICAL_PORTS > 1
    const pnet_port_cfg_t * p_port_cfg;
 #endif
 
    memset (net->eth_id_map, 0, sizeof (net->eth_id_map));
 
-#if (PNET_MAX_PORT == 1)
+#if (PNET_NUMBER_OF_PHYSICAL_PORTS == 1)
    main_port_receive_type = PNAL_ETHTYPE_ALL;
 #else
    main_port_receive_type = PNAL_ETHTYPE_PROFINET;
@@ -113,7 +102,7 @@ int pf_eth_init (pnet_t * net, const pnet_cfg_t * p_cfg)
    {
       p_port_data = pf_port_get_state (net, port);
 
-#if PNET_MAX_PORT > 1
+#if PNET_NUMBER_OF_PHYSICAL_PORTS > 1
       p_port_cfg = pf_port_get_config (net, port);
 
       if (
@@ -133,6 +122,7 @@ int pf_eth_init (pnet_t * net, const pnet_cfg_t * p_cfg)
 
       port = pf_port_get_next (&port_iterator);
    }
+
    return 0;
 }
 

--- a/src/common/pf_eth.h
+++ b/src/common/pf_eth.h
@@ -22,10 +22,10 @@ extern "C" {
 
 /**
  * Initialize ETH component and network interfaces according to configuration
- * If device is configured with one network interface (PNET_MAX_PORT==1),
- * the management port and physical port 1 refers to same network interface.
- * In a multi port configuration, the management port and physical ports are
- * different network interfaces.
+ * If device is configured with one network interface
+ * (PNET_NUMBER_OF_PHYSICAL_PORTS==1), the management port and physical port 1
+ * refers to same network interface. In a multi port configuration, the
+ * management port and physical ports are different network interfaces.
  * @param net              InOut: The p-net stack instance
  * @param p_cfg            In:    Configuration
  * @return   0 on success

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -33,7 +33,6 @@
  * This file should not have any knowledge of Profinet slots, subslots etc.
  *
  * ToDo: Differentiate between device and port MAC addresses.
- * ToDo: Handle PNET_MAX_PORT ports.
  */
 
 #include "pf_includes.h"
@@ -987,7 +986,8 @@ void pf_lldp_mac_address_to_string (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param buf              Out:   Ethernet frame buffer of size
  *                                PF_FRAME_BUFFER_SIZE bytes.
  *
@@ -1068,7 +1068,8 @@ size_t pf_lldp_construct_frame (pnet_t * net, int loc_port_num, uint8_t buf[])
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  */
 static void pf_lldp_send (pnet_t * net, int loc_port_num)
 {
@@ -1134,7 +1135,8 @@ static void pf_lldp_trigger_sending (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param send             In:    Send LLDP message
  */
 static void pf_lldp_tx_restart (pnet_t * net, int loc_port_num, bool send)
@@ -1825,7 +1827,8 @@ int pf_lldp_generate_alias_name (
  *
  * @param net              InOut: p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param new_info         In:    Peer data to be stored
  */
 void pf_lldp_store_peer_info (
@@ -1853,7 +1856,8 @@ void pf_lldp_store_peer_info (
  *
  * @param net              InOut: p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param lldp_peer_info   In:    Peer data to be applied
  */
 void pf_lldp_update_peer (

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -502,7 +502,11 @@ static void pf_lldp_receive_timeout (
    pf_port_t * p_port_data = (pf_port_t *)arg;
 
    p_port_data->lldp.rx_timeout = 0;
-   LOG_WARNING (PF_LLDP_LOG, "LLDP(%d): Receive timeout expired\n", __LINE__);
+   LOG_INFO (
+      PF_LLDP_LOG,
+      "LLDP(%d): Port %d, receive timeout expired\n",
+      __LINE__,
+      p_port_data->port_num);
 
    pf_pdport_peer_lldp_timeout (net, p_port_data->port_num);
    pf_lldp_invalidate_peer_info (net, p_port_data->port_num);
@@ -1816,6 +1820,37 @@ int pf_lldp_generate_alias_name (
    return 0;
 }
 
+bool pf_lldp_is_alias_matching (pnet_t * net, const char * alias)
+{
+   char port_alias[PF_ALIAS_NAME_MAX_SIZE]; /** Terminated */
+   int port;
+   pf_port_iterator_t port_iterator;
+   pf_port_t * p_port_data = NULL;
+
+   pf_port_init_iterator_over_ports (net, &port_iterator);
+   port = pf_port_get_next (&port_iterator);
+   while (port != 0)
+   {
+      p_port_data = pf_port_get_state (net, port);
+      if (
+         p_port_data->lldp.is_peer_info_received &&
+         (pf_lldp_generate_alias_name (
+             p_port_data->lldp.peer_info.port_id.string,
+             p_port_data->lldp.peer_info.chassis_id.string,
+             port_alias,
+             sizeof (port_alias)) == 0))
+      {
+         if (strcmp (alias, port_alias) == 0)
+         {
+            return true;
+         }
+      }
+
+      port = pf_port_get_next (&port_iterator);
+   }
+   return false;
+}
+
 /**
  * @internal
  * Store peer information
@@ -1865,8 +1900,6 @@ void pf_lldp_update_peer (
    int loc_port_num,
    const pf_lldp_peer_info_t * lldp_peer_info)
 {
-   int error = 0;
-   char new_alias[PF_ALIAS_NAME_MAX_SIZE]; /** Terminated */
    pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
 
    pf_lldp_reset_peer_timeout (net, loc_port_num, lldp_peer_info->ttl);
@@ -1881,27 +1914,41 @@ void pf_lldp_update_peer (
       return;
    }
 
-   error = pf_lldp_generate_alias_name (
-      lldp_peer_info->port_id.string,
+   LOG_INFO (
+      PF_LLDP_LOG,
+      "LLDP(%d): Port %d, peer info changed\n",
+      __LINE__,
+      loc_port_num);
+
+   LOG_INFO (
+      PF_LLDP_LOG,
+      "LLDP(%d): Old peer info - MAC: %02X:%02X:%02X:%02X:%02X:%02X "
+      "Chassis ID: %s Port ID: %s\n",
+      __LINE__,
+      p_port_data->lldp.peer_info.mac_address.addr[0],
+      p_port_data->lldp.peer_info.mac_address.addr[1],
+      p_port_data->lldp.peer_info.mac_address.addr[2],
+      p_port_data->lldp.peer_info.mac_address.addr[3],
+      p_port_data->lldp.peer_info.mac_address.addr[4],
+      p_port_data->lldp.peer_info.mac_address.addr[5],
+      p_port_data->lldp.peer_info.chassis_id.string,
+      p_port_data->lldp.peer_info.port_id.string);
+
+   LOG_INFO (
+      PF_LLDP_LOG,
+      "LLDP(%d): New peer info - MAC: %02X:%02X:%02X:%02X:%02X:%02X "
+      "Chassis ID: %s Port ID: %s\n",
+      __LINE__,
+      lldp_peer_info->mac_address.addr[0],
+      lldp_peer_info->mac_address.addr[1],
+      lldp_peer_info->mac_address.addr[2],
+      lldp_peer_info->mac_address.addr[3],
+      lldp_peer_info->mac_address.addr[4],
+      lldp_peer_info->mac_address.addr[5],
       lldp_peer_info->chassis_id.string,
-      new_alias,
-      sizeof (new_alias));
-   if (!error && (strcmp (new_alias, net->cmina_current_dcp_ase.alias_name) != 0))
-   {
-      LOG_INFO (
-         PF_LLDP_LOG,
-         "LLDP(%d): Updating alias name: %s -> %s\n",
-         __LINE__,
-         net->cmina_current_dcp_ase.alias_name,
-         new_alias);
+      lldp_peer_info->port_id.string);
 
-      strncpy (
-         net->cmina_current_dcp_ase.alias_name,
-         new_alias,
-         sizeof (net->cmina_current_dcp_ase.alias_name));
-
-      pf_pdport_peer_indication (net, loc_port_num, lldp_peer_info);
-   }
+   pf_pdport_peer_indication (net, loc_port_num, lldp_peer_info);
 
    pf_lldp_store_peer_info (net, loc_port_num, lldp_peer_info);
 }

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -35,7 +35,8 @@ extern "C" {
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_timestamp_10ms Out:   Time when the LLDP packet with the info
  *                                was first received, in units of
@@ -70,7 +71,8 @@ void pf_lldp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id);
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_chassis_id     Out:   Chassis ID of remote device.
  * @return  0 if the operation succeeded.
@@ -88,7 +90,8 @@ int pf_lldp_get_peer_chassis_id (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_port_id        Out:   Port ID of local port.
  */
@@ -108,7 +111,8 @@ void pf_lldp_get_port_id (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_port_id        Out:   Port ID of remote port.
  * @return  0 if the operation succeeded.
@@ -126,7 +130,8 @@ int pf_lldp_get_peer_port_id (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_port_desc      Out:   Port description of local port.
  */
@@ -143,7 +148,8 @@ void pf_lldp_get_port_description (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_port_desc      Out:   Port description of remote port.
  * @return  0 if the operation succeeded.
@@ -185,7 +191,8 @@ void pf_lldp_get_management_address (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_man_address    Out:   Management address of remote interface.
  * @return  0 if the operation succeeded.
@@ -208,7 +215,8 @@ int pf_lldp_get_peer_management_address (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_station_name   Out:   Station name of remote interface.
  * @return  0 if the operation succeeded.
@@ -232,7 +240,8 @@ int pf_lldp_get_peer_station_name (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_port_name      Out:   Port name of remote port.
  * @return  0 if the operation succeeded.
@@ -252,7 +261,8 @@ int pf_lldp_get_peer_port_name (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_delays         Out:   Measured signal delays on local port.
  */
@@ -271,7 +281,8 @@ void pf_lldp_get_signal_delays (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_delays         Out:   Measured signal delays on remote port.
  * @return  0 if the operation succeeded.
@@ -289,7 +300,8 @@ int pf_lldp_get_peer_signal_delays (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_link_status    Out:   Link status of local port.
  */
@@ -306,7 +318,8 @@ void pf_lldp_get_link_status (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_port_get_list_of_ports().
  * @param p_link_status    Out:   Link status of remote port.
  * @return  0 if the operation succeeded.
@@ -366,7 +379,8 @@ void pf_lldp_init (pnet_t * net);
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
  * @param timeout_in_secs  In:    TTL of the peer, typically 20 seconds.
  */
 void pf_lldp_reset_peer_timeout (
@@ -380,7 +394,8 @@ void pf_lldp_reset_peer_timeout (
  * An initial lldp frame is transmitted when operation is called.
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
  */
 void pf_lldp_send_enable (pnet_t * net, int loc_port_num);
 
@@ -389,7 +404,8 @@ void pf_lldp_send_enable (pnet_t * net, int loc_port_num);
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
  */
 void pf_lldp_send_disable (pnet_t * net, int loc_port_num);
 

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -430,6 +430,16 @@ int pf_lldp_recv (
    pnal_buf_t * p_frame_buf,
    uint16_t offset);
 
+/**
+ * Check if an alias name matches any of the LLDP peers.
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param alias            In:    Alias to be compared with LLDP peers
+ * return                  true if the alias matches any of the peers,
+ *                         false if not.
+ */
+bool pf_lldp_is_alias_matching (pnet_t * net, const char * alias);
+
 /************ Internal functions, made available for unit testing ************/
 
 int pf_lldp_generate_alias_name (

--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -362,7 +362,7 @@ void pf_snmp_get_system_description (
 
 void pf_snmp_get_port_list (pnet_t * net, pf_lldp_port_list_t * p_list)
 {
-   pf_port_get_list_of_ports (net, PNET_MAX_PORT, p_list);
+   pf_port_get_list_of_ports (net, PNET_NUMBER_OF_PHYSICAL_PORTS, p_list);
 }
 
 void pf_snmp_init_port_iterator (pnet_t * net, pf_port_iterator_t * p_iterator)

--- a/src/common/pf_snmp.h
+++ b/src/common/pf_snmp.h
@@ -424,7 +424,8 @@ int pf_snmp_get_next_port (pf_port_iterator_t * p_iterator);
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_timestamp_10ms Out:   Time when the LLDP packet with the info
  *                                was first received, in units of
@@ -467,7 +468,8 @@ void pf_snmp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id);
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_chassis_id     Out:   Chassis ID of remote device.
  * @return  0 if the operation succeeded.
@@ -488,7 +490,8 @@ int pf_snmp_get_peer_chassis_id (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_port_id        Out:   Port ID of local port.
  */
@@ -514,7 +517,8 @@ void pf_snmp_get_port_id (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_port_id        Out:   Port ID of remote port.
  * @return  0 if the operation succeeded.
@@ -534,7 +538,8 @@ int pf_snmp_get_peer_port_id (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_port_desc      Out:   Port description of local port.
  */
@@ -556,7 +561,8 @@ void pf_snmp_get_port_description (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_port_desc      Out:   Port description of remote port.
  * @return  0 if the operation succeeded.
@@ -600,7 +606,8 @@ void pf_snmp_get_management_address (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_man_address    Out:   Management address of remote interface.
  * @return  0 if the operation succeeded.
@@ -651,7 +658,8 @@ void pf_snmp_get_management_port_index (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_man_port_index Out:   Index in remote IfTable for Management port.
  * @return  0 if the operation succeeded.
@@ -706,7 +714,8 @@ void pf_snmp_get_station_name (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_station_name   Out:   Station name of remote interface.
  * @return  0 if the operation succeeded.
@@ -729,7 +738,8 @@ int pf_snmp_get_peer_station_name (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_delays         Out:   Measured signal delays on local port.
  */
@@ -751,7 +761,8 @@ void pf_snmp_get_signal_delays (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_delays         Out:   Measured signal delays on remote port.
  * @return  0 if the operation succeeded.
@@ -777,7 +788,8 @@ int pf_snmp_get_peer_signal_delays (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_link_status    Out:   Link status of local port.
  */
@@ -802,7 +814,8 @@ void pf_snmp_get_link_status (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                See pf_snmp_get_next_port().
  * @param p_link_status    Out:   Link status of remote port.
  * @return  0 if the operation succeeded.

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3578,14 +3578,12 @@ void pf_put_pdport_data_real (
    pf_lldp_port_name_t port_name;
    pnal_eth_status_t eth_status;
    const uint16_t subslot = pf_port_loc_port_num_to_dap_subslot (loc_port_num);
-   const pnet_port_cfg_t * p_port_config =
-      pf_port_get_config (net, loc_port_num);
    const pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
    const pf_lldp_peer_info_t * p_peer_info = &p_port_data->lldp.peer_info;
 
    num_peers = p_port_data->lldp.is_peer_info_received ? 1 : 0;
 
-   if (pnal_eth_get_status (p_port_config->phy_port.if_name, &eth_status) != 0)
+   if (pnal_eth_get_status (p_port_data->netif.name, &eth_status) != 0)
    {
       memset (&eth_status, 0, sizeof (eth_status));
    }
@@ -3608,12 +3606,12 @@ void pf_put_pdport_data_real (
    pf_put_uint16 (is_big_endian, subslot, res_len, p_bytes, p_pos);
 
    /* Length OwnPortName */
-   pf_put_byte (strlen (p_port_config->port_name), res_len, p_bytes, p_pos);
+   pf_put_byte (strlen (p_port_data->port_name), res_len, p_bytes, p_pos);
 
    /* OwnPortName */
    pf_put_mem (
-      p_port_config->port_name,
-      strlen (p_port_config->port_name),
+      p_port_data->port_name,
+      strlen (p_port_data->port_name),
       res_len,
       p_bytes,
       p_pos);
@@ -3863,10 +3861,7 @@ static void pf_put_pd_multiblock_interface_and_statistics (
    uint16_t block_len = 0;
    pnal_port_stats_t port_stats;
 
-   if (
-      pnal_get_port_statistics (
-         net->fspm_cfg.if_cfg.main_port.if_name,
-         &port_stats) != 0)
+   if (pnal_get_port_statistics (net->pf_interface.main_port.name, &port_stats) != 0)
    {
       memset (&port_stats, 0, sizeof (port_stats));
    }
@@ -3947,9 +3942,9 @@ static void pf_put_pd_multiblock_port_and_statistics (
    uint16_t block_len = 0;
    pnal_port_stats_t port_stats;
    const uint16_t subslot = pf_port_loc_port_num_to_dap_subslot (loc_port_num);
-   const pnet_port_cfg_t * p_port_cfg = pf_port_get_config (net, loc_port_num);
+   const pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
 
-   if (pnal_get_port_statistics (p_port_cfg->phy_port.if_name, &port_stats) != 0)
+   if (pnal_get_port_statistics (p_port_data->netif.name, &port_stats) != 0)
    {
       memset (&port_stats, 0, sizeof (port_stats));
    }

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3923,7 +3923,8 @@ static void pf_put_pd_multiblock_interface_and_statistics (
  * @param net              InOut: The p-net stack instance
  * @param is_big_endian    In:    Endianness of the destination buffer.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param p_res            In:    The entity to insert
  * @param res_len          In:    Size of destination buffer.
  * @param p_bytes          Out:   Destination buffer.

--- a/src/device/pf_block_writer.h
+++ b/src/device/pf_block_writer.h
@@ -765,7 +765,8 @@ void pf_put_pd_interface_adj (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param is_big_endian    In:    Endianness of the destination buffer.
  * @param p_res            In:    Read result
  * @param res_len          In:    Size of destination buffer.

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -1150,10 +1150,6 @@ int pf_cmina_dcp_get_req (
          *p_block_error = PF_DCP_BLOCK_ERROR_SUBOPTION_NOT_SUPPORTED;
          ret = -1;
          break;
-      case PF_DCP_SUB_DEV_PROP_ALIAS:
-         *p_value_length = sizeof (net->cmina_current_dcp_ase.alias_name);
-         *pp_value = (uint8_t *)&net->cmina_current_dcp_ase.alias_name;
-         break;
       case PF_DCP_SUB_DEV_PROP_INSTANCE:
          *p_value_length = sizeof (net->cmina_current_dcp_ase.instance_id);
          *pp_value = (uint8_t *)&net->cmina_current_dcp_ase.instance_id;
@@ -1167,6 +1163,7 @@ int pf_cmina_dcp_get_req (
             sizeof (net->cmina_current_dcp_ase.standard_gw_value);
          *pp_value = (uint8_t *)&net->cmina_current_dcp_ase.standard_gw_value;
          break;
+      case PF_DCP_SUB_DEV_PROP_ALIAS:
       default:
          *p_block_error = PF_DCP_BLOCK_ERROR_SUBOPTION_NOT_SUPPORTED;
          ret = -1;

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -191,7 +191,7 @@ int pf_cmina_set_default_cfg (pnet_t * net, uint16_t reset_mode)
 
       memcpy (
          net->cmina_nonvolatile_dcp_ase.mac_address.addr,
-         p_cfg->if_cfg.main_port.eth_addr.addr,
+         net->pf_interface.main_port.mac_address.addr,
          sizeof (pnet_ethaddr_t));
 
       strcpy (net->cmina_nonvolatile_dcp_ase.port_name, ""); /* Terminated */
@@ -420,7 +420,7 @@ void pf_cmina_dcp_set_commit (pnet_t * net)
 
       net->cmina_commit_ip_suite = false;
       res = pnal_set_ip_suite (
-         net->fspm_cfg.if_cfg.main_port.if_name,
+         net->pf_interface.main_port.name,
          &net->cmina_current_dcp_ase.full_ip_suite.ip_suite.ip_addr,
          &net->cmina_current_dcp_ase.full_ip_suite.ip_suite.ip_mask,
          &net->cmina_current_dcp_ase.full_ip_suite.ip_suite.ip_gateway,
@@ -1265,7 +1265,7 @@ pnal_ipaddr_t pf_cmina_get_gateway (const pnet_t * net)
 
 const pnet_ethaddr_t * pf_cmina_get_device_macaddr (const pnet_t * net)
 {
-   return &net->fspm_cfg.if_cfg.main_port.eth_addr;
+   return &net->pf_interface.main_port.mac_address;
 }
 
 /************************* Utilites ******************************************/
@@ -1344,19 +1344,16 @@ void pf_cmina_port_statistics_show (pnet_t * net)
    int port;
    pf_port_iterator_t port_iterator;
    pnal_port_stats_t stats;
-   const pnet_port_cfg_t * p_port_config;
+   pf_port_t * p_port_data;
 
-   if (
-      pnal_get_port_statistics (
-         net->fspm_cfg.if_cfg.main_port.if_name,
-         &stats) == 0)
+   if (pnal_get_port_statistics (net->pf_interface.main_port.name, &stats) == 0)
    {
       printf (
          "Main interface %s    In: %" PRIu32 " bytes %" PRIu32
          " errors %" PRIu32 " discards  Out: %" PRIu32 " bytes %" PRIu32
          " errors %" PRIu32 " discards"
          "s\n",
-         net->fspm_cfg.if_cfg.main_port.if_name,
+         net->pf_interface.main_port.name,
          stats.if_in_octets,
          stats.if_in_errors,
          stats.if_in_discards,
@@ -1368,23 +1365,23 @@ void pf_cmina_port_statistics_show (pnet_t * net)
    {
       printf (
          "Did not find main interface %s\n",
-         net->fspm_cfg.if_cfg.main_port.if_name);
+         net->pf_interface.main_port.name);
    }
 
    pf_port_init_iterator_over_ports (net, &port_iterator);
    port = pf_port_get_next (&port_iterator);
    while (port != 0)
    {
-      p_port_config = pf_port_get_config (net, port);
+      p_port_data = pf_port_get_state (net, port);
 
-      if (pnal_get_port_statistics (p_port_config->phy_port.if_name, &stats) == 0)
+      if (pnal_get_port_statistics (p_port_data->netif.name, &stats) == 0)
       {
          printf (
             "Port        %s    In: %" PRIu32 " bytes %" PRIu32
             " errors %" PRIu32 " discards  Out: %" PRIu32 " bytes %" PRIu32
             " errors %" PRIu32 " discards"
             "s\n",
-            p_port_config->phy_port.if_name,
+            p_port_data->netif.name,
             stats.if_in_octets,
             stats.if_in_errors,
             stats.if_in_discards,
@@ -1394,7 +1391,7 @@ void pf_cmina_port_statistics_show (pnet_t * net)
       }
       else
       {
-         printf ("Did not find port %s\n", p_port_config->phy_port.if_name);
+         printf ("Did not find port %s\n", p_port_data->netif.name);
       }
 
       port = pf_port_get_next (&port_iterator);
@@ -1471,12 +1468,12 @@ void pf_cmina_show (pnet_t * net)
 
    printf (
       "MAC                            : %02x:%02x:%02x:%02x:%02x:%02x\n",
-      p_cfg->if_cfg.main_port.eth_addr.addr[0],
-      p_cfg->if_cfg.main_port.eth_addr.addr[1],
-      p_cfg->if_cfg.main_port.eth_addr.addr[2],
-      p_cfg->if_cfg.main_port.eth_addr.addr[3],
-      p_cfg->if_cfg.main_port.eth_addr.addr[4],
-      p_cfg->if_cfg.main_port.eth_addr.addr[5]);
+      net->pf_interface.main_port.mac_address.addr[0],
+      net->pf_interface.main_port.mac_address.addr[1],
+      net->pf_interface.main_port.mac_address.addr[2],
+      net->pf_interface.main_port.mac_address.addr[3],
+      net->pf_interface.main_port.mac_address.addr[4],
+      net->pf_interface.main_port.mac_address.addr[5]);
 
    pf_cmina_port_statistics_show (net);
 }

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -471,7 +471,7 @@ static int pf_session_allocate (pnet_t * net, pf_session_info_t ** pp_sess)
       p_sess = &net->cmrpc_session_info[ix];
       memset (p_sess, 0, sizeof (*p_sess));
       p_sess->in_use = true;
-      p_sess->eth_handle = net->eth_handle;
+      p_sess->eth_handle = net->pf_interface.main_port.handle;
       p_sess->p_ar = NULL;
       p_sess->sequence_nmb_send = 0;
       p_sess->dcontrol_sequence_nmb = UINT32_MAX;

--- a/src/device/pf_cmrpc_epm.c
+++ b/src/device/pf_cmrpc_epm.c
@@ -161,7 +161,7 @@ static int pf_cmrdr_add_epmv4_entry (
 {
    pf_generate_epm_handle (
       os_get_current_time_us(),
-      net->fspm_cfg.if_cfg.main_port.eth_addr,
+      net->pf_interface.main_port.mac_address,
       &p_lookup_rsp->rpc_handle);
 
    p_lookup_rsp->num_entry++;
@@ -202,7 +202,7 @@ static int pf_cmrdr_add_pnio_entry (
 {
    pf_generate_epm_handle (
       os_get_current_time_us(),
-      net->fspm_cfg.if_cfg.main_port.eth_addr,
+      net->pf_interface.main_port.mac_address,
       &p_lookup_rsp->rpc_handle);
 
    /*Set the number of entries */

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -222,7 +222,7 @@ int pf_fspm_validate_configuration (const pnet_cfg_t * p_cfg)
       return -1;
    }
 
-   if (strlen (p_cfg->if_cfg.main_port.if_name) == 0)
+   if (strlen (p_cfg->if_cfg.main_netif_name) == 0)
    {
       LOG_ERROR (
          PNET_LOG,

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -116,8 +116,8 @@ void pf_fspm_option_show (const pnet_t * net)
       "PNET_MAX_DFP_IOCR                              : %d\n",
       PNET_MAX_DFP_IOCR);
    printf (
-      "PNET_MAX_PORT                                  : %d\n",
-      PNET_MAX_PORT);
+      "PNET_NUMBER_OF_PHYSICAL_PORTS                             : %d\n",
+      PNET_NUMBER_OF_PHYSICAL_PORTS);
    printf (
       "PNET_MAX_LOG_BOOK_ENTRIES                      : %d\n",
       PNET_MAX_LOG_BOOK_ENTRIES);

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -399,7 +399,6 @@ int pf_pdport_read_ind (
    pf_port_iterator_t port_iterator;
    pnal_port_stats_t port_stats;
    pf_port_t * p_port_data;
-   const pnet_port_cfg_t * p_port_cfg;
    uint16_t slot = p_read_req->slot_number;
    uint16_t subslot = p_read_req->subslot_number;
    uint16_t index = p_read_req->index;
@@ -532,12 +531,12 @@ int pf_pdport_read_ind (
 
          if (loc_port_num == 0)
          {
-            netif_name = net->fspm_cfg.if_cfg.main_port.if_name;
+            netif_name = net->interface.main_port.name;
          }
          else
          {
-            p_port_cfg = pf_port_get_config (net, loc_port_num);
-            netif_name = p_port_cfg->phy_port.if_name;
+            p_port_data = pf_port_get_state (net, loc_port_num);
+            netif_name = p_port_data->netif.name;
          }
 
          if (pnal_get_port_statistics (netif_name, &port_stats) == 0)

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -27,7 +27,8 @@
  * Get configuration file name for one port
  *
  * @param loc_port_num      In:   Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @return  The configuration file name
  */
 static const char * pf_pdport_get_filename (int loc_port_num)
@@ -58,7 +59,8 @@ static const char * pf_pdport_get_filename (int loc_port_num)
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @return  0  if operation succeeded.
  *          -1 if an error occurred.
  */
@@ -152,7 +154,8 @@ static int pf_pdport_load (pnet_t * net, int loc_port_num)
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @return  0  if operation succeeded.
  *          -1 if an error occurred.
  */
@@ -213,7 +216,8 @@ static int pf_pdport_save (pnet_t * net, int loc_port_num)
  * @param diag_source      InOut: Diag source to be initialized
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  */
 static void pf_pdport_init_diag_source (
    pnet_diag_source_t * diag_source,
@@ -232,7 +236,8 @@ static void pf_pdport_init_diag_source (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num      In:   Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  */
 static void pf_pdport_remove_all_diag (pnet_t * net, int loc_port_num)
 {
@@ -315,7 +320,7 @@ void pf_pdport_remove_data_files (const char * file_directory)
    int port;
 
    /* Do not use port iterator as net is not available */
-   for (port = PNET_PORT_1; port <= PNET_MAX_PORT; port++)
+   for (port = PNET_PORT_1; port <= PNET_NUMBER_OF_PHYSICAL_PORTS; port++)
    {
       pf_file_clear (file_directory, pf_pdport_get_filename (port));
    }
@@ -531,7 +536,7 @@ int pf_pdport_read_ind (
 
          if (loc_port_num == 0)
          {
-            netif_name = net->interface.main_port.name;
+            netif_name = net->pf_interface.main_port.name;
          }
          else
          {
@@ -590,7 +595,8 @@ int pf_pdport_read_ind (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  */
 static void pf_pdport_check_peer_station_name (pnet_t * net, int loc_port_num)
 {
@@ -663,7 +669,8 @@ static void pf_pdport_check_peer_station_name (pnet_t * net, int loc_port_num)
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  */
 static void pf_pdport_check_peer_port_name (pnet_t * net, int loc_port_num)
 {
@@ -736,7 +743,8 @@ static void pf_pdport_check_peer_port_name (pnet_t * net, int loc_port_num)
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  */
 static void pf_pdport_run_peer_check (pnet_t * net, int loc_port_num)
 {
@@ -817,7 +825,8 @@ void pf_pdport_periodic (pnet_t * net)
  * @param p_ar             In:    The AR instance.
  * @param p_write_req      In:    The IODWrite request.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param p_bytes          In:    Input data
  * @param p_datalength     In:    Size of the data to write.
  * @param p_result         Out:   Detailed error information.
@@ -917,7 +926,8 @@ static int pf_pdport_write_data_check (
  * @param p_ar             In:    The AR instance.
  * @param p_write_req      In:    The IODWrite request.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param p_bytes          In:    Input data
  * @param p_datalength     In:    Size of the data to write.
  * @param p_result         Out:   Detailed error information.

--- a/src/device/pf_pdport.h
+++ b/src/device/pf_pdport.h
@@ -132,7 +132,8 @@ int pf_pdport_write_req (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param p_lldp_peer_info In:    Peer info
  */
 void pf_pdport_peer_indication (
@@ -146,7 +147,8 @@ void pf_pdport_peer_indication (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  */
 void pf_pdport_peer_lldp_timeout (pnet_t * net, int loc_port_num);
 

--- a/src/device/pf_port.c
+++ b/src/device/pf_port.c
@@ -17,8 +17,13 @@
 
 #include <string.h>
 
-#if PNET_MAX_PORT < 1
-#error "PNET_MAX_PORT needs to be at least 1"
+#if PNET_NUMBER_OF_PHYSICAL_PORTS < 1
+#error "PNET_NUMBER_OF_PHYSICAL_PORTS needs to be at least 1"
+#endif
+
+#if PNET_MAX_SUBSLOTS < (2 + PNET_NUMBER_OF_PHYSICAL_PORTS)
+#error                                                                         \
+   "DAP requires 2 + PNET_NUMBER_OF_PHYSICAL_PORTS subslots. Increase PNET_MAX_SUBSLOTS."
 #endif
 
 /**
@@ -79,7 +84,9 @@ int pf_port_get_next (pf_port_iterator_t * p_iterator)
 {
    int ret = p_iterator->next_port;
 
-   if (p_iterator->next_port == PNET_MAX_PORT || p_iterator->next_port == 0)
+   if (
+      p_iterator->next_port == PNET_NUMBER_OF_PHYSICAL_PORTS ||
+      p_iterator->next_port == 0)
    {
       p_iterator->next_port = 0;
    }
@@ -93,13 +100,15 @@ int pf_port_get_next (pf_port_iterator_t * p_iterator)
 
 pf_port_t * pf_port_get_state (pnet_t * net, int loc_port_num)
 {
-   CC_ASSERT (loc_port_num > 0 && loc_port_num <= PNET_MAX_PORT);
+   CC_ASSERT (
+      loc_port_num > 0 && loc_port_num <= PNET_NUMBER_OF_PHYSICAL_PORTS);
    return &net->pf_interface.port[loc_port_num - 1];
 }
 
 const pnet_port_cfg_t * pf_port_get_config (pnet_t * net, int loc_port_num)
 {
-   CC_ASSERT (loc_port_num > 0 && loc_port_num <= PNET_MAX_PORT);
+   CC_ASSERT (
+      loc_port_num > 0 && loc_port_num <= PNET_NUMBER_OF_PHYSICAL_PORTS);
    return &net->fspm_cfg.if_cfg.physical_ports[loc_port_num - 1];
 }
 
@@ -113,7 +122,7 @@ uint16_t pf_port_loc_port_num_to_dap_subslot (int loc_port_num)
 int pf_port_dap_subslot_to_local_port (uint16_t subslot)
 {
    int port = PNET_PORT_1 + subslot - PNET_SUBSLOT_DAP_INTERFACE_1_PORT_1_IDENT;
-   if (port < PNET_PORT_1 || port > PNET_MAX_PORT)
+   if (port < PNET_PORT_1 || port > PNET_NUMBER_OF_PHYSICAL_PORTS)
    {
       port = 0;
    }
@@ -128,14 +137,15 @@ bool pf_port_subslot_is_dap_port_id (uint16_t subslot)
 
 bool pf_port_is_valid (pnet_t * net, int loc_port_num)
 {
-   return (loc_port_num > 0 && loc_port_num <= PNET_MAX_PORT);
+   return (loc_port_num > 0 && loc_port_num <= PNET_NUMBER_OF_PHYSICAL_PORTS);
 }
 
 int pf_port_get_port_number (pnet_t * net, pnal_eth_handle_t * eth_handle)
 {
    int loc_port_num;
 
-   for (loc_port_num = 1; loc_port_num <= PNET_MAX_PORT; loc_port_num++)
+   for (loc_port_num = 1; loc_port_num <= PNET_NUMBER_OF_PHYSICAL_PORTS;
+        loc_port_num++)
    {
       if (net->pf_interface.port[loc_port_num - 1].netif.handle == eth_handle)
       {

--- a/src/device/pf_port.c
+++ b/src/device/pf_port.c
@@ -39,6 +39,11 @@ void pf_port_init (pnet_t * net)
    {
       p_port_data = pf_port_get_state (net, port);
       p_port_data->port_num = port;
+      snprintf (
+         p_port_data->port_name,
+         sizeof (p_port_data->port_name),
+         "port-%03u",
+         (uint8_t)port); /* Cast to avoid format-truncation */
       port = pf_port_get_next (&port_iterator);
    }
 }
@@ -95,7 +100,7 @@ pf_port_t * pf_port_get_state (pnet_t * net, int loc_port_num)
 const pnet_port_cfg_t * pf_port_get_config (pnet_t * net, int loc_port_num)
 {
    CC_ASSERT (loc_port_num > 0 && loc_port_num <= PNET_MAX_PORT);
-   return &net->fspm_cfg.if_cfg.ports[loc_port_num - 1];
+   return &net->fspm_cfg.if_cfg.physical_ports[loc_port_num - 1];
 }
 
 uint16_t pf_port_loc_port_num_to_dap_subslot (int loc_port_num)
@@ -132,7 +137,7 @@ int pf_port_get_port_number (pnet_t * net, pnal_eth_handle_t * eth_handle)
 
    for (loc_port_num = 1; loc_port_num <= PNET_MAX_PORT; loc_port_num++)
    {
-      if (net->pf_interface.port[loc_port_num - 1].eth_handle == eth_handle)
+      if (net->pf_interface.port[loc_port_num - 1].netif.handle == eth_handle)
       {
          return loc_port_num;
       }

--- a/src/device/pf_port.h
+++ b/src/device/pf_port.h
@@ -35,7 +35,7 @@ void pf_port_init (pnet_t * net);
  *
  * @param net              In:    The p-net stack instance.
  * @param max_port         In:    Max port number supported.
- *                                Typically PNET_MAX_PORT.
+ *                                Typically PNET_NUMBER_OF_PHYSICAL_PORTS.
  *                                Parameter added for testability.
  * @param p_list           Out:   List of local ports.
  */
@@ -74,7 +74,8 @@ int pf_port_get_next (pf_port_iterator_t * p_iterator);
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @return DAP subslot number for port identity
  */
 uint16_t pf_port_loc_port_num_to_dap_subslot (int loc_port_num);
@@ -91,7 +92,7 @@ bool pf_port_subslot_is_dap_port_id (uint16_t subslot);
 /**
  * Get local port from DAP port subslot
  *
- * Considers PNET_MAX_PORT
+ * Considers PNET_NUMBER_OF_PHYSICAL_PORTS
  *
  * @param subslot              In: Subslot number
  * @return The port number mapping to the subslot.
@@ -109,7 +110,8 @@ int pf_port_dap_subslot_to_local_port (uint16_t subslot);
  *
  * @param net              In:    The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @return port runtime data
  */
 pf_port_t * pf_port_get_state (pnet_t * net, int loc_port_num);
@@ -124,7 +126,8 @@ pf_port_t * pf_port_get_state (pnet_t * net, int loc_port_num);
  *
  * @param net              In:    The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
  * @return port configuration
  */
 const pnet_port_cfg_t * pf_port_get_config (pnet_t * net, int loc_port_num);
@@ -134,7 +137,8 @@ const pnet_port_cfg_t * pf_port_get_config (pnet_t * net, int loc_port_num);
  *
  * @param net              In:    The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. PNET_MAX_PORT
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @return  true  if port number is valid,
  *          false if not
  */

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2728,14 +2728,21 @@ typedef struct pf_lldp_port
    bool is_peer_info_received;
 } pf_lldp_port_t;
 
+/** Network interface */
+typedef struct pf_netif
+{
+   char name[PNET_INTERFACE_NAME_MAX_SIZE]; /**< Terminated string */
+   pnet_ethaddr_t mac_address;
+   pnal_eth_handle_t * handle;
+} pf_netif_t;
+
 /**
  * Port runtime data
- * Note that physical port configuration
- * is part of the configuration (pnet_port_cfg_t)
  */
 typedef struct pf_port
 {
-   pnal_eth_handle_t * eth_handle;
+   pf_netif_t netif;
+   char port_name[PNET_PORT_NAME_MAX_SIZE]; /* Terminated string */
    uint8_t port_num;
    pf_pdport_t pdport;
    pf_lldp_port_t lldp;
@@ -2757,7 +2764,6 @@ struct pnet
    uint32_t dcp_sam_timeout;          /* Handle to the SAM timeout instance */
    uint32_t dcp_identresp_timeout;    /* Handle to the DCP identify timeout
                                          instance */
-   pnal_eth_handle_t * eth_handle;    /* Management port */
    pf_eth_frame_id_map_t eth_id_map[PF_ETH_MAX_MAP];
    volatile pf_scheduler_timeouts_t scheduler_timeouts[PF_MAX_TIMEOUTS];
    volatile uint32_t scheduler_timeout_first;
@@ -2811,6 +2817,7 @@ struct pnet
     */
    struct
    {
+      pf_netif_t main_port; /* Management port */
       struct
       {
          bool active;

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -1103,8 +1103,6 @@ typedef struct pf_cmina_dcp_ase
    uint8_t device_role;        /* Only value "1" supported */
    uint16_t device_initiative; /* 1: Should send hello. 0: No sending of hello
                                 */
-
-   char alias_name[PF_ALIAS_NAME_MAX_SIZE]; /** Terminated */
    struct
    {
       /* Order is important!! */

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -1702,7 +1702,7 @@ typedef struct pf_cpm
    uint16_t dht; /* Set to zero at incoming cyclic frame, increased by
                     pf_cpm_control_interval_expired() */
    bool new_data;
-   uint32_t rxa[PNET_MAX_PORT][2]; /* Max 2 frame_ids */
+   uint32_t rxa[PNET_NUMBER_OF_PHYSICAL_PORTS][2]; /* Max 2 frame_ids */
    int32_t cycle;                  /* value -1 means "never" */
 
    uint32_t control_interval;
@@ -2823,7 +2823,7 @@ struct pnet
          bool active;
          pf_lldp_name_of_device_mode_t mode;
       } name_of_device_mode;
-      pf_port_t port[PNET_MAX_PORT];
+      pf_port_t port[PNET_NUMBER_OF_PHYSICAL_PORTS];
    } pf_interface;
 };
 

--- a/src/ports/linux/pnal_eth.c
+++ b/src/ports/linux/pnal_eth.c
@@ -128,7 +128,7 @@ pnal_eth_handle_t * pnal_eth_init (
    strcpy (ifr.ifr_name, if_name);
    ifr.ifr_flags = 0;
    ioctl (handle->socket, SIOCGIFFLAGS, &ifr);
-   ifr.ifr_flags = ifr.ifr_flags | IFF_PROMISC | IFF_BROADCAST;
+   ifr.ifr_flags = ifr.ifr_flags | IFF_MULTICAST | IFF_BROADCAST;
    ioctl (handle->socket, SIOCSIFFLAGS, &ifr);
 
    /* Bind socket to all protocols */

--- a/src/ports/linux/sampleapp_main.c
+++ b/src/ports/linux/sampleapp_main.c
@@ -34,11 +34,11 @@
 #include <string.h>
 #include <unistd.h>
 
-#if PNET_MAX_PORT == 1
+#if PNET_NUMBER_OF_PHYSICAL_PORTS == 1
 #define APP_DEFAULT_ETHERNET_INTERFACE "eth0"
-#elif PNET_MAX_PORT == 2
+#elif PNET_NUMBER_OF_PHYSICAL_PORTS == 2
 #define APP_DEFAULT_ETHERNET_INTERFACE "br0,eth0,eth1"
-#elif PNET_MAX_PORT == 3
+#elif PNET_NUMBER_OF_PHYSICAL_PORTS == 3
 #define APP_DEFAULT_ETHERNET_INTERFACE "br0,eth0,eth1,eth2"
 #else
 #define APP_DEFAULT_ETHERNET_INTERFACE ""
@@ -383,7 +383,7 @@ int main (int argc, char * argv[])
          PNET_MAX_SLOTS);
       printf ("P-net log level:      %u (DEBUG=0, FATAL=4)\n", LOG_LEVEL);
       printf ("App verbosity level:  %u\n", appdata.arguments.verbosity);
-      printf ("Number of ports:      %u\n", PNET_MAX_PORT);
+      printf ("Number of ports:      %u\n", PNET_NUMBER_OF_PHYSICAL_PORTS);
       printf ("Network interfaces:   %s\n", appdata.arguments.eth_interfaces);
       printf ("Button1 file:         %s\n", appdata.arguments.path_button1);
       printf ("Button2 file:         %s\n", appdata.arguments.path_button2);

--- a/src/ports/linux/sampleapp_main.c
+++ b/src/ports/linux/sampleapp_main.c
@@ -396,6 +396,7 @@ int main (int argc, char * argv[])
 
    ret = app_pnet_cfg_init_netifs (
       appdata.arguments.eth_interfaces,
+      &appdata.if_list,
       &pnet_default_cfg,
       appdata.arguments.verbosity);
    if (ret != 0)

--- a/src/ports/rt-kernel/mib/lldp-ext-dot3-mib.c
+++ b/src/ports/rt-kernel/mib/lldp-ext-dot3-mib.c
@@ -405,7 +405,8 @@ static snmp_err_t lldpxdot3remporttable_get_next_instance (
  * @param value            Out:   Value to be returned in response.
  * @param port             In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param column           In:    Column index for the cell.
  * @return  Size of returned value, in bytes.
  *          -1 if no valid value could be returned.

--- a/src/ports/rt-kernel/mib/lldp-ext-pno-mib.c
+++ b/src/ports/rt-kernel/mib/lldp-ext-pno-mib.c
@@ -414,7 +414,8 @@ static snmp_err_t lldpxpnoremtable_get_next_instance (
  * @param value            Out:   Value to be returned in response.
  * @param port             In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param column           In:    Column index for the cell.
  * @return  Size of returned value, in bytes.
  *          -1 if no valid value could be returned.

--- a/src/ports/rt-kernel/mib/lldp-mib.c
+++ b/src/ports/rt-kernel/mib/lldp-mib.c
@@ -828,7 +828,8 @@ static snmp_err_t lldpremtable_get_next_instance (
  * @param value            Out:   Value to be returned in response.
  * @param port             In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param column           In:    Column index for the cell.
  * @return  Size of returned value, in bytes.
  *          -1 if no valid value could be returned.
@@ -1071,7 +1072,8 @@ static snmp_err_t lldpremmanaddrtable_get_next_instance (
  * @param value            Out:   Value to be returned in response.
  * @param port             In:    Local port number for port directly
  *                                connected to the remote interface.
- *                                Valid range: 1 .. PNET_MAX_PORT.
+ *                                Valid range:
+ *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
  * @param column           In:    Column index for the cell.
  * @return  Size of returned value, in bytes.
  *          -1 if no valid value could be returned.

--- a/src/ports/rt-kernel/sampleapp_main.c
+++ b/src/ports/rt-kernel/sampleapp_main.c
@@ -198,6 +198,7 @@ int main (void)
 
    ret = app_pnet_cfg_init_netifs (
       appdata.arguments.eth_interfaces,
+      &appdata.if_list,
       &pnet_default_cfg,
       appdata.arguments.verbosity);
    if (ret != 0)

--- a/src/ports/rt-kernel/sampleapp_main.c
+++ b/src/ports/rt-kernel/sampleapp_main.c
@@ -186,7 +186,7 @@ int main (void)
          PNET_MAX_SLOTS);
       printf ("P-net log level:      %u (DEBUG=0, FATAL=4)\n", LOG_LEVEL);
       printf ("App verbosity level:  %u\n", appdata.arguments.verbosity);
-      printf ("Number of ports:      %u\n", PNET_MAX_PORT);
+      printf ("Number of ports:      %u\n", PNET_NUMBER_OF_PHYSICAL_PORTS);
       printf ("Network interfaces:   %s\n", appdata.arguments.eth_interfaces);
       printf ("Default station name: %s\n", appdata.arguments.station_name);
    }

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -117,6 +117,19 @@ int mock_pnal_eth_send (pnal_eth_handle_t * handle, pnal_buf_t * p_buf)
    return p_buf->len;
 }
 
+int mock_pnal_get_macaddress (
+   const char * interface_name,
+   pnal_ethaddr_t * p_mac)
+{
+   p_mac->addr[0] = 0x12;
+   p_mac->addr[1] = 0x34;
+   p_mac->addr[2] = 0x00;
+   p_mac->addr[3] = 0x78;
+   p_mac->addr[4] = 0x90;
+   p_mac->addr[5] = 0xab;
+   return 0;
+}
+
 int mock_pnal_udp_open (pnal_ipaddr_t addr, pnal_ipport_t port)
 {
    int ret = 2;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -37,7 +37,7 @@ typedef struct mock_os_data_obj
     * Note that port numbers start at 1. To simplify test cases, we add a
     * dummy array element at index 0.
     */
-   pnal_eth_status_t eth_status[PNET_MAX_PORT + 1];
+   pnal_eth_status_t eth_status[PNET_NUMBER_OF_PHYSICAL_PORTS + 1];
 
    uint16_t udp_sendto_len;
    uint16_t udp_sendto_count;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -102,6 +102,9 @@ pnal_eth_handle_t * mock_pnal_eth_init (
    pnal_eth_callback_t * callback,
    void * arg);
 int mock_pnal_eth_send (pnal_eth_handle_t * handle, pnal_buf_t * buf);
+int mock_pnal_get_macaddress (
+   const char * interface_name,
+   pnal_ethaddr_t * p_mac);
 int mock_pnal_eth_get_status (
    const char * interface_name,
    pnal_eth_status_t * status);

--- a/test/test_cmrpc.cpp
+++ b/test/test_cmrpc.cpp
@@ -659,7 +659,7 @@ TEST_F (CmrpcTest, CmrpcConnectReleaseIOSAR_DA)
    EXPECT_EQ (appdata.call_counters.state_calls, 1);
    EXPECT_EQ (appdata.cmdev_state, PNET_EVENT_STARTUP);
    EXPECT_EQ (appdata.call_counters.connect_calls, 1);
-   EXPECT_EQ (mock_os_data.eth_send_count, PNET_MAX_PORT);
+   EXPECT_EQ (mock_os_data.eth_send_count, PNET_NUMBER_OF_PHYSICAL_PORTS);
 
    TEST_TRACE ("\nGenerating mock release request IOSAR_DA\n");
    mock_set_pnal_udp_recvfrom_buffer (

--- a/test/test_dcp.cpp
+++ b/test/test_dcp.cpp
@@ -104,7 +104,7 @@ TEST_F (DcpTest, DcpHelloTest)
    ret = pf_eth_recv (mock_os_data.eth_if_handle, net, p_buf);
 
    EXPECT_EQ (ret, 1);
-   EXPECT_EQ (mock_os_data.eth_send_count, PNET_MAX_PORT + 1);
+   EXPECT_EQ (mock_os_data.eth_send_count, PNET_NUMBER_OF_PHYSICAL_PORTS + 1);
 
    EXPECT_EQ (appdata.call_counters.led_off_calls, 1);
    EXPECT_EQ (appdata.call_counters.led_on_calls, 0);
@@ -154,7 +154,9 @@ TEST_F (DcpTest, DcpRunTest)
    /* Wait for LED to flash three times at 1 Hz */
    run_stack (4 * 1000 * 1000);
 
-   EXPECT_EQ (mock_os_data.eth_send_count, 9 + (PNET_MAX_PORT - 1) * 4);
+   EXPECT_EQ (
+      mock_os_data.eth_send_count,
+      9 + (PNET_NUMBER_OF_PHYSICAL_PORTS - 1) * 4);
    EXPECT_EQ (mock_os_data.set_ip_suite_count, 2);
 
    EXPECT_EQ (appdata.call_counters.led_on_calls, 3);

--- a/test/test_fspm.cpp
+++ b/test/test_fspm.cpp
@@ -37,7 +37,7 @@ TEST_F (FspmUnitTest, FspmCheckValidateConfiguration)
    cfg.tick_us = 1000;
    cfg.min_device_interval = 1;
    cfg.im_0_data.im_supported = 0;
-   strcpy (cfg.if_cfg.main_port.if_name, "eth0");
+   cfg.if_cfg.main_netif_name = "eth0";
 
    EXPECT_EQ (pf_fspm_validate_configuration (&cfg), 0);
 

--- a/test/test_lldp.cpp
+++ b/test/test_lldp.cpp
@@ -460,7 +460,7 @@ TEST_F (LldpTest, LldpInitTest)
    EXPECT_EQ (appdata.call_counters.ccontrol_calls, 0);
    EXPECT_EQ (appdata.call_counters.read_calls, 0);
    EXPECT_EQ (appdata.call_counters.write_calls, 0);
-   EXPECT_EQ (mock_os_data.eth_send_count, PNET_MAX_PORT);
+   EXPECT_EQ (mock_os_data.eth_send_count, PNET_NUMBER_OF_PHYSICAL_PORTS);
 }
 
 TEST_F (LldpTest, LldpGenerateAliasName)

--- a/test/test_port.cpp
+++ b/test/test_port.cpp
@@ -71,7 +71,7 @@ TEST_F (PortTest, PortCheckIterator)
    EXPECT_EQ (port, 1);
 
    /* More ports might be available dependent on compile time setting */
-   for (ix = 2; ix <= PNET_MAX_PORT; ix++)
+   for (ix = 2; ix <= PNET_NUMBER_OF_PHYSICAL_PORTS; ix++)
    {
       port = pf_port_get_next (&port_iterator);
       EXPECT_EQ (port, ix);
@@ -129,7 +129,7 @@ TEST_F (PortTest, dap_subslot_to_local_port)
    EXPECT_EQ (local_port_num, 0);
 
    /* Invalid / not port sub slot  (high)*/
-   local_port_num =
-      pf_port_dap_subslot_to_local_port (0x8000 + PNET_MAX_PORT + 1);
+   local_port_num = pf_port_dap_subslot_to_local_port (
+      0x8000 + PNET_NUMBER_OF_PHYSICAL_PORTS + 1);
    EXPECT_EQ (local_port_num, 0);
 }

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -493,18 +493,7 @@ void PnetIntegrationTestBase::cfg_init()
    strcpy (pnet_default_cfg.station_name, "");
    strcpy (pnet_default_cfg.product_name, "PNET unit tests");
 
-   strcpy (
-      pnet_default_cfg.if_cfg.ports[0].phy_port.if_name,
-      TEST_INTERFACE_NAME);
-   strcpy (pnet_default_cfg.if_cfg.ports[0].port_name, "port-001");
-   pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[0] = 0x12;
-   pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[1] = 0x34;
-   pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[2] = 0x00;
-   pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[3] = 0x78;
-   pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[4] = 0x90;
-   pnet_default_cfg.if_cfg.ports[0].phy_port.eth_addr.addr[5] = 0xab;
-   pnet_default_cfg.if_cfg.ports[0].rtclass_2_status = 0;
-   pnet_default_cfg.if_cfg.ports[0].rtclass_3_status = 0;
+   pnet_default_cfg.if_cfg.physical_ports[0].netif_name = TEST_INTERFACE_NAME;
 
    /* Timing */
    pnet_default_cfg.min_device_interval = 32; /* Corresponds to 1 ms */
@@ -512,13 +501,7 @@ void PnetIntegrationTestBase::cfg_init()
    /* Network configuration */
    pnet_default_cfg.send_hello = 1; /* Send HELLO */
    pnet_default_cfg.if_cfg.ip_cfg.dhcp_enable = 0;
-   strcpy (pnet_default_cfg.if_cfg.main_port.if_name, TEST_INTERFACE_NAME);
-   pnet_default_cfg.if_cfg.main_port.eth_addr.addr[0] = 0x12;
-   pnet_default_cfg.if_cfg.main_port.eth_addr.addr[1] = 0x34;
-   pnet_default_cfg.if_cfg.main_port.eth_addr.addr[2] = 0x00;
-   pnet_default_cfg.if_cfg.main_port.eth_addr.addr[3] = 0x78;
-   pnet_default_cfg.if_cfg.main_port.eth_addr.addr[4] = 0x90;
-   pnet_default_cfg.if_cfg.main_port.eth_addr.addr[5] = 0xab;
+   pnet_default_cfg.if_cfg.main_netif_name = TEST_INTERFACE_NAME;
    pnet_default_cfg.if_cfg.ip_cfg.ip_addr.a = 192;
    pnet_default_cfg.if_cfg.ip_cfg.ip_addr.b = 168;
    pnet_default_cfg.if_cfg.ip_cfg.ip_addr.c = 1;


### PR DESCRIPTION
In promiscuous mode, ignore unicast packets that are not for this device.
Based on top of #333 and #348