### PR TITLE
Update OSAL and gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,17 +18,35 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/tools")
 project (PROFINET VERSION 0.1.0)
 
+# Default settings if this is the main project
+if (CMAKE_PROJECT_NAME STREQUAL PROFINET)
+  include(CTest)
+
+  # Make option visible in ccmake, cmake-gui
+  option (BUILD_SHARED_LIBS "Build shared library" OFF)
+
+  # Default to release build with debug info
+  if (NOT CMAKE_BUILD_TYPE)
+    set (CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
+      "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+      FORCE)
+  endif (NOT CMAKE_BUILD_TYPE)
+
+  # Default to installing in build directory
+  if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX ${PROFINET_BINARY_DIR}/install
+      CACHE PATH "Default install path" FORCE)
+  endif()
+
+  message(STATUS "Current build type is: ${CMAKE_BUILD_TYPE}")
+  message(STATUS "Current install path is: ${CMAKE_INSTALL_PREFIX}")
+  message(STATUS "Building for ${CMAKE_SYSTEM_NAME}")
+endif()
+
 include(AddOsal)
 include(GenerateExportHeader)
 include(CMakeDependentOption)
-
-if (CMAKE_PROJECT_NAME STREQUAL PROFINET)
-  include(CTest)
-endif()
-
-# Set required standard level
-set (CMAKE_C_STANDARD 99)
-set (CMAKE_CXX_STANDARD 11)
+include(GetGitRevision)
 
 # Always use standard .o suffix
 set(CMAKE_C_OUTPUT_EXTENSION_REPLACE 1)
@@ -36,7 +54,6 @@ set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
 
 # Options. See options.h.in for more information.
 
-option (BUILD_SHARED_LIBS "Build shared library" OFF)
 option (PNET_OPTION_FAST_STARTUP "" ON)
 option (PNET_OPTION_PARAMETER_SERVER "" ON)
 option (PNET_OPTION_IR "" ON)
@@ -137,30 +154,7 @@ set_property(CACHE PF_PNAL_LOG PROPERTY STRINGS ${LOG_STATE_VALUES})
 set(PNET_LOG ON CACHE STRING "PNET log")
 set_property(CACHE PNET_LOG PROPERTY STRINGS ${LOG_STATE_VALUES})
 
-# Default to release build with debug info
-if (NOT CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
-    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
-    FORCE)
-endif (NOT CMAKE_BUILD_TYPE)
-message (STATUS "Current build type is: ${CMAKE_BUILD_TYPE}")
-
-# Default to installing in build directory
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX ${PROFINET_BINARY_DIR}/install
-    CACHE PATH "Default install path" FORCE)
-endif()
-message(STATUS "Current install path is: ${CMAKE_INSTALL_PREFIX}")
-
-# Get git revision if available
-find_package(Git QUIET)
-execute_process(COMMAND
-  "${GIT_EXECUTABLE}" describe --tags --always --dirty
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  OUTPUT_VARIABLE PNET_VERSION_GIT
-  ERROR_QUIET
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
+# Generate version numbers
 configure_file (
   version.h.in
   ${PROFINET_BINARY_DIR}/src/version.h
@@ -182,13 +176,19 @@ if (CMAKE_PROJECT_NAME STREQUAL PROFINET AND BUILD_TESTING)
 endif()
 
 # Platform configuration
-include(${CMAKE_SYSTEM_NAME})
-message (STATUS "Building for ${CMAKE_SYSTEM_NAME}")
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/${CMAKE_SYSTEM_NAME}.cmake)
 
 generate_export_header(profinet
   BASE_NAME pnet
   EXPORT_FILE_NAME ${PROFINET_BINARY_DIR}/include/pnet_export.h
   )
+
+set_target_properties (profinet pn_dev
+  PROPERTIES
+  C_STANDARD 99
+  )
+
+target_compile_features(profinet PUBLIC c_std_99)
 
 target_include_directories(profinet
   PUBLIC

--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -82,8 +82,6 @@ target_compile_options(profinet
 
 target_link_libraries(profinet
   PUBLIC
-  pthread
-  rt
   $<$<BOOL:${PNET_OPTION_SNMP}>:NetSNMP::NetSNMPAgent>
   $<$<BOOL:${PNET_OPTION_SNMP}>:NetSNMP::NetSNMP>
   INTERFACE

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -29,6 +29,9 @@ extern "C" {
 #include <stdatomic.h>
 #else
 #define atomic_int         uint32_t
+#ifdef ATOMIC_VAR_INIT
+#undef ATOMIC_VAR_INIT
+#endif
 #define ATOMIC_VAR_INIT(x) x
 
 #ifdef atomic_fetch_add

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,12 @@
 
 option(TEST_DEBUG "Add trace output to tests" OFF)
 
+set_target_properties (pf_test
+  PROPERTIES
+  C_STANDARD 99
+  CXX_STANDARD 11
+  )
+
 target_sources(pf_test PRIVATE
   # Unit tests
   test_alarm.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -117,3 +117,6 @@ target_link_libraries(pf_test
   PRIVATE
   profinet
   )
+
+# No need for gmock
+set(BUILD_GMOCK OFF CACHE BOOL "")

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -13,9 +13,12 @@
  * full license information.
  ********************************************************************/
 
+// TODO: Must be included first due to redefinition of atomics in
+// pf_types.h
+#include <gtest/gtest.h>
+
 #include "mocks.h"
 
-#include <gtest/gtest.h>
 #include <string.h>
 
 struct pnal_eth_handle

--- a/test/pf_test.cpp
+++ b/test/pf_test.cpp
@@ -17,7 +17,11 @@
 
 int main (int argc, char * argv[])
 {
-   ::testing::InitGoogleTest (&argc, argv);
+   if (argc > 0)
+      ::testing::InitGoogleTest (&argc, argv);
+   else
+      ::testing::InitGoogleTest();
+
    int result = RUN_ALL_TESTS();
    return result;
 }

--- a/version.h.in
+++ b/version.h.in
@@ -1,10 +1,25 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2018 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
 #ifndef VERSION_H
 #define VERSION_H
 
-#cmakedefine PNET_VERSION_GIT "@PNET_VERSION_GIT@"
+#cmakedefine PROFINET_GIT_REVISION "@PROFINET_GIT_REVISION@"
 
-#if !defined(PNET_VERSION_BUILD) && defined(PNET_VERSION_GIT)
-#define PNET_VERSION_BUILD PNET_VERSION_GIT
+#if !defined(PNET_VERSION_BUILD) && defined(PROFINET_GIT_REVISION)
+#define PNET_VERSION_BUILD PROFINET_GIT_REVISION
 #endif
 
 /* clang-format-off */


### PR DESCRIPTION
This PR updates gtest to fix cmake deprecation warnings, and to fix a runtime warning on embedded targets. Unfortunately gtest no longer builds on GCC version 4 or older due to incomplete c++11 support. Use of incompatible GCC is detected at configuration time and the user can disable test by setting BUILD_TESTING=OFF.

It also updates OSAL and reduces the number of global cmake settings being forced, to simplify including this project in a superproject.
