### PR TITLE
Fix for test case SM_Legacy

### DIFF
--- a/src/common/pf_cpm.c
+++ b/src/common/pf_cpm.c
@@ -153,6 +153,13 @@ static void pf_cpm_control_interval_expired (
                                                                         */
 
             pf_cpm_set_state (&p_iocr->cpm, PF_CPM_STATE_W_START);
+
+            /* Generate an alarm. */
+            pf_cmsu_cpm_error_ind (
+               net,
+               p_iocr->p_ar,
+               p_iocr->p_ar->err_cls,
+               p_iocr->p_ar->err_code);
          }
          else
          {

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -4661,7 +4661,7 @@ static int pf_cmdev_cm_connect_rsp_pos (
                PNET_ERROR_CODE_CONNECT,
                PNET_ERROR_DECODE_PNIO,
                PNET_ERROR_CODE_1_CMRPC,
-               PNET_ERROR_CODE_2_CMRPC_PDEV_ALREADY_OWNED);
+               PNET_ERROR_CODE_2_CMRPC_NO_AR_RESOURCES);
             pnet_create_log_book_entry (
                net,
                p_ar->arep,


### PR DESCRIPTION
To enable the test for legacy startup mode,
in the gsdml file, set the StartupMode attribute to "Legacy;Advanced"