### PR TITLE
Respect max_alarm_data_length

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1660,13 +1660,17 @@ PNET_EXPORT void pnet_create_log_book_entry (
  * This function may be used by the application to issue a process alarm.
  * Such alarms are sent to the controller using high-priority alarm messages.
  *
- * Optional payload may be attached to the alarm. If \a payload_usi is != 0 then
+ * Optional payload may be attached to the alarm. If \a payload_usi is != 0
+ * and \a payload_len > 0 then
  * the \a payload_usi and the payload at \a p_payload is attached to the alarm.
  *
  * After calling this function the application must wait for
  * the \a pnet_alarm_cnf() callback before sending another alarm.
  * This function fails if the application does not wait for the
  * \a pnet_alarm_cnf() between sending two alarms.
+ *
+ * Note that the PLC can set the max alarm payload length at startup. This
+ * limit can be 200 to 1432 bytes.
  *
  * This functionality is used for alarms triggered by the IO-device.
  *
@@ -1676,8 +1680,9 @@ PNET_EXPORT void pnet_create_log_book_entry (
  * @param slot             In:    The slot.
  * @param subslot          In:    The sub-slot.
  * @param payload_usi      In:    The USI for the payload. Max 0x7fff
- * @param payload_len      In:    Length in bytes of the payload.
- *                                Max PNET_MAX_ALARM_PAYLOAD_DATA_SIZE.
+ * @param payload_len      In:    Length in bytes of the payload. May be 0.
+ *                                Max PNET_MAX_ALARM_PAYLOAD_DATA_SIZE or
+ *                                value from PLC.
  * @param p_payload        In:    The alarm payload (USI specific format).
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred (or waiting for ACK from controller: re-try
@@ -1882,6 +1887,9 @@ PNET_EXPORT int pnet_diag_std_remove (
  * Use the manufacturer specific format ("USI format") only if it's not
  * possible to use the standard format.
  *
+ * Note that the PLC can set the max alarm payload length at startup, and
+ * that affects how large diagnosis entries can be sent via alarms.
+ *
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
@@ -1891,8 +1899,9 @@ PNET_EXPORT int pnet_diag_std_remove (
  * @param usi              In:    The USI. Range 0..0x7fff
  * @param manuf_data_len   In:    Length in bytes of the
  *                                manufacturer specific diagnosis data.
- *                                Max PNET_MAX_DIAG_MANUF_DATA_SIZE.
  *                                A value 0 is allowed.
+ *                                Max PNET_MAX_DIAG_MANUF_DATA_SIZE or value
+ *                                from PLC.
  * @param p_manuf_data     In:    The manufacturer specific diagnosis data.
  *                                Mandatory if manuf_data_len > 0, otherwise
  *                                NULL.
@@ -1916,6 +1925,9 @@ PNET_EXPORT int pnet_diag_usi_add (
  * Use \a pnet_diag_usi_add() instead if you would like to create the
  * missing diagnosis when trying to update it.
  *
+ * Note that the PLC can set the max alarm payload length at startup, and
+ * that affects how large diagnosis entries can be sent via alarms.
+ *
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
@@ -1925,8 +1937,9 @@ PNET_EXPORT int pnet_diag_usi_add (
  * @param usi              In:    The USI. Range 0..0x7fff
  * @param manuf_data_len   In:    Length in bytes of the
  *                                manufacturer specific diagnosis data.
- *                                Max PNET_MAX_DIAG_MANUF_DATA_SIZE.
  *                                A value 0 is allowed.
+ *                                Max PNET_MAX_DIAG_MANUF_DATA_SIZE or
+ *                                value from PLC.
  * @param p_manuf_data     In:    New manufacturer specific diagnosis data.
  *                                Mandatory if manuf_data_len > 0, otherwise
  *                                NULL.
@@ -1972,6 +1985,9 @@ PNET_EXPORT int pnet_diag_usi_remove (
  *  - pnet_diag_std_add()
  *  - pnet_diag_usi_add()
  *
+ * Note that the PLC can set the max alarm payload length at startup, and
+ * that affects how large diagnosis entries can be sent via alarms.
+ *
  * This sends a diagnosis alarm.
  *
  * @param net                 InOut: The p-net stack instance.
@@ -1986,7 +2002,8 @@ PNET_EXPORT int pnet_diag_usi_remove (
  * @param usi                 In:    The USI.
  * @param manuf_data_len      In:    Length in bytes of the
  *                                   manufacturer specific diagnosis data.
- *                                   Max PNET_MAX_DIAG_MANUF_DATA_SIZE.
+ *                                   Max PNET_MAX_DIAG_MANUF_DATA_SIZE or
+ *                                   value from PLC.
  *                                   (Only needed if USI <= 0x7fff,
  *                                    and may still be 0).
  * @param p_manuf_data        In:    The manufacturer specific diagnosis data.
@@ -2026,6 +2043,9 @@ PNET_EXPORT int pnet_diag_add (
  * USI in manufacturer-specific range) or the extended channel additional
  * value is updated.
  *
+ * Note that the PLC can set the max alarm payload length at startup, and
+ * that affects how large diagnosis entries can be sent via alarms.
+ *
  * This sends a diagnosis alarm.
  *
  * @param net               InOut: The p-net stack instance.
@@ -2036,7 +2056,8 @@ PNET_EXPORT int pnet_diag_add (
  * @param usi               In:    The USI.
  * @param manuf_data_len    In:    Length in bytes of the
  *                                 manufacturer specific diagnosis data.
- *                                 Max PNET_MAX_DIAG_MANUF_DATA_SIZE.
+ *                                 Max PNET_MAX_DIAG_MANUF_DATA_SIZE or
+ *                                 value from PLC.
  *                                 (Only needed if USI <= 0x7fff,
  *                                  and may still be 0).
  * @param p_manuf_data      In:    New manufacturer specific diagnosis data.

--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -2607,6 +2607,9 @@ int pf_alarm_alpmr_alarm_ack (
  * Also look in the diagnostics database to attach information whether
  * there are any relevant diagnosis items.
  *
+ * Note that the PLC can set the max alarm payload length at startup. This
+ * limit can be 200 to 1432 bytes.
+ *
  * ALPMI: ALPMI_Alarm_Notification.req
  *
  * @param net              InOut: The p-net stack instance
@@ -2628,7 +2631,8 @@ int pf_alarm_alpmr_alarm_ack (
  *                                or sizeof(pf_diag_item_t) for diagnosis in
  *                                standard format.
  *                                May be 0 also for manufacturer data.
- *                                Max PNET_MAX_ALARM_PAYLOAD_DATA_SIZE
+ *                                Max PNET_MAX_ALARM_PAYLOAD_DATA_SIZE or
+ *                                value from PLC.
  * @param p_payload        In:    pf_diag_item_t, manufacturer data or NULL.
  *                                Mandatory if payload_len > 0 or for USI
  *                                values for diagnosis in standard format
@@ -2668,6 +2672,16 @@ static int pf_alarm_send_alarm (
             __LINE__,
             payload_len,
             sizeof (alarm_data.payload.data));
+      }
+      else if (payload_len > p_ar->alarm_cr_request.max_alarm_data_length)
+      {
+         LOG_ERROR (
+            PF_ALARM_LOG,
+            "Alarm(%d): You provided too long alarm payload (%u bytes) but PLC "
+            "said max %u bytes.\n",
+            __LINE__,
+            payload_len,
+            p_ar->alarm_cr_request.max_alarm_data_length);
       }
       else
       {

--- a/src/common/pf_alarm.h
+++ b/src/common/pf_alarm.h
@@ -173,6 +173,9 @@ int pf_alarm_send_plug_wrong (
  * User-supplied payload. Not attached to diagnosis ASE, but might have a
  * relation to channels.
  *
+ * Note that the PLC can set the max alarm payload length at startup. This
+ * limit can be 200 to 1432 bytes.
+ *
  * @param net              InOut: The p-net stack instance
  * @param p_ar             InOut: The AR instance.
  * @param api_id           In:    The API identifier.
@@ -181,7 +184,8 @@ int pf_alarm_send_plug_wrong (
  * @param payload_usi      In:    The USI for the alarm. Use 0 if no payload.
  *                                Max 0x7fff
  * @param payload_len      In:    Length of diagnostics data (may be 0).
- *                                Max PNET_MAX_ALARM_PAYLOAD_DATA_SIZE
+ *                                Max PNET_MAX_ALARM_PAYLOAD_DATA_SIZE or
+ *                                value from PLC.
  * @param p_payload        In:    User supplied payload (may be NULL if
  *                                payload_usi == 0).
  * @return  0  if operation succeeded.

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -4750,9 +4750,7 @@ int pf_cmdev_rm_connect_ind (
             p_ar->alarm_cr_request.alarm_cr_type;
          p_ar->alarm_cr_result.remote_alarm_reference =
             p_ar->alarm_cr_request.local_alarm_reference;
-         p_ar->alarm_cr_result.max_alarm_data_length = 200; /* ToDo: Add a
-                                                               define for this
-                                                               value */
+         p_ar->alarm_cr_result.max_alarm_data_length = PF_MAX_ALARM_DATA_LEN;
 
          pf_cmina_get_station_name (net, station_name);
          strncpy (

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -1244,6 +1244,12 @@ static int pf_cmrpc_rm_connect_interpret_ind (
                if (ret == 0)
                {
                   p_ar->nbr_alarm_cr++;
+                  LOG_DEBUG (
+                     PF_RPC_LOG,
+                     "CMRPC(%d): Requested max alarm data length: %u bytes\n",
+                     __LINE__,
+                     p_ar->alarm_cr_request.max_alarm_data_length);
+
                }
             }
             break;

--- a/src/device/pf_diag.h
+++ b/src/device/pf_diag.h
@@ -53,6 +53,9 @@ int pf_diag_exit (void);
  *  - pf_diag_std_add()
  *  - pf_diag_usi_add()
  *
+ * Note that the PLC can set the max alarm payload length at startup, and
+ * that affects how large diagnosis entries can be sent via alarms.
+ *
  * This sends a diagnosis alarm.
  *
  * @param net                 InOut: The p-net stack instance.
@@ -67,7 +70,8 @@ int pf_diag_exit (void);
  * @param usi                 In:    The USI.
  * @param manuf_data_len      In:    Length in bytes of the
  *                                   manufacturer specific diagnosis data.
- *                                   Max PNET_MAX_DIAG_MANUF_DATA_SIZE.
+ *                                   Max PNET_MAX_DIAG_MANUF_DATA_SIZE  or
+ *                                   value from PLC.
  *                                   (Only needed if USI <= 0x7fff,
  *                                    and may still be 0).
  * @param p_manuf_data        In:    The manufacturer specific diagnosis data.
@@ -106,6 +110,9 @@ int pf_diag_add (
  * USI in manufacturer-specific range) or the extended channel additional
  * value is updated.
  *
+ * Note that the PLC can set the max alarm payload length at startup, and
+ * that affects how large diagnosis entries can be sent via alarms.
+ *
  * This sends a diagnosis alarm.
  *
  * @param net               InOut: The p-net stack instance.
@@ -116,7 +123,8 @@ int pf_diag_add (
  * @param usi               In:    The USI.
  * @param manuf_data_len    In:    Length in bytes of the
  *                                 manufacturer specific diagnosis data.
- *                                 Max PNET_MAX_DIAG_MANUF_DATA_SIZE.
+ *                                 Max PNET_MAX_DIAG_MANUF_DATA_SIZE or
+ *                                 value from PLC.
  *                                (Only needed if USI <= 0x7fff,
  *                                 and may still be 0).
  * @param p_manuf_data      In:    New manufacturer specific diagnosis data.
@@ -242,6 +250,9 @@ int pf_diag_std_remove (
  * A diagnosis in USI format is assigned to the channel "whole submodule"
  * (not individual channels). The severity is always "Fault".
  *
+ * Note that the PLC can set the max alarm payload length at startup, and
+ * that affects how large diagnosis entries can be sent via alarms.
+ *
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
@@ -251,7 +262,8 @@ int pf_diag_std_remove (
  * @param usi              In:    The USI. Range 0..0x7fff
  * @param manuf_data_len   In:    Length in bytes of the
  *                                manufacturer specific diagnosis data.
- *                                Max PNET_MAX_DIAG_MANUF_DATA_SIZE.
+ *                                Max PNET_MAX_DIAG_MANUF_DATA_SIZE or
+ *                                value from PLC.
  * @param p_manuf_data     In:    The manufacturer specific diagnosis data.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
@@ -270,6 +282,9 @@ int pf_diag_usi_add (
  *
  * An error is returned if the diagnosis doesn't exist.
  *
+ * Note that the PLC can set the max alarm payload length at startup, and
+ * that affects how large diagnosis entries can be sent via alarms.
+ *
  * This sends a diagnosis alarm.
  *
  * @param net              InOut: The p-net stack instance.
@@ -279,7 +294,8 @@ int pf_diag_usi_add (
  * @param usi              In:    The USI. Range 0..0x7fff
  * @param manuf_data_len   In:    Length in bytes of the
  *                                manufacturer specific diagnosis data.
- *                                Max PNET_MAX_DIAG_MANUF_DATA_SIZE.
+ *                                Max PNET_MAX_DIAG_MANUF_DATA_SIZE or
+ *                                value from PLC.
  * @param p_manuf_data     In:    New manufacturer specific diagnosis data.
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -1594,6 +1594,11 @@ typedef struct pf_alarm_cr_tag_header
                                    USER_PRIORITY_HIGH (6) */
 } pf_alarm_cr_tag_header_t;
 
+/** The largest alarmdata we can accept
+ *  Allowed 200..1432
+*/
+#define PF_MAX_ALARM_DATA_LEN 200
+
 typedef struct pf_alarm_cr_request
 {
    bool valid;


### PR DESCRIPTION
Also use a define for the max_alarm_data_length we send back to the PLC