### PR TITLE
Export pnet options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,14 +156,18 @@ set_property(CACHE PNET_LOG PROPERTY STRINGS ${LOG_STATE_VALUES})
 
 # Generate version numbers
 configure_file (
-  version.h.in
-  ${PROFINET_BINARY_DIR}/src/version.h
+  pnet_version.h.in
+  ${PROFINET_BINARY_DIR}/include/pnet_version.h
   )
 
 # Generate config options
 configure_file (
   options.h.in
   ${PROFINET_BINARY_DIR}/src/options.h
+  )
+configure_file (
+  pnet_options.h.in
+  ${PROFINET_BINARY_DIR}/include/pnet_options.h
   )
 
 # Add platform-dependent targets early, so they can be configured by
@@ -218,6 +222,8 @@ install(
 install (FILES
   include/pnet_api.h
   ${PROFINET_BINARY_DIR}/include/pnet_export.h
+  ${PROFINET_BINARY_DIR}/include/pnet_options.h
+  ${PROFINET_BINARY_DIR}/include/pnet_version.h
   DESTINATION include
   )
 

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -32,7 +32,9 @@
 extern "C" {
 #endif
 
-#include <pnet_export.h>
+#include "pnet_export.h"
+#include "pnet_options.h"
+#include "pnet_version.h"
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/options.h.in
+++ b/options.h.in
@@ -1,3 +1,18 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2018 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
 #ifndef OPTIONS_H
 #define OPTIONS_H
 
@@ -112,11 +127,6 @@
 #define PNET_MAX_DFP_IOCR         @PNET_MAX_DFP_IOCR@
 #endif
 
-#if !defined (PNET_NUMBER_OF_PHYSICAL_PORTS)
-/** 2 for media redundancy. Currently only 1 is supported. */
-#define PNET_NUMBER_OF_PHYSICAL_PORTS        @PNET_NUMBER_OF_PHYSICAL_PORTS@
-#endif
-
 #if !defined (PNET_MAX_LOG_BOOK_ENTRIES)
 #define PNET_MAX_LOG_BOOK_ENTRIES @PNET_MAX_LOG_BOOK_ENTRIES@
 #endif
@@ -161,11 +171,6 @@
 #if !defined (PNET_MAX_SESSION_BUFFER_SIZE)
 /** Max fragmented RPC request/response length */
 #define PNET_MAX_SESSION_BUFFER_SIZE @PNET_MAX_SESSION_BUFFER_SIZE@
-#endif
-
-#if !defined (PNET_MAX_DIRECTORYPATH_SIZE)
-/** Max directory path size, including termination */
-#define PNET_MAX_DIRECTORYPATH_SIZE @PNET_MAX_DIRECTORYPATH_SIZE@
 #endif
 
 #if !defined (PNET_MAX_FILENAME_SIZE)

--- a/pnet_options.h.in
+++ b/pnet_options.h.in
@@ -1,0 +1,29 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2018 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#ifndef PNET_OPTIONS_H
+#define PNET_OPTIONS_H
+
+#if !defined (PNET_NUMBER_OF_PHYSICAL_PORTS)
+/** Number of physical ports */
+#define PNET_NUMBER_OF_PHYSICAL_PORTS @PNET_NUMBER_OF_PHYSICAL_PORTS@
+#endif
+
+#if !defined (PNET_MAX_DIRECTORYPATH_SIZE)
+/** Max directory path size, including termination */
+#define PNET_MAX_DIRECTORYPATH_SIZE @PNET_MAX_DIRECTORYPATH_SIZE@
+#endif
+
+#endif  /* PNET_OPTIONS_H */

--- a/pnet_version.h.in
+++ b/pnet_version.h.in
@@ -13,8 +13,8 @@
  * full license information.
  ********************************************************************/
 
-#ifndef VERSION_H
-#define VERSION_H
+#ifndef PNET_VERSION_H
+#define PNET_VERSION_H
 
 #cmakedefine PROFINET_GIT_REVISION "@PROFINET_GIT_REVISION@"
 
@@ -30,7 +30,7 @@
 
 #if defined(PNET_VERSION_BUILD)
 #define PNET_VERSION \
-   "@PROFINET_VERSION_MAJOR@.@PROFINET_VERSION_MINOR@.@PROFINET_VERSION_PATCH@+"PNET_VERSION_BUILD
+   "@PROFINET_VERSION_MAJOR@.@PROFINET_VERSION_MINOR@.@PROFINET_VERSION_PATCH@+" PNET_VERSION_BUILD
 #else
 #define PNET_VERSION \
    "@PROFINET_VERSION_MAJOR@.@PROFINET_VERSION_MINOR@.@PROFINET_VERSION_PATCH@"
@@ -38,4 +38,4 @@
 
 /* clang-format-on */
 
-#endif /* VERSION_H */
+#endif /* PNET_VERSION_H */

--- a/sample_app/sampleapp_common.c
+++ b/sample_app/sampleapp_common.c
@@ -18,7 +18,6 @@
 #include "osal.h"
 #include "pnal.h"
 #include <pnet_api.h>
-#include "version.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -16,7 +16,6 @@
 #ifndef SAMPLEAPP_COMMON_H
 #define SAMPLEAPP_COMMON_H
 
-#include "options.h" /* Remove when #224 is solved */
 #include "osal.h"
 #include "pnal.h"
 #include <pnet_api.h>

--- a/src/ports/linux/pnal_filetools.c
+++ b/src/ports/linux/pnal_filetools.c
@@ -18,6 +18,7 @@
 
 #include "pnal_filetools.h"
 
+#include "pnet_options.h"
 #include "options.h"
 #include "osal_log.h"
 

--- a/src/ports/linux/sampleapp_main.c
+++ b/src/ports/linux/sampleapp_main.c
@@ -17,13 +17,11 @@
 
 #include "sampleapp_common.h"
 
-#include "options.h" /* Rename/remove when #224 is solved */
 #include "osal.h"
 #include "osal_log.h" /* For LOG_LEVEL */
 #include "pnal.h"
 #include "pnal_filetools.h"
 #include <pnet_api.h>
-#include "version.h" /* Rename/remove when #224 is solved */
 
 #include <net/if.h>
 #include <sys/ioctl.h>

--- a/src/ports/rt-kernel/sampleapp_main.c
+++ b/src/ports/rt-kernel/sampleapp_main.c
@@ -18,7 +18,6 @@
 #include "osal_log.h"
 #include "osal.h"
 #include <pnet_api.h>
-#include "version.h"
 
 #include <gpio.h>
 #include <kern/kern.h>


### PR DESCRIPTION
Split options.h into two files. The new file pnet_options.h contains
options that are used by pnet_api.h.

Also rename and export pnet_version.h.

Fix #224.