### PR TITLE
Use configurable number of ports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,11 +77,11 @@ set(PNET_MAX_CR                 2
 set(PNET_MAX_SLOTS            5
   CACHE STRING "Per API. Should be > 1 to allow at least one I/O module")
 set(PNET_MAX_SUBSLOTS         3
-  CACHE STRING "Per slot (DAP requires 2 + PNET_NUMBER_OF_PHYSICAL_PORTS)")
+  CACHE STRING "Per slot (DAP requires 2 + PNET_MAX_PHYSICAL_PORTS)")
 set(PNET_MAX_DFP_IOCR           2
   CACHE STRING "Allowed values are 0 (zero) or 2")
-set(PNET_NUMBER_OF_PHYSICAL_PORTS          1
-  CACHE STRING "Number of physical ports")
+set(PNET_MAX_PHYSICAL_PORTS          1
+  CACHE STRING "Max number of physical ports")
 set(PNET_MAX_LOG_BOOK_ENTRIES   16
   CACHE STRING "")
 set(PNET_MAX_ALARMS             3

--- a/doc/multiple_ports.rst
+++ b/doc/multiple_ports.rst
@@ -151,13 +151,14 @@ To run p-net and the sample application with multiple ports a couple
 of things need to be done. Note that the settings described in the
 following sections are changed by running ``ccmake .`` in the build folder.
 ``options.h`` will be regenerated. Another way to set the options is to
-set them on the cmake command line (-DPNET_NUMBER_OF_PHYSICAL_PORTS=2 -DPNET_MAX_SUBSLOTS=4).
+set them on the cmake command line (-DPNET_MAX_PHYSICAL_PORTS=2 -DPNET_MAX_SUBSLOTS=4).
 
-Reconfigure setting ``PNET_NUMBER_OF_PHYSICAL_PORTS`` to the actual number of physical ports available in the system.
-For this example ``PNET_NUMBER_OF_PHYSICAL_PORTS`` shall be set to 2.
+Reconfigure configuration setting ``num_physical_ports`` to the actual number
+of physical ports available in the system (and must be PNET_MAX_PHYSICAL_PORTS
+or less). For this example the value shall be set to 2.
 
-Reconfigure setting ``PNET_MAX_SUBSLOTS``. Each additional port will require an additional subslot.
-For this example the ``PNET_MAX_SUBSLOTS`` should be be set to 4.
+Reconfigure setting ``PNET_MAX_SUBSLOTS``. Each additional port will require
+an additional subslot. For this example the value should be be set to 4.
 
 Example of initial log when starting the demo application with a multi port configuration::
 

--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1193,7 +1193,7 @@ typedef struct pnet_if_cfg
    const char * main_netif_name; /**< Main (DAP) network interface. */
    pnet_ip_cfg_t ip_cfg;         /**< IP Settings for main network interface */
 
-   pnet_port_cfg_t physical_ports[PNET_NUMBER_OF_PHYSICAL_PORTS];
+   pnet_port_cfg_t physical_ports[PNET_MAX_PHYSICAL_PORTS];
 } pnet_if_cfg_t;
 
 /**
@@ -1260,6 +1260,9 @@ typedef struct pnet_cfg
 
    /** Capabilities */
    bool send_hello; /**< Send DCP HELLO message on startup if true. */
+
+   /** Number of physical ports. Should respect PNET_MAX_PHYSICAL_PORTS */
+   uint8_t num_physical_ports; // TODO int or uint16_t ?
 
    /** Send diagnosis in the qualified format (otherwise extended format) */
    bool use_qualified_diagnosis;

--- a/pnet_options.h.in
+++ b/pnet_options.h.in
@@ -16,9 +16,9 @@
 #ifndef PNET_OPTIONS_H
 #define PNET_OPTIONS_H
 
-#if !defined (PNET_NUMBER_OF_PHYSICAL_PORTS)
-/** Number of physical ports */
-#define PNET_NUMBER_OF_PHYSICAL_PORTS @PNET_NUMBER_OF_PHYSICAL_PORTS@
+#if !defined (PNET_MAX_PHYSICAL_PORTS)
+/** Max number of physical ports */
+#define PNET_MAX_PHYSICAL_PORTS @PNET_MAX_PHYSICAL_PORTS@
 #endif
 
 #if !defined (PNET_MAX_DIRECTORYPATH_SIZE)

--- a/sample_app/GSDML-V2.4-RT-Labs-P-Net-Sample-App-20210202.xml
+++ b/sample_app/GSDML-V2.4-RT-Labs-P-Net-Sample-App-20210202.xml
@@ -56,7 +56,7 @@
                   </InterfaceSubmoduleItem>
                   <PortSubmoduleItem ID="IDS_P1" SubmoduleIdentNumber="0x00008001" SubslotNumber="32769" TextId="IDT_NAME_PS1" MaxPortRxDelay="350" MaxPortTxDelay="160">
                      <MAUTypeList>
-<!-- 
+<!--
 MAUTypeItems shall match the actual network interfaces of the device.
 Current list works for Raspberry Pi, Linksys usb/ethernet dongle and xmc sample targets
 -->
@@ -65,8 +65,8 @@ Current list works for Raspberry Pi, Linksys usb/ethernet dongle and xmc sample 
                         <MAUTypeItem Value="5"/>
                      </MAUTypeList>
                   </PortSubmoduleItem>
-<!-- 
-Enable to support additional port. (PNET_NUMBER_OF_PHYSICAL_PORTS == 2)
+<!--
+Enable to support additional port. (PNET_MAX_PHYSICAL_PORTS == 2)
 Add additional PortSubmoduleItems to support additional ports
 -->
 <!--

--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -130,7 +130,7 @@ static const cfg_submodule_type_t cfg_available_submodule_types[] = {
     PNET_DIR_NO_IO,
     0,
     0},
-#if PNET_NUMBER_OF_PHYSICAL_PORTS >= 2
+#if PNET_MAX_PHYSICAL_PORTS >= 2
    {"DAP Port 2",
     APP_API,
     PNET_MOD_DAP_IDENT,
@@ -139,7 +139,7 @@ static const cfg_submodule_type_t cfg_available_submodule_types[] = {
     0,
     0},
 #endif
-#if PNET_NUMBER_OF_PHYSICAL_PORTS >= 3
+#if PNET_MAX_PHYSICAL_PORTS >= 3
    {"DAP Port 3",
     APP_API,
     PNET_MOD_DAP_IDENT,
@@ -148,7 +148,7 @@ static const cfg_submodule_type_t cfg_available_submodule_types[] = {
     0,
     0},
 #endif
-#if PNET_NUMBER_OF_PHYSICAL_PORTS >= 4
+#if PNET_MAX_PHYSICAL_PORTS >= 4
    {"DAP Port 4",
     APP_API,
     PNET_MOD_DAP_IDENT,
@@ -189,8 +189,8 @@ struct cmd_args
    char path_storage_directory[PNET_MAX_DIRECTORYPATH_SIZE]; /** Terminated */
    char station_name[PNET_STATION_NAME_MAX_SIZE]; /** Terminated string */
    char eth_interfaces
-      [PNET_INTERFACE_NAME_MAX_SIZE * (PNET_NUMBER_OF_PHYSICAL_PORTS + 1) +
-       PNET_NUMBER_OF_PHYSICAL_PORTS]; /** Terminated string */
+      [PNET_INTERFACE_NAME_MAX_SIZE * (PNET_MAX_PHYSICAL_PORTS + 1) +
+       PNET_MAX_PHYSICAL_PORTS]; /** Terminated string */
    int verbosity;
    int show;
    bool factory_reset;
@@ -204,7 +204,7 @@ typedef struct app_netif_name
 
 typedef struct app_netif_namelist
 {
-   app_netif_name_t netif[PNET_NUMBER_OF_PHYSICAL_PORTS + 1];
+   app_netif_name_t netif[PNET_MAX_PHYSICAL_PORTS + 1];
 } app_netif_namelist_t;
 
 typedef struct app_subslot
@@ -315,29 +315,43 @@ int app_pnet_cfg_init_default (pnet_cfg_t * stack_config);
 int app_pnet_cfg_init_netifs (
    const char * netif_list_str,
    app_netif_namelist_t * if_list,
+   uint16_t * p_number_of_ports,
    pnet_cfg_t * p_cfg,
    int verbosity);
 
 /**
  * Parse a comma separated list of network interfaces and check
- * that the number of interfaces match the PNET_NUMBER_OF_PHYSICAL_PORTS
- * configuration. Examples: PNET_NUMBER_OF_PHYSICAL_PORTS     arg_str status 1
- * "eth0"                  ok 1                 "eth0,eth1"             err 2
- * "br0,eth0,eth1"         ok 2                 "br0,eth0,"             err
+ * that the number of interfaces match the PNET_MAX_PHYSICAL_PORTS
+ * configuration.
  *
- * @param arg_str    In:   Network interface list as comma separated,
- *                         terminated string. For example "eth0" or
- *                         "br0,eth0,eth1".
- * @param p_if_list  Out:  List of network interfaces
- * @param max_port   In:   PNET_NUMBER_OF_PHYSICAL_PORTS, passed as argument to
- *                         allow test
- * @return  0  if network interface list matches configuration
+ * For a single Ethernet interface, the \a arg_str should consist of
+ * one name. For two Ethernet interfaces, the  \a arg_str should consist of
+ * three names, as we also need a bridge interface.
+ *
+ * Does only consider the number of commaseparated names. No check of the
+ * names themselves are done.
+ *
+ * Examples:
+ * arg_str                 num_ports
+ * "eth0"                  1
+ * "eth0,eth1"             error (We need a bridge as well)
+ * "br0,eth0,eth1"         2
+ *
+ * @param arg_str      In:   Network interface list as comma separated,
+ *                           terminated string. For example "eth0" or
+ *                           "br0,eth0,eth1".
+ * @param max_port     In:   PNET_MAX_PHYSICAL_PORTS, passed as argument to
+ *                           allow test.
+ * @param p_if_list    Out:  List of network interfaces
+ * @param p_num_ports  Out:  Resulting number of physical ports
+ * @return  0  on success
  *         -1  on error
  */
 int app_get_netif_namelist (
    const char * arg_str,
+   uint16_t max_port,
    app_netif_namelist_t * p_if_list,
-   uint16_t max_port);
+   uint16_t * p_num_ports);
 
 /**
  * Plug DAP (sub-)modules. This operation shall be called after p-net

--- a/src/common/pf_cpm.c
+++ b/src/common/pf_cpm.c
@@ -578,7 +578,7 @@ int pf_cpm_activate_req (pnet_t * net, pf_ar_t * p_ar, uint32_t crep)
           (uint32_t)p_iocr->param.reduction_ratio * 1000U) /
          32U; /* us */
 
-      for (ix = 0; ix < PNET_NUMBER_OF_PHYSICAL_PORTS; ix++)
+      for (ix = 0; ix < pf_port_get_number_of_ports (net); ix++)
       {
          p_cpm->rxa[ix][0] = -1; /* "invalid" cycle counter */
          p_cpm->rxa[ix][1] = -1;

--- a/src/common/pf_eth.h
+++ b/src/common/pf_eth.h
@@ -23,7 +23,7 @@ extern "C" {
 /**
  * Initialize ETH component and network interfaces according to configuration
  * If device is configured with one network interface
- * (PNET_NUMBER_OF_PHYSICAL_PORTS==1), the management port and physical port 1
+ * (num_physical_ports==1), the management port and physical port 1
  * refers to same network interface. In a multi port configuration, the
  * management port and physical ports are different network interfaces.
  * @param net              InOut: The p-net stack instance

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -991,8 +991,7 @@ void pf_lldp_mac_address_to_string (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param buf              Out:   Ethernet frame buffer of size
  *                                PF_FRAME_BUFFER_SIZE bytes.
  *
@@ -1073,8 +1072,7 @@ size_t pf_lldp_construct_frame (pnet_t * net, int loc_port_num, uint8_t buf[])
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  */
 static void pf_lldp_send (pnet_t * net, int loc_port_num)
 {
@@ -1140,8 +1138,7 @@ static void pf_lldp_trigger_sending (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param send             In:    Send LLDP message
  */
 static void pf_lldp_tx_restart (pnet_t * net, int loc_port_num, bool send)
@@ -1863,8 +1860,7 @@ bool pf_lldp_is_alias_matching (pnet_t * net, const char * alias)
  *
  * @param net              InOut: p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param new_info         In:    Peer data to be stored
  */
 void pf_lldp_store_peer_info (
@@ -1892,8 +1888,7 @@ void pf_lldp_store_peer_info (
  *
  * @param net              InOut: p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param lldp_peer_info   In:    Peer data to be applied
  */
 void pf_lldp_update_peer (

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -35,8 +35,7 @@ extern "C" {
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_timestamp_10ms Out:   Time when the LLDP packet with the info
  *                                was first received, in units of
@@ -71,8 +70,7 @@ void pf_lldp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id);
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_chassis_id     Out:   Chassis ID of remote device.
  * @return  0 if the operation succeeded.
@@ -90,8 +88,7 @@ int pf_lldp_get_peer_chassis_id (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_port_id        Out:   Port ID of local port.
  */
@@ -111,8 +108,7 @@ void pf_lldp_get_port_id (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_port_id        Out:   Port ID of remote port.
  * @return  0 if the operation succeeded.
@@ -130,8 +126,7 @@ int pf_lldp_get_peer_port_id (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_port_desc      Out:   Port description of local port.
  */
@@ -148,8 +143,7 @@ void pf_lldp_get_port_description (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_port_desc      Out:   Port description of remote port.
  * @return  0 if the operation succeeded.
@@ -191,8 +185,7 @@ void pf_lldp_get_management_address (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_man_address    Out:   Management address of remote interface.
  * @return  0 if the operation succeeded.
@@ -216,8 +209,7 @@ int pf_lldp_get_peer_management_address (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_station_name   Out:   Station name of remote interface.
  * @return  0 if the operation succeeded.
@@ -241,8 +233,7 @@ int pf_lldp_get_peer_station_name (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_port_name      Out:   Port name of remote port.
  * @return  0 if the operation succeeded.
@@ -262,8 +253,7 @@ int pf_lldp_get_peer_port_name (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_delays         Out:   Measured signal delays on local port.
  */
@@ -282,8 +272,7 @@ void pf_lldp_get_signal_delays (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_delays         Out:   Measured signal delays on remote port.
  * @return  0 if the operation succeeded.
@@ -301,8 +290,7 @@ int pf_lldp_get_peer_signal_delays (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_link_status    Out:   Link status of local port.
  */
@@ -319,8 +307,7 @@ void pf_lldp_get_link_status (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_port_get_list_of_ports().
  * @param p_link_status    Out:   Link status of remote port.
  * @return  0 if the operation succeeded.
@@ -379,8 +366,7 @@ void pf_lldp_init (pnet_t * net);
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
+ *                                Valid range: 1 .. num_physical_ports
  * @param timeout_in_secs  In:    TTL of the peer, typically 20 seconds.
  */
 void pf_lldp_restart_peer_timeout (
@@ -395,8 +381,7 @@ void pf_lldp_restart_peer_timeout (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
+ *                                Valid range: 1 .. num_physical_ports
  */
 void pf_lldp_stop_peer_timeout (pnet_t * net, int loc_port_num);
 
@@ -405,8 +390,7 @@ void pf_lldp_stop_peer_timeout (pnet_t * net, int loc_port_num);
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
+ *                                Valid range: 1 .. num_physical_ports
  */
 void pf_lldp_invalidate_peer_info (pnet_t * net, int loc_port_num);
 
@@ -416,8 +400,7 @@ void pf_lldp_invalidate_peer_info (pnet_t * net, int loc_port_num);
  * An initial LLDP frame is transmitted when operation is called.
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
+ *                                Valid range: 1 .. num_physical_ports
  */
 void pf_lldp_send_enable (pnet_t * net, int loc_port_num);
 
@@ -426,8 +409,7 @@ void pf_lldp_send_enable (pnet_t * net, int loc_port_num);
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
+ *                                Valid range: 1 .. num_physical_ports
  */
 void pf_lldp_send_disable (pnet_t * net, int loc_port_num);
 

--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -362,7 +362,7 @@ void pf_snmp_get_system_description (
 
 void pf_snmp_get_port_list (pnet_t * net, pf_lldp_port_list_t * p_list)
 {
-   pf_port_get_list_of_ports (net, PNET_NUMBER_OF_PHYSICAL_PORTS, p_list);
+   pf_port_get_list_of_ports (net, p_list);
 }
 
 void pf_snmp_init_port_iterator (pnet_t * net, pf_port_iterator_t * p_iterator)

--- a/src/common/pf_snmp.h
+++ b/src/common/pf_snmp.h
@@ -424,8 +424,7 @@ int pf_snmp_get_next_port (pf_port_iterator_t * p_iterator);
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_timestamp_10ms Out:   Time when the LLDP packet with the info
  *                                was first received, in units of
@@ -468,8 +467,7 @@ void pf_snmp_get_chassis_id (pnet_t * net, pf_lldp_chassis_id_t * p_chassis_id);
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_chassis_id     Out:   Chassis ID of remote device.
  * @return  0 if the operation succeeded.
@@ -490,8 +488,7 @@ int pf_snmp_get_peer_chassis_id (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_port_id        Out:   Port ID of local port.
  */
@@ -517,8 +514,7 @@ void pf_snmp_get_port_id (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_port_id        Out:   Port ID of remote port.
  * @return  0 if the operation succeeded.
@@ -538,8 +534,7 @@ int pf_snmp_get_peer_port_id (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_port_desc      Out:   Port description of local port.
  */
@@ -561,8 +556,7 @@ void pf_snmp_get_port_description (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_port_desc      Out:   Port description of remote port.
  * @return  0 if the operation succeeded.
@@ -606,8 +600,7 @@ void pf_snmp_get_management_address (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_man_address    Out:   Management address of remote interface.
  * @return  0 if the operation succeeded.
@@ -658,8 +651,7 @@ void pf_snmp_get_management_port_index (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_man_port_index Out:   Index in remote IfTable for Management port.
  * @return  0 if the operation succeeded.
@@ -716,8 +708,7 @@ void pf_snmp_get_station_name (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_station_name   Out:   Station name of remote interface.
  * @return  0 if the operation succeeded.
@@ -740,8 +731,7 @@ int pf_snmp_get_peer_station_name (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_delays         Out:   Measured signal delays on local port.
  */
@@ -763,8 +753,7 @@ void pf_snmp_get_signal_delays (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_delays         Out:   Measured signal delays on remote port.
  * @return  0 if the operation succeeded.
@@ -790,8 +779,7 @@ int pf_snmp_get_peer_signal_delays (
  *
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_link_status    Out:   Link status of local port.
  */
@@ -816,8 +804,7 @@ void pf_snmp_get_link_status (
  * @param net              In:    The p-net stack instance.
  * @param loc_port_num     In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  *                                See pf_snmp_get_next_port().
  * @param p_link_status    Out:   Link status of remote port.
  * @return  0 if the operation succeeded.

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -2853,7 +2853,8 @@ static void pf_put_diag_subslot (
    uint16_t * p_pos)
 {
    uint16_t usi = 0;
-   int err = pf_cmdev_get_next_diagnosis_usi (net, p_subslot->diag_list, 0, &usi);
+   int err =
+      pf_cmdev_get_next_diagnosis_usi (net, p_subslot->diag_list, 0, &usi);
 
    while (err == 0)
    {
@@ -2870,7 +2871,8 @@ static void pf_put_diag_subslot (
          p_bytes,
          p_pos);
 
-      err = pf_cmdev_get_next_diagnosis_usi (net, p_subslot->diag_list, usi, &usi);
+      err =
+         pf_cmdev_get_next_diagnosis_usi (net, p_subslot->diag_list, usi, &usi);
    }
 }
 
@@ -3644,7 +3646,8 @@ void pf_put_pdport_data_real (
    pf_lldp_station_name_t station_name;
    pf_lldp_port_name_t port_name;
    pnal_eth_status_t eth_status;
-   const uint16_t subslot = pf_port_loc_port_num_to_dap_subslot (loc_port_num);
+   const uint16_t subslot =
+      pf_port_loc_port_num_to_dap_subslot (net, loc_port_num);
    const pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
    const pf_lldp_peer_info_t * p_peer_info = &p_port_data->lldp.peer_info;
 
@@ -3987,11 +3990,12 @@ static void pf_put_pd_multiblock_interface_and_statistics (
  * @internal
  * Insert multiblock port and statistics for one port
  *
+ * If the local port number is out of range this operation will assert.
+ *
  * @param net              InOut: The p-net stack instance
  * @param is_big_endian    In:    Endianness of the destination buffer.
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param p_res            In:    The entity to insert
  * @param res_len          In:    Size of destination buffer.
  * @param p_bytes          Out:   Destination buffer.
@@ -4009,7 +4013,8 @@ static void pf_put_pd_multiblock_port_and_statistics (
    uint16_t block_pos = *p_pos;
    uint16_t block_len = 0;
    pnal_port_stats_t port_stats;
-   const uint16_t subslot = pf_port_loc_port_num_to_dap_subslot (loc_port_num);
+   const uint16_t subslot =
+      pf_port_loc_port_num_to_dap_subslot (net, loc_port_num);
    const pf_port_t * p_port_data = pf_port_get_state (net, loc_port_num);
 
    if (pnal_get_port_statistics (p_port_data->netif.name, &port_stats) != 0)

--- a/src/device/pf_block_writer.h
+++ b/src/device/pf_block_writer.h
@@ -769,10 +769,11 @@ void pf_put_pd_interface_adj (
  *
  * Includes peer chassis ID, peer MAC address and peer MAU type.
  *
+ * If the local port number is out of range this operation will assert.
+ *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports.
  * @param is_big_endian    In:    Endianness of the destination buffer.
  * @param p_res            In:    Read result
  * @param res_len          In:    Size of destination buffer.

--- a/src/device/pf_cmrdr.c
+++ b/src/device/pf_cmrdr.c
@@ -60,7 +60,7 @@ int pf_cmrdr_rm_read_ind (
 
    if (
       (p_read_request->slot_number == PNET_SLOT_DAP_IDENT) &&
-      (pf_port_subslot_is_dap_port_id (p_read_request->subslot_number) == true))
+      (pf_port_subslot_is_dap_port_id (net, p_read_request->subslot_number)))
    {
       LOG_INFO (
          PNET_LOG,
@@ -70,7 +70,7 @@ int pf_cmrdr_rm_read_ind (
          p_read_request->slot_number,
          p_read_request->subslot_number,
          p_read_request->index,
-         pf_port_dap_subslot_to_local_port (p_read_request->subslot_number),
+         pf_port_dap_subslot_to_local_port (net, p_read_request->subslot_number),
          pf_index_to_logstring (p_read_request->index));
    }
    else

--- a/src/device/pf_cmwrr.c
+++ b/src/device/pf_cmwrr.c
@@ -157,8 +157,7 @@ static int pf_cmwrr_write (
 
    if (
       (p_write_request->slot_number == PNET_SLOT_DAP_IDENT) &&
-      (pf_port_subslot_is_dap_port_id (p_write_request->subslot_number) ==
-       true))
+      (pf_port_subslot_is_dap_port_id (net, p_write_request->subslot_number)))
    {
       LOG_INFO (
          PNET_LOG,
@@ -168,7 +167,9 @@ static int pf_cmwrr_write (
          p_write_request->slot_number,
          p_write_request->subslot_number,
          p_write_request->index,
-         pf_port_dap_subslot_to_local_port (p_write_request->subslot_number),
+         pf_port_dap_subslot_to_local_port (
+            net,
+            p_write_request->subslot_number),
          pf_index_to_logstring (p_write_request->index));
    }
    else

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -113,8 +113,8 @@ void pf_fspm_option_show (const pnet_t * net)
       "PNET_MAX_DFP_IOCR                              : %d\n",
       PNET_MAX_DFP_IOCR);
    printf (
-      "PNET_NUMBER_OF_PHYSICAL_PORTS                             : %d\n",
-      PNET_NUMBER_OF_PHYSICAL_PORTS);
+      "PNET_MAX_PHYSICAL_PORTS                             : %d\n",
+      PNET_MAX_PHYSICAL_PORTS);
    printf (
       "PNET_MAX_LOG_BOOK_ENTRIES                      : %d\n",
       PNET_MAX_LOG_BOOK_ENTRIES);
@@ -231,6 +231,20 @@ int pf_fspm_validate_configuration (const pnet_cfg_t * p_cfg)
          PNET_LOG,
          "FSPM(%d): Length of network interface name must not be 0.\n",
          __LINE__);
+      return -1;
+   }
+
+   if (
+      p_cfg->num_physical_ports == 0 ||
+      p_cfg->num_physical_ports > PNET_MAX_PHYSICAL_PORTS)
+   {
+      LOG_ERROR (
+         PNET_LOG,
+         "FSPM(%d): The number of ports setting is wrong. Given: %d  "
+         "PNET_MAX_PHYSICAL_PORTS: %d\n",
+         __LINE__,
+         p_cfg->num_physical_ports,
+         PNET_MAX_PHYSICAL_PORTS);
       return -1;
    }
 

--- a/src/device/pf_pdport.h
+++ b/src/device/pf_pdport.h
@@ -131,8 +131,7 @@ int pf_pdport_write_req (
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  */
 void pf_pdport_peer_indication (pnet_t * net, int loc_port_num);
 

--- a/src/device/pf_port.h
+++ b/src/device/pf_port.h
@@ -35,20 +35,24 @@ void pf_port_init (pnet_t * net);
 void pf_port_main_interface_init (pnet_t * net);
 
 /**
+ * Get number of physical ports.
+ *
+ * @param net              In:    The p-net stack instance.
+ * @return the number of physical ports.
+ */
+uint8_t pf_port_get_number_of_ports (const pnet_t * net);
+
+/**
  * Get list of local ports.
  *
  * This is the list of physical ports on the local interface.
  * The management port is not included.
  *
  * @param net              In:    The p-net stack instance.
- * @param max_port         In:    Max port number supported.
- *                                Typically PNET_NUMBER_OF_PHYSICAL_PORTS.
- *                                Parameter added for testability.
  * @param p_list           Out:   List of local ports.
  */
 void pf_port_get_list_of_ports (
-   pnet_t * net,
-   uint16_t max_port,
+   const pnet_t * net,
    pf_lldp_port_list_t * p_list);
 
 /**
@@ -62,7 +66,7 @@ void pf_port_get_list_of_ports (
  * @param p_iterator       Out:   Port iterator.
  */
 void pf_port_init_iterator_over_ports (
-   pnet_t * net,
+   const pnet_t * net,
    pf_port_iterator_t * p_iterator);
 
 /**
@@ -70,7 +74,7 @@ void pf_port_init_iterator_over_ports (
  *
  * If no more ports are available, 0 is returned.
  *
- * Will return: 1 2 3 ... PNET_NUMBER_OF_PHYSICAL_PORTS 0 0 0
+ * Will return: 1 2 3 ... num_physical_ports 0 0 0
  *
  * @param p_iterator       InOut: Port iterator.
  * @return Local port number for next port on local interface.
@@ -84,7 +88,7 @@ int pf_port_get_next (pf_port_iterator_t * p_iterator);
  * After highest port number has been returned, next time 1 will be returned
  * (and then 2 etc)
  *
- * Will return: 1 2 3 ... PNET_NUMBER_OF_PHYSICAL_PORTS 1 2 3 ... etc
+ * Will return: 1 2 3 ... num_physical_ports 1 2 3 ... etc
  *
  * @param p_iterator       InOut: Port iterator.
  * @return Local port number for next port on local interface.
@@ -96,33 +100,34 @@ int pf_port_get_next_repeat_cyclic (pf_port_iterator_t * p_iterator);
  *
  * If the local port number is out of range this operation will assert.
  *
- * @param net              InOut: The p-net stack instance
+ * @param net              In:    The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range:  1 .. num_physical_ports
  * @return DAP subslot number for port identity
  */
-uint16_t pf_port_loc_port_num_to_dap_subslot (int loc_port_num);
+uint16_t pf_port_loc_port_num_to_dap_subslot (
+   const pnet_t * net,
+   int loc_port_num);
 
 /**
  * Check if a DAP port subslot is mapped to a local port
  *
- * @param subslot              In: Subslot number
+ * @param net              In:    The p-net stack instance
+ * @param subslot          In:    Subslot number
  * @return true  if the subslot is mapped to a local port.
  *         false if the subslot is not supported.
  */
-bool pf_port_subslot_is_dap_port_id (uint16_t subslot);
+bool pf_port_subslot_is_dap_port_id (const pnet_t * net, uint16_t subslot);
 
 /**
  * Get local port from DAP port subslot
  *
- * Considers PNET_NUMBER_OF_PHYSICAL_PORTS
- *
- * @param subslot              In: Subslot number
+ * @param net              In:    The p-net stack instance
+ * @param subslot          In:    Subslot number
  * @return The port number mapping to the subslot.
  *         0 if the subslot is not supported.
  */
-int pf_port_dap_subslot_to_local_port (uint16_t subslot);
+int pf_port_dap_subslot_to_local_port (const pnet_t * net, uint16_t subslot);
 
 /**
  * Get port runtime data.
@@ -134,8 +139,7 @@ int pf_port_dap_subslot_to_local_port (uint16_t subslot);
  *
  * @param net              In:    The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @return port runtime data
  */
 pf_port_t * pf_port_get_state (pnet_t * net, int loc_port_num);
@@ -150,8 +154,7 @@ pf_port_t * pf_port_get_state (pnet_t * net, int loc_port_num);
  *
  * @param net              In:    The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS
+ *                                Valid range: 1 .. num_physical_ports
  * @return port configuration
  */
 const pnet_port_cfg_t * pf_port_get_config (pnet_t * net, int loc_port_num);
@@ -161,12 +164,11 @@ const pnet_port_cfg_t * pf_port_get_config (pnet_t * net, int loc_port_num);
  *
  * @param net              In:    The p-net stack instance
  * @param loc_port_num     In:    Local port number.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @return  true  if port number is valid,
  *          false if not
  */
-bool pf_port_is_valid (pnet_t * net, int loc_port_num);
+bool pf_port_is_valid (const pnet_t * net, int loc_port_num);
 
 /**
  * Get port number for network interface. If network interface
@@ -177,7 +179,7 @@ bool pf_port_is_valid (pnet_t * net, int loc_port_num);
  * @return local port number
  *         0 if no local port matches the network interface handle
  */
-int pf_port_get_port_number (pnet_t * net, pnal_eth_handle_t * eth_handle);
+int pf_port_get_port_number (const pnet_t * net, pnal_eth_handle_t * eth_handle);
 
 /**
  * Decode media type from Ethernet MAU type.

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -1717,8 +1717,8 @@ typedef struct pf_cpm
    uint16_t dht; /* Set to zero at incoming cyclic frame, increased by
                     pf_cpm_control_interval_expired() */
    bool new_data;
-   uint32_t rxa[PNET_NUMBER_OF_PHYSICAL_PORTS][2]; /* Max 2 frame_ids */
-   int32_t cycle;                                  /* value -1 means "never" */
+   uint32_t rxa[PNET_MAX_PHYSICAL_PORTS][2]; /* Max 2 frame_ids */
+   int32_t cycle;                            /* value -1 means "never" */
 
    uint32_t control_interval;
    bool ci_running;
@@ -2549,6 +2549,7 @@ typedef struct pf_lldp_port_list_t
 typedef struct pf_port_iterator
 {
    int next_port;
+   int number_of_ports;
 } pf_port_iterator_t;
 
 /**
@@ -2839,7 +2840,7 @@ struct pnet
          bool active;
          pf_lldp_name_of_device_mode_t mode;
       } name_of_device_mode;
-      pf_port_t port[PNET_NUMBER_OF_PHYSICAL_PORTS];
+      pf_port_t port[PNET_MAX_PHYSICAL_PORTS];
       pf_port_iterator_t link_monitor_iterator;
       uint32_t link_monitor_timeout; /* Scheduler timeout instance. */
    } pf_interface;

--- a/src/ports/linux/sampleapp_main.c
+++ b/src/ports/linux/sampleapp_main.c
@@ -32,23 +32,15 @@
 #include <string.h>
 #include <unistd.h>
 
-#if PNET_NUMBER_OF_PHYSICAL_PORTS == 1
 #define APP_DEFAULT_ETHERNET_INTERFACE "eth0"
-#elif PNET_NUMBER_OF_PHYSICAL_PORTS == 2
-#define APP_DEFAULT_ETHERNET_INTERFACE "br0,eth0,eth1"
-#elif PNET_NUMBER_OF_PHYSICAL_PORTS == 3
-#define APP_DEFAULT_ETHERNET_INTERFACE "br0,eth0,eth1,eth2"
-#else
-#define APP_DEFAULT_ETHERNET_INTERFACE ""
-#endif
 
-#define APP_MAIN_SLEEPTIME_US      5000 * 1000
-#define APP_MAIN_THREAD_PRIORITY   15
-#define APP_MAIN_THREAD_STACKSIZE  4096 /* bytes */
-#define APP_SNMP_THREAD_PRIORITY   1
-#define APP_SNMP_THREAD_STACKSIZE  256 * 1024 /* bytes */
-#define APP_ETH_THREAD_PRIORITY    10
-#define APP_ETH_THREAD_STACKSIZE   4096 /* bytes */
+#define APP_MAIN_SLEEPTIME_US     5000 * 1000
+#define APP_MAIN_THREAD_PRIORITY  15
+#define APP_MAIN_THREAD_STACKSIZE 4096 /* bytes */
+#define APP_SNMP_THREAD_PRIORITY  1
+#define APP_SNMP_THREAD_STACKSIZE 256 * 1024 /* bytes */
+#define APP_ETH_THREAD_PRIORITY   10
+#define APP_ETH_THREAD_STACKSIZE  4096 /* bytes */
 /* Note that this sample application uses os_timer_create() for the timer
    that controls the ticks. It is implemented in OSAL, and the Linux
    implementation uses a thread internally. To modify the timer thread priority,
@@ -370,6 +362,7 @@ int main (int argc, char * argv[])
    app_data_and_stack_t appdata_and_stack;
    app_data_t appdata;
    int ret = 0;
+   uint16_t number_of_ports = 0;
 
    memset (&appdata, 0, sizeof (appdata));
    appdata.alarm_allowed = true;
@@ -389,7 +382,7 @@ int main (int argc, char * argv[])
          PNET_MAX_SLOTS);
       printf ("P-net log level:      %u (DEBUG=0, FATAL=4)\n", LOG_LEVEL);
       printf ("App verbosity level:  %u\n", appdata.arguments.verbosity);
-      printf ("Number of ports:      %u\n", PNET_NUMBER_OF_PHYSICAL_PORTS);
+      printf ("Max number of ports:  %u\n", PNET_MAX_PHYSICAL_PORTS);
       printf ("Network interfaces:   %s\n", appdata.arguments.eth_interfaces);
       printf ("Button1 file:         %s\n", appdata.arguments.path_button1);
       printf ("Button2 file:         %s\n", appdata.arguments.path_button2);
@@ -408,12 +401,14 @@ int main (int argc, char * argv[])
    ret = app_pnet_cfg_init_netifs (
       appdata.arguments.eth_interfaces,
       &appdata.if_list,
+      &number_of_ports,
       &pnet_default_cfg,
       appdata.arguments.verbosity);
    if (ret != 0)
    {
       exit (EXIT_FAILURE);
    }
+   pnet_default_cfg.num_physical_ports = number_of_ports;
 
    ret = app_pnet_cfg_init_storage (&pnet_default_cfg, &appdata.arguments);
    if (ret != 0)

--- a/src/ports/rt-kernel/mib/lldp-ext-dot3-mib.c
+++ b/src/ports/rt-kernel/mib/lldp-ext-dot3-mib.c
@@ -405,8 +405,7 @@ static snmp_err_t lldpxdot3remporttable_get_next_instance (
  * @param value            Out:   Value to be returned in response.
  * @param port             In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param column           In:    Column index for the cell.
  * @return  Size of returned value, in bytes.
  *          -1 if no valid value could be returned.

--- a/src/ports/rt-kernel/mib/lldp-ext-pno-mib.c
+++ b/src/ports/rt-kernel/mib/lldp-ext-pno-mib.c
@@ -414,8 +414,7 @@ static snmp_err_t lldpxpnoremtable_get_next_instance (
  * @param value            Out:   Value to be returned in response.
  * @param port             In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param column           In:    Column index for the cell.
  * @return  Size of returned value, in bytes.
  *          -1 if no valid value could be returned.

--- a/src/ports/rt-kernel/mib/lldp-mib.c
+++ b/src/ports/rt-kernel/mib/lldp-mib.c
@@ -828,8 +828,7 @@ static snmp_err_t lldpremtable_get_next_instance (
  * @param value            Out:   Value to be returned in response.
  * @param port             In:    Local port number for port directly
  *                                connected to the remote device.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param column           In:    Column index for the cell.
  * @return  Size of returned value, in bytes.
  *          -1 if no valid value could be returned.
@@ -1072,8 +1071,7 @@ static snmp_err_t lldpremmanaddrtable_get_next_instance (
  * @param value            Out:   Value to be returned in response.
  * @param port             In:    Local port number for port directly
  *                                connected to the remote interface.
- *                                Valid range:
- *                                1 .. PNET_NUMBER_OF_PHYSICAL_PORTS.
+ *                                Valid range: 1 .. num_physical_ports
  * @param column           In:    Column index for the cell.
  * @return  Size of returned value, in bytes.
  *          -1 if no valid value could be returned.

--- a/src/ports/rt-kernel/sampleapp_main.c
+++ b/src/ports/rt-kernel/sampleapp_main.c
@@ -165,6 +165,7 @@ int main (void)
    app_data_t appdata;
    g_net = NULL;
    gp_appdata = &appdata;
+   uint16_t number_of_ports = 0;
 
    /* Prepare appdata */
    memset (&appdata, 0, sizeof (appdata));
@@ -185,7 +186,7 @@ int main (void)
          PNET_MAX_SLOTS);
       printf ("P-net log level:      %u (DEBUG=0, FATAL=4)\n", LOG_LEVEL);
       printf ("App verbosity level:  %u\n", appdata.arguments.verbosity);
-      printf ("Number of ports:      %u\n", PNET_NUMBER_OF_PHYSICAL_PORTS);
+      printf ("Max number of ports:  %u\n", PNET_MAX_PHYSICAL_PORTS);
       printf ("Network interfaces:   %s\n", appdata.arguments.eth_interfaces);
       printf ("Default station name: %s\n", appdata.arguments.station_name);
    }
@@ -199,12 +200,14 @@ int main (void)
    ret = app_pnet_cfg_init_netifs (
       appdata.arguments.eth_interfaces,
       &appdata.if_list,
+      &number_of_ports,
       &pnet_default_cfg,
       appdata.arguments.verbosity);
    if (ret != 0)
    {
       return -1;
    }
+   pnet_default_cfg.num_physical_ports = number_of_ports;
 
    /* Initialize profinet stack */
    g_net = pnet_init (&pnet_default_cfg);

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -37,7 +37,7 @@ typedef struct mock_os_data_obj
     * Note that port numbers start at 1. To simplify test cases, we add a
     * dummy array element at index 0.
     */
-   pnal_eth_status_t eth_status[PNET_NUMBER_OF_PHYSICAL_PORTS + 1];
+   pnal_eth_status_t eth_status[PNET_MAX_PHYSICAL_PORTS + 1];
 
    uint16_t udp_sendto_len;
    uint16_t udp_sendto_count;

--- a/test/test_cmrpc.cpp
+++ b/test/test_cmrpc.cpp
@@ -659,7 +659,7 @@ TEST_F (CmrpcTest, CmrpcConnectReleaseIOSAR_DA)
    EXPECT_EQ (appdata.call_counters.state_calls, 1);
    EXPECT_EQ (appdata.cmdev_state, PNET_EVENT_STARTUP);
    EXPECT_EQ (appdata.call_counters.connect_calls, 1);
-   EXPECT_EQ (mock_os_data.eth_send_count, PNET_NUMBER_OF_PHYSICAL_PORTS);
+   EXPECT_EQ (mock_os_data.eth_send_count, PNET_MAX_PHYSICAL_PORTS);
 
    TEST_TRACE ("\nGenerating mock release request IOSAR_DA\n");
    mock_set_pnal_udp_recvfrom_buffer (

--- a/test/test_dcp.cpp
+++ b/test/test_dcp.cpp
@@ -104,7 +104,7 @@ TEST_F (DcpTest, DcpHelloTest)
    ret = pf_eth_recv (mock_os_data.eth_if_handle, net, p_buf);
 
    EXPECT_EQ (ret, 1);
-   EXPECT_EQ (mock_os_data.eth_send_count, PNET_NUMBER_OF_PHYSICAL_PORTS + 1);
+   EXPECT_EQ (mock_os_data.eth_send_count, PNET_MAX_PHYSICAL_PORTS + 1);
 
    EXPECT_EQ (appdata.call_counters.led_off_calls, 1);
    EXPECT_EQ (appdata.call_counters.led_on_calls, 0);
@@ -156,7 +156,7 @@ TEST_F (DcpTest, DcpRunTest)
 
    EXPECT_EQ (
       mock_os_data.eth_send_count,
-      9 + (PNET_NUMBER_OF_PHYSICAL_PORTS - 1) * 4);
+      9 + (PNET_MAX_PHYSICAL_PORTS - 1) * 4);
    EXPECT_EQ (mock_os_data.set_ip_suite_count, 2);
 
    EXPECT_EQ (appdata.call_counters.led_on_calls, 3);

--- a/test/test_fspm.cpp
+++ b/test/test_fspm.cpp
@@ -38,11 +38,25 @@ TEST_F (FspmUnitTest, FspmCheckValidateConfiguration)
    cfg.min_device_interval = 1;
    cfg.im_0_data.im_supported = 0;
    cfg.if_cfg.main_netif_name = "eth0";
+   cfg.num_physical_ports = PNET_MAX_PHYSICAL_PORTS;
 
    EXPECT_EQ (pf_fspm_validate_configuration (&cfg), 0);
 
    /* Check pointer validity */
    EXPECT_EQ (pf_fspm_validate_configuration (NULL), -1);
+
+   /* Check number of ports */
+   cfg.num_physical_ports = PNET_MAX_PHYSICAL_PORTS + 1;
+   EXPECT_EQ (pf_fspm_validate_configuration (&cfg), -1);
+
+   cfg.num_physical_ports = 0;
+   EXPECT_EQ (pf_fspm_validate_configuration (&cfg), -1);
+
+   cfg.num_physical_ports = 1;
+   EXPECT_EQ (pf_fspm_validate_configuration (&cfg), 0);
+
+   cfg.num_physical_ports = PNET_MAX_PHYSICAL_PORTS;
+   EXPECT_EQ (pf_fspm_validate_configuration (&cfg), 0);
 
    /* Check minimum stack update interval */
    cfg.min_device_interval = 0;

--- a/test/test_lldp.cpp
+++ b/test/test_lldp.cpp
@@ -460,7 +460,7 @@ TEST_F (LldpTest, LldpInitTest)
    EXPECT_EQ (appdata.call_counters.ccontrol_calls, 0);
    EXPECT_EQ (appdata.call_counters.read_calls, 0);
    EXPECT_EQ (appdata.call_counters.write_calls, 0);
-   EXPECT_EQ (mock_os_data.eth_send_count, PNET_NUMBER_OF_PHYSICAL_PORTS);
+   EXPECT_EQ (mock_os_data.eth_send_count, PNET_MAX_PHYSICAL_PORTS);
 }
 
 TEST_F (LldpTest, LldpGenerateAliasName)

--- a/test/test_port.cpp
+++ b/test/test_port.cpp
@@ -26,159 +26,212 @@ class PortTest : public PnetIntegrationTest
 
 class PortUnitTest : public PnetUnitTest
 {
+   protected:
+      pnet_t dummystack = {};
 };
 
 TEST_F (PortUnitTest, PortGetPortList)
 {
-   pnet_t * dummystack = NULL;
    pf_lldp_port_list_t port_list;
 
    memset (&port_list, 0xff, sizeof (port_list));
 
-   pf_port_get_list_of_ports (dummystack, 1, &port_list);
+   dummystack.fspm_cfg.num_physical_ports = 1;
+   pf_port_get_list_of_ports (&dummystack, &port_list);
    EXPECT_EQ (port_list.ports[0], 0x80);
    EXPECT_EQ (port_list.ports[1], 0x00);
 
-   pf_port_get_list_of_ports (dummystack, 2, &port_list);
+   dummystack.fspm_cfg.num_physical_ports = 2;
+   pf_port_get_list_of_ports (&dummystack, &port_list);
    EXPECT_EQ (port_list.ports[0], 0xC0);
    EXPECT_EQ (port_list.ports[1], 0x00);
 
-   pf_port_get_list_of_ports (dummystack, 4, &port_list);
+   dummystack.fspm_cfg.num_physical_ports = 4;
+   pf_port_get_list_of_ports (&dummystack, &port_list);
    EXPECT_EQ (port_list.ports[0], 0xF0);
    EXPECT_EQ (port_list.ports[1], 0x00);
 
-   pf_port_get_list_of_ports (dummystack, 8, &port_list);
+   dummystack.fspm_cfg.num_physical_ports = 8;
+   pf_port_get_list_of_ports (&dummystack, &port_list);
    EXPECT_EQ (port_list.ports[0], 0xFF);
    EXPECT_EQ (port_list.ports[1], 0x00);
 
-   pf_port_get_list_of_ports (dummystack, 9, &port_list);
+   dummystack.fspm_cfg.num_physical_ports = 9;
+   pf_port_get_list_of_ports (&dummystack, &port_list);
    EXPECT_EQ (port_list.ports[0], 0xFF);
    EXPECT_EQ (port_list.ports[1], 0x80);
 
-   pf_port_get_list_of_ports (dummystack, 12, &port_list);
+   dummystack.fspm_cfg.num_physical_ports = 12;
+   pf_port_get_list_of_ports (&dummystack, &port_list);
    EXPECT_EQ (port_list.ports[0], 0xFF);
    EXPECT_EQ (port_list.ports[1], 0xF0);
 
-   pf_port_get_list_of_ports (dummystack, 16, &port_list);
+   dummystack.fspm_cfg.num_physical_ports = 16;
+   pf_port_get_list_of_ports (&dummystack, &port_list);
    EXPECT_EQ (port_list.ports[0], 0xFF);
    EXPECT_EQ (port_list.ports[1], 0xFF);
 }
 
 TEST_F (PortUnitTest, PortCheckIterator)
 {
-   pnet_t * dummystack = NULL;
    pf_port_iterator_t port_iterator;
-   int port;
-   int ix;
 
-   /* Retrieve first port */
-   pf_port_init_iterator_over_ports (dummystack, &port_iterator);
-   port = pf_port_get_next (&port_iterator);
-   EXPECT_EQ (port, 1);
+   dummystack.fspm_cfg.num_physical_ports = 6;
 
-   /* More ports might be available dependent on compile time setting */
-   for (ix = 2; ix <= PNET_NUMBER_OF_PHYSICAL_PORTS; ix++)
-   {
-      port = pf_port_get_next (&port_iterator);
-      EXPECT_EQ (port, ix);
-   }
+   pf_port_init_iterator_over_ports (&dummystack, &port_iterator);
 
-   /* Verify that we return 0 when we are done */
-   port = pf_port_get_next (&port_iterator);
-   EXPECT_EQ (port, 0);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 2);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 3);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 4);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 5);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 6);
 
-   /* Do not restart automatically */
-   port = pf_port_get_next (&port_iterator);
-   EXPECT_EQ (port, 0);
+   /* Verify that we return 0 when we are done, and no auto restart */
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 0);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 0);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 0);
 
    /* Restart the iterator */
-   pf_port_init_iterator_over_ports (dummystack, &port_iterator);
-   port = pf_port_get_next (&port_iterator);
-   EXPECT_EQ (port, 1);
+   pf_port_init_iterator_over_ports (&dummystack, &port_iterator);
+
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 2);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 3);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 4);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 5);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 6);
+
+   /* Different number of ports */
+   dummystack.fspm_cfg.num_physical_ports = 1;
+   pf_port_init_iterator_over_ports (&dummystack, &port_iterator);
+
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 0);
+   EXPECT_EQ (pf_port_get_next (&port_iterator), 0);
 }
 
 TEST_F (PortUnitTest, PortCheckIteratorRepeatCyclic)
 {
-   pnet_t * dummystack = NULL;
    pf_port_iterator_t port_iterator;
-   int port;
-   int ix;
 
-   /* Retrieve first port */
-   pf_port_init_iterator_over_ports (dummystack, &port_iterator);
-   port = pf_port_get_next_repeat_cyclic (&port_iterator);
-   EXPECT_EQ (port, 1);
+   dummystack.fspm_cfg.num_physical_ports = 6;
 
-   /* More ports might be available dependent on compile time setting */
+   pf_port_init_iterator_over_ports (&dummystack, &port_iterator);
 
-   for (ix = 2; ix <= PNET_NUMBER_OF_PHYSICAL_PORTS; ix++)
-   {
-      port = pf_port_get_next_repeat_cyclic (&port_iterator);
-      EXPECT_EQ (port, ix);
-   }
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 2);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 3);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 4);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 5);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 6);
 
-   /* Verify that we return 1 again  */
-   port = pf_port_get_next_repeat_cyclic (&port_iterator);
-   EXPECT_EQ (port, 1);
+   /* Verify auto restart */
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 2);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 3);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 4);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 5);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 6);
 
-   /* Continue to loop over available ports */
-   for (ix = 2; ix <= PNET_NUMBER_OF_PHYSICAL_PORTS; ix++)
-   {
-      port = pf_port_get_next_repeat_cyclic (&port_iterator);
-      EXPECT_EQ (port, ix);
-   }
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 2);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 3);
 
-   /* Verify that we return 1 again  */
-   port = pf_port_get_next_repeat_cyclic (&port_iterator);
-   EXPECT_EQ (port, 1);
+   /* Restart the iterator from first port */
+   pf_port_init_iterator_over_ports (&dummystack, &port_iterator);
 
-   /* Restart the iterator */
-   pf_port_init_iterator_over_ports (dummystack, &port_iterator);
-   port = pf_port_get_next_repeat_cyclic (&port_iterator);
-   EXPECT_EQ (port, 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 2);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 3);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 4);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 5);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 6);
+
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 2);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 3);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 4);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 5);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 6);
+
+   /* Different number of ports */
+   dummystack.fspm_cfg.num_physical_ports = 1;
+   pf_port_init_iterator_over_ports (&dummystack, &port_iterator);
+
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
+   EXPECT_EQ (pf_port_get_next_repeat_cyclic (&port_iterator), 1);
 }
 
-TEST_F (PortUnitTest, loc_port_num_to_dap_subslot)
+TEST_F (PortUnitTest, PortNumToSubslot)
 {
-   pnet_t * dummystack = NULL;
-   int port;
-   uint16_t sub_slot;
-   pf_port_iterator_t port_iterator;
+   dummystack.fspm_cfg.num_physical_ports = 16;
 
-   pf_port_init_iterator_over_ports (dummystack, &port_iterator);
-   port = pf_port_get_next (&port_iterator);
-
-   while (port != 0)
-   {
-      sub_slot = pf_port_loc_port_num_to_dap_subslot (port);
-      EXPECT_EQ (sub_slot, 0x8000 + port);
-      port = pf_port_get_next (&port_iterator);
-   }
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 1), 0x8001);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 2), 0x8002);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 3), 0x8003);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 4), 0x8004);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 5), 0x8005);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 6), 0x8006);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 7), 0x8007);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 8), 0x8008);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 9), 0x8009);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 10), 0x800A);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 11), 0x800B);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 12), 0x800C);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 13), 0x800D);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 14), 0x800E);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 15), 0x800F);
+   EXPECT_EQ (pf_port_loc_port_num_to_dap_subslot (&dummystack, 16), 0x8010);
 }
 
-TEST_F (PortUnitTest, dap_subslot_to_local_port)
+TEST_F (PortUnitTest, PortSubslotToLocalPort)
 {
-   pnet_t * dummystack = NULL;
-   int port;
-   int local_port_num;
-   pf_port_iterator_t port_iterator;
+   dummystack.fspm_cfg.num_physical_ports = 4;
 
-   pf_port_init_iterator_over_ports (dummystack, &port_iterator);
-   port = pf_port_get_next (&port_iterator);
+   EXPECT_EQ (pf_port_dap_subslot_to_local_port (&dummystack, 0x8001), 1);
+   EXPECT_EQ (pf_port_dap_subslot_to_local_port (&dummystack, 0x8002), 2);
+   EXPECT_EQ (pf_port_dap_subslot_to_local_port (&dummystack, 0x8003), 3);
+   EXPECT_EQ (pf_port_dap_subslot_to_local_port (&dummystack, 0x8004), 4);
 
-   while (port != 0)
-   {
-      local_port_num = pf_port_dap_subslot_to_local_port (0x8000 + port);
-      EXPECT_EQ (local_port_num, port);
-      port = pf_port_get_next (&port_iterator);
-   }
+   /* Out of range */
+   EXPECT_EQ (pf_port_dap_subslot_to_local_port (&dummystack, 0x8000), 0);
+   EXPECT_EQ (pf_port_dap_subslot_to_local_port (&dummystack, 0x8005), 0);
+}
 
-   /* Invalid / not port sub slot  (low)*/
-   local_port_num = pf_port_dap_subslot_to_local_port (0x8000);
-   EXPECT_EQ (local_port_num, 0);
+TEST_F (PortUnitTest, PortIsSubslotDap)
+{
+   dummystack.fspm_cfg.num_physical_ports = 4;
 
-   /* Invalid / not port sub slot  (high)*/
-   local_port_num = pf_port_dap_subslot_to_local_port (
-      0x8000 + PNET_NUMBER_OF_PHYSICAL_PORTS + 1);
-   EXPECT_EQ (local_port_num, 0);
+   EXPECT_EQ (pf_port_subslot_is_dap_port_id (&dummystack, 0x8001), true);
+   EXPECT_EQ (pf_port_subslot_is_dap_port_id (&dummystack, 0x8002), true);
+   EXPECT_EQ (pf_port_subslot_is_dap_port_id (&dummystack, 0x8003), true);
+   EXPECT_EQ (pf_port_subslot_is_dap_port_id (&dummystack, 0x8004), true);
+
+   /* Out of range */
+   EXPECT_EQ (pf_port_subslot_is_dap_port_id (&dummystack, 0x8000), false);
+   EXPECT_EQ (pf_port_subslot_is_dap_port_id (&dummystack, 0x8005), false);
+}
+
+TEST_F (PortUnitTest, PortIsValid)
+{
+   dummystack.fspm_cfg.num_physical_ports = 4;
+
+   EXPECT_EQ (pf_port_is_valid (&dummystack, 1), true);
+   EXPECT_EQ (pf_port_is_valid (&dummystack, 2), true);
+   EXPECT_EQ (pf_port_is_valid (&dummystack, 3), true);
+   EXPECT_EQ (pf_port_is_valid (&dummystack, 4), true);
+
+   /* Out of range */
+   EXPECT_EQ (pf_port_is_valid (&dummystack, 0), false);
+   EXPECT_EQ (pf_port_is_valid (&dummystack, 5), false);
+}
+
+TEST_F (PortUnitTest, PortGetNumberOfPorts)
+{
+   dummystack.fspm_cfg.num_physical_ports = 4;
+
+   EXPECT_EQ (pf_port_get_number_of_ports (&dummystack), 4);
 }

--- a/test/utils_for_testing.cpp
+++ b/test/utils_for_testing.cpp
@@ -544,6 +544,8 @@ void PnetIntegrationTestBase::cfg_init()
 
    /* Diagnosis */
    pnet_default_cfg.use_qualified_diagnosis = true;
+
+   pnet_default_cfg.num_physical_ports = PNET_MAX_PHYSICAL_PORTS;
 }
 
 void PnetIntegrationTestBase::run_stack (int us)


### PR DESCRIPTION
This allows the same precompiled library to be used for different number of ports