### PR TITLE
Basic adaption of pnet to multiple connections

### DIFF
--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -36,7 +36,6 @@ extern "C" {
 
 #define APP_DATA_LED_ID            1
 #define APP_PROFINET_SIGNAL_LED_ID 2
-#define APP_EVENT_READY_FOR_DATA   BIT (0)
 #define APP_EVENT_TIMER            BIT (1)
 #define APP_EVENT_ALARM            BIT (2)
 #define APP_EVENT_ABORT            BIT (15)

--- a/src/common/pf_ppm.c
+++ b/src/common/pf_ppm.c
@@ -441,21 +441,7 @@ int pf_ppm_close_req (pnet_t * net, pf_ar_t * p_ar, uint32_t crep)
    return 0;
 }
 
-/**
- * @internal
- * Find the AR, input IOCR and IODATA object instances for the specified
- * sub-slot.
- * @param net              InOut: The p-net stack instance
- * @param api_id           In:   The API id.
- * @param slot_nbr         In:   The slot number.
- * @param subslot_nbr      In:   The sub-slot number.
- * @param pp_ar            Out:  The AR instance.
- * @param pp_iocr          Out:  The IOCR instance.
- * @param pp_iodata        Out:  The IODATA object instance.
- * @return  0  If the information has been found.
- *          -1 If the information was not found.
- */
-static int pf_ppm_get_ar_iocr_desc (
+int pf_ppm_get_ar_iocr_desc (
    pnet_t * net,
    uint32_t api_id,
    uint16_t slot_nbr,

--- a/src/common/pf_ppm.h
+++ b/src/common/pf_ppm.h
@@ -47,6 +47,28 @@ int pf_ppm_activate_req (pnet_t * net, pf_ar_t * p_ar, uint32_t crep);
 int pf_ppm_close_req (pnet_t * net, pf_ar_t * p_ar, uint32_t crep);
 
 /**
+ * Find the AR, input IOCR and IODATA object instances for the specified
+ * sub-slot.
+ * @param net              InOut: The p-net stack instance
+ * @param api_id           In:    The API id.
+ * @param slot_nbr         In:    The slot number.
+ * @param subslot_nbr      In:    The sub-slot number.
+ * @param pp_ar            Out:   The AR instance.
+ * @param pp_iocr          Out:   The IOCR instance.
+ * @param pp_iodata        Out:   The IODATA object instance.
+ * @return  0  If the information has been found.
+ *          -1 If the information was not found.
+ */
+int pf_ppm_get_ar_iocr_desc (
+   pnet_t * net,
+   uint32_t api_id,
+   uint16_t slot_nbr,
+   uint16_t subslot_nbr,
+   pf_ar_t ** pp_ar,
+   pf_iocr_t ** pp_iocr,
+   pf_iodata_object_t ** pp_iodata);
+
+/**
  * Set the data and IOPS for a sub-module.
  * @param net              InOut: The p-net stack instance
  * @param api_id           In:   The API id.

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -4466,12 +4466,12 @@ int pf_cmdev_generate_submodule_diff (pnet_t * net, pf_ar_t * p_ar)
                         has_sub_diff = true;
                      }
 
-                     /* Check submodule diagnosis state and update diff. */
                      p_submodule_state = &p_ar->api_diffs[nbr_api_diffs]
                                              .module_diffs[nbr_mod_diffs]
                                              .submodule_diffs[nbr_sub_diffs]
                                              .submodule_state;
 
+                     /* Check submodule diagnosis state and update diff. */
                      if (
                         (p_cfg_subslot->submodule_state.fault == true) ||
                         (p_cfg_subslot->submodule_state.maintenance_demanded ==
@@ -4491,6 +4491,20 @@ int pf_cmdev_generate_submodule_diff (pnet_t * net, pf_ar_t * p_ar)
                            p_cfg_subslot->submodule_state.maintenance_demanded;
                         p_submodule_state->maintenance_required =
                            p_cfg_subslot->submodule_state.maintenance_required;
+                        has_sub_diff = true;
+                     }
+
+                     /* Check if other AR owns the submodule and update diff */
+                     if (p_cfg_subslot->p_ar != NULL && p_cfg_subslot->p_ar != p_ar)
+                     {
+                        p_ar->api_diffs[nbr_api_diffs]
+                           .module_diffs[nbr_mod_diffs]
+                           .submodule_diffs[nbr_sub_diffs]
+                           .submodule_ident_number =
+                           p_cfg_subslot->submodule_ident_number;
+
+                        p_submodule_state->ar_info =
+                           PF_SUBMOD_AR_INFO_LOCKED_BY_IO_CONTROLLER;
                         has_sub_diff = true;
                      }
                   }
@@ -4532,31 +4546,38 @@ int pf_cmdev_generate_submodule_diff (pnet_t * net, pf_ar_t * p_ar)
 
 /**
  * @internal
- * Verify that the frame id is not already used by this AR.
+ * Verify that the frame id is not already used by any AR.
  *
+ * Looks in all ARs, both in input CR and output CR.
+ *
+ * @param net              InOut: The p-net stack instance
  * @param p_ar             In:    The AR instance.
  * @param frame_id         In:    The frame id to check.
  * @return  true  if the frame_id is free to use.
- *          false if the frame id is already used by this AR.
+ *          false if the frame id is already used.
  */
-static bool pf_cmdev_verify_free_frame_id (
-   const pf_ar_t * p_ar,
-   uint16_t frame_id)
+static bool pf_cmdev_verify_free_frame_id (pnet_t * net, uint16_t frame_id)
 {
-   bool is_free = true;
-   uint16_t ix;
-   const pf_iocr_param_t * p_iocr_param;
+   int ix = 0;
+   int iy = 0;
+   pf_ar_t * p_ar = NULL;
 
-   for (ix = 0; ix < p_ar->nbr_iocrs; ix++)
+   for (ix = 0; ix < PNET_MAX_AR; ix++)
    {
-      p_iocr_param = &p_ar->iocrs[ix].param;
-      if (p_iocr_param->frame_id == frame_id)
+      p_ar = pf_ar_find_by_index (net, ix);
+      if ((p_ar != NULL) && (p_ar->in_use == true))
       {
-         is_free = false;
+         for (iy = 0; iy < p_ar->nbr_iocrs; iy++)
+         {
+            if (p_ar->iocrs[iy].param.frame_id == frame_id)
+            {
+               return false;
+            }
+         }
       }
    }
 
-   return is_free;
+   return true;
 }
 
 /**
@@ -4564,9 +4585,10 @@ static bool pf_cmdev_verify_free_frame_id (
  * The controller may send 0xffff as the frame id for output CRs.
  * In that case we must supply a preferred frame id in the response.
  *
+ * @param net              InOut: The p-net stack instance
  * @param p_ar             InOut: The AR instance.
  */
-static void pf_cmdev_fix_frame_id (pf_ar_t * p_ar)
+static void pf_cmdev_fix_frame_id (pnet_t * net, pf_ar_t * p_ar)
 {
    uint16_t ix;
    pf_iocr_param_t * p_iocr_param;
@@ -4608,10 +4630,11 @@ static void pf_cmdev_fix_frame_id (pf_ar_t * p_ar)
 
          frame_id = start;
          while ((frame_id <= stop) &&
-                (pf_cmdev_verify_free_frame_id (p_ar, frame_id) == false))
+                (pf_cmdev_verify_free_frame_id (net, frame_id) == false))
          {
             frame_id++;
          }
+
          if (frame_id <= stop)
          {
             p_iocr_param->frame_id = frame_id;
@@ -4771,7 +4794,7 @@ int pf_cmdev_rm_connect_ind (
             sizeof (pnet_ethaddr_t));
          p_ar->ar_result.responder_udp_rt_port = PF_UDP_UNICAST_PORT;
 
-         pf_cmdev_fix_frame_id (p_ar);
+         pf_cmdev_fix_frame_id (net, p_ar);
 
          for (ix = 0; ix < p_ar->nbr_iocrs; ix++)
          {
@@ -5012,6 +5035,10 @@ int pf_cmdev_cm_ccontrol_req (pnet_t * net, pf_ar_t * p_ar)
    uint16_t ix;
    uint16_t iy;
    bool data_avail = true; /* Assume all OK */
+   pf_iodata_object_t * p_iodata = NULL;
+   pf_ar_t * p_owning_ar = NULL;
+   pf_iocr_t * p_owning_iocr = NULL;
+   pf_iodata_object_t * p_owning_iodata = NULL;
 
    if (p_ar->ar_param.ar_properties.device_access == false)
    {
@@ -5027,17 +5054,70 @@ int pf_cmdev_cm_ccontrol_req (pnet_t * net, pf_ar_t * p_ar)
             {
                for (iy = 0; iy < p_ar->iocrs[ix].nbr_data_desc; iy++)
                {
-                  /* Member data_avail is set directly by the PPM. The value is
-                   * true also if only the IOPS is set.*/
+                  p_iodata = &p_ar->iocrs[ix].data_desc[iy];
+
+                  /* The application is limited to setting data for a specific
+                     subslot. Check that it has tried to set the data.
+                     If some other AR owns the subslot, check that data is
+                     set for that AR.
+
+                     In the future we might implement reading inputdata from
+                     one subslot to several connections (different PLCs).
+
+                     Find owning AR, CR and descriptor */
                   if (
-                     (p_ar->iocrs[ix].data_desc[iy].iops_length > 0) &&
-                     (p_ar->iocrs[ix].data_desc[iy].data_avail == false))
+                     pf_ppm_get_ar_iocr_desc (
+                        net,
+                        p_iodata->api_id,
+                        p_iodata->slot_nbr,
+                        p_iodata->subslot_nbr,
+                        &p_owning_ar,
+                        &p_owning_iocr,
+                        &p_owning_iodata) == 0)
                   {
+                     if (
+                        p_owning_ar != p_ar ||
+                        p_owning_iocr != &p_ar->iocrs[ix] ||
+                        p_owning_iodata != p_iodata)
+                     {
+                        LOG_DEBUG (
+                           PNET_LOG,
+                           "CMDEV(%d): Slot %u subslot 0x%04x is owned by "
+                           "AREP %u CREP %u but AREP %u CREP %u is asking to "
+                           "use it.\n",
+                           __LINE__,
+                           p_iodata->slot_nbr,
+                           p_iodata->subslot_nbr,
+                           p_owning_ar->arep,
+                           p_owning_iocr->crep,
+                           p_ar->arep,
+                           p_ar->iocrs[ix].crep);
+                     }
+
+                     /* Member data_avail is set directly by the PPM. The value
+                        is true also if only the IOPS is set. */
+                     if (
+                        p_owning_iodata->iops_length > 0 &&
+                        p_owning_iodata->data_avail == false)
+                     {
+                        data_avail = false;
+                     }
+                  }
+                  else
+                  {
+                     LOG_DEBUG (
+                        PNET_LOG,
+                        "CMDEV(%d): Could not find owning AR for slot %u "
+                        "subslot 0x%04x\n",
+                        __LINE__,
+                        p_iodata->slot_nbr,
+                        p_iodata->subslot_nbr);
                      data_avail = false;
                   }
                }
             }
          }
+
          if (data_avail == true)
          {
             pf_cmdev_state_ind (net, p_ar, PNET_EVENT_APPLRDY);
@@ -5046,6 +5126,7 @@ int pf_cmdev_cm_ccontrol_req (pnet_t * net, pf_ar_t * p_ar)
                ret = pf_cmdev_set_state (net, p_ar, PF_CMDEV_STATE_W_ARDYCNF);
             }
          }
+
          break;
       default:
          /* Ignore and stay in all other states. */

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -665,6 +665,8 @@ static int pf_ar_allocate (pnet_t * net, pf_ar_t ** pp_ar)
    {
       memset (&net->cmrpc_ar[ix], 0, sizeof (net->cmrpc_ar[ix]));
       net->cmrpc_ar[ix].in_use = true;
+      pf_cmsu_init (net, &net->cmrpc_ar[ix]);
+      pf_cmwrr_init (net, &net->cmrpc_ar[ix]);
 
       *pp_ar = &net->cmrpc_ar[ix];
 

--- a/src/device/pf_cmsu.h
+++ b/src/device/pf_cmsu.h
@@ -22,8 +22,10 @@ extern "C" {
 
 /**
  * Initialize the CMSU component.
+ * @param net              InOut: The p-net stack instance
+ * @param p_ar             InOut: The AR instance.
  */
-void pf_cmsu_init (pnet_t * net);
+void pf_cmsu_init (pnet_t * net, pf_ar_t * p_ar);
 
 /**
  * Handle CMDEV events.

--- a/src/device/pf_cmwrr.c
+++ b/src/device/pf_cmwrr.c
@@ -32,9 +32,9 @@
  * Triggers the \a pnet_write_ind() user callback for some values.
  */
 
-void pf_cmwrr_init (pnet_t * net)
+void pf_cmwrr_init (pnet_t * net, pf_ar_t * p_ar)
 {
-   net->cmwrr_state = PF_CMWRR_STATE_IDLE;
+   p_ar->cmwrr_state = PF_CMWRR_STATE_IDLE;
 }
 
 /**
@@ -68,7 +68,7 @@ static const char * pf_cmwrr_state_to_string (pf_cmwrr_state_values_t state)
 
 void pf_cmwrr_show (const pnet_t * net, const pf_ar_t * p_ar)
 {
-   const char * s = pf_cmwrr_state_to_string (net->cmwrr_state);
+   const char * s = pf_cmwrr_state_to_string (p_ar->cmwrr_state);
 
    printf ("CMWRR state           = %s\n", s);
    (void)s;
@@ -76,41 +76,41 @@ void pf_cmwrr_show (const pnet_t * net, const pf_ar_t * p_ar)
 
 int pf_cmwrr_cmdev_state_ind (
    pnet_t * net,
-   const pf_ar_t * p_ar,
+   pf_ar_t * p_ar,
    pnet_event_values_t event)
 {
-   switch (net->cmwrr_state)
+   switch (p_ar->cmwrr_state)
    {
    case PF_CMWRR_STATE_IDLE:
       if (event == PNET_EVENT_STARTUP)
       {
-         net->cmwrr_state = PF_CMWRR_STATE_STARTUP;
+         p_ar->cmwrr_state = PF_CMWRR_STATE_STARTUP;
       }
       break;
    case PF_CMWRR_STATE_STARTUP:
       if (event == PNET_EVENT_PRMEND)
       {
-         net->cmwrr_state = PF_CMWRR_STATE_PRMEND;
+         p_ar->cmwrr_state = PF_CMWRR_STATE_PRMEND;
       }
       else if (event == PNET_EVENT_ABORT)
       {
-         net->cmwrr_state = PF_CMWRR_STATE_IDLE;
+         p_ar->cmwrr_state = PF_CMWRR_STATE_IDLE;
       }
       break;
    case PF_CMWRR_STATE_PRMEND:
       if (event == PNET_EVENT_ABORT)
       {
-         net->cmwrr_state = PF_CMWRR_STATE_IDLE;
+         p_ar->cmwrr_state = PF_CMWRR_STATE_IDLE;
       }
       else if (event == PNET_EVENT_APPLRDY)
       {
-         net->cmwrr_state = PF_CMWRR_STATE_DATA;
+         p_ar->cmwrr_state = PF_CMWRR_STATE_DATA;
       }
       break;
    case PF_CMWRR_STATE_DATA:
       if (event == PNET_EVENT_ABORT)
       {
-         net->cmwrr_state = PF_CMWRR_STATE_IDLE;
+         p_ar->cmwrr_state = PF_CMWRR_STATE_IDLE;
       }
       break;
    default:
@@ -118,7 +118,7 @@ int pf_cmwrr_cmdev_state_ind (
          PNET_LOG,
          "CMWRR(%d): BAD state in cmwrr %u\n",
          __LINE__,
-         (unsigned)net->cmwrr_state);
+         (unsigned)p_ar->cmwrr_state);
       break;
    }
 
@@ -135,12 +135,12 @@ int pf_cmwrr_cmdev_state_ind (
  * Triggers the \a pnet_write_ind() user callback for some values.
  *
  * @param net              InOut: The p-net stack instance
- * @param p_ar             In:   The AR instance.
- * @param p_write_request  In:   The IODWrite request.
- * @param p_req_buf        In:   The request buffer.
- * @param data_length      In:   Size of the data to write.
- * @param p_req_pos        InOut:Position within the request buffer.
- * @param p_result         Out:  Detailed error information.
+ * @param p_ar             In:    The AR instance.
+ * @param p_write_request  In:    The IODWrite request.
+ * @param p_req_buf        In:    The request buffer.
+ * @param data_length      In:    Size of the data to write.
+ * @param p_req_pos        InOut: Position within the request buffer.
+ * @param p_result         Out:   Detailed error information.
  * @return  0  if operation succeeded.
  *          -1 if an error occurred.
  */
@@ -162,7 +162,7 @@ static int pf_cmwrr_write (
       LOG_INFO (
          PNET_LOG,
          "CMWRR(%d): PLC is writing slot %u subslot 0x%04X index 0x%04X "
-         "(local port %u) \"%s\"\n",
+         "(local port %u) \"%s\" for AREP %u\n",
          __LINE__,
          p_write_request->slot_number,
          p_write_request->subslot_number,
@@ -170,19 +170,21 @@ static int pf_cmwrr_write (
          pf_port_dap_subslot_to_local_port (
             net,
             p_write_request->subslot_number),
-         pf_index_to_logstring (p_write_request->index));
+         pf_index_to_logstring (p_write_request->index),
+         p_ar->arep);
    }
    else
    {
       LOG_INFO (
          PNET_LOG,
          "CMWRR(%d): PLC is writing slot %u subslot 0x%04X index 0x%04X "
-         "\"%s\"\n",
+         "\"%s\" for AREP %u\n",
          __LINE__,
          p_write_request->slot_number,
          p_write_request->subslot_number,
          p_write_request->index,
-         pf_index_to_logstring (p_write_request->index));
+         pf_index_to_logstring (p_write_request->index),
+         p_ar->arep);
    }
 
    if (p_write_request->index <= PF_IDX_USER_MAX)
@@ -265,7 +267,7 @@ int pf_cmwrr_rm_write_ind (
    p_write_result->index = p_write_request->index;
    p_write_result->record_data_length = 0;
 
-   switch (net->cmwrr_state)
+   switch (p_ar->cmwrr_state)
    {
    case PF_CMWRR_STATE_IDLE:
       p_result->pnio_status.error_code = PNET_ERROR_CODE_PNIO;

--- a/src/device/pf_cmwrr.h
+++ b/src/device/pf_cmwrr.h
@@ -24,7 +24,7 @@ extern "C" {
  * Initialize the CMWRR component.
  * @param net              InOut: The p-net stack instance
  */
-void pf_cmwrr_init (pnet_t * net);
+void pf_cmwrr_init (pnet_t * net, pf_ar_t * p_ar);
 
 /**
  * Show the CMWRR part of the specified AR.
@@ -44,7 +44,7 @@ void pf_cmwrr_show (const pnet_t * net, const pf_ar_t * p_ar);
  */
 int pf_cmwrr_cmdev_state_ind (
    pnet_t * net,
-   const pf_ar_t * p_ar,
+   pf_ar_t * p_ar,
    pnet_event_values_t event);
 
 /**

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -30,8 +30,6 @@ int pnet_init_only (pnet_t * net, const pnet_cfg_t * p_cfg)
    net->cmdev_initialized = false; /* TODO How to handle that pf_cmdev_exit()
                                       is used before pf_cmdev_init()? */
 
-   pf_cmsu_init (net);
-   pf_cmwrr_init (net);
    pf_cpm_init (net);
    pf_ppm_init (net);
    pf_alarm_init (net);

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2048,6 +2048,10 @@ typedef struct pf_ar
    uint8_t err_cls;
    uint8_t err_code;
 
+   pf_cmwrr_state_values_t cmwrr_state;
+
+   pf_cmsu_state_values_t cmsu_state;
+
    pf_cmsm_state_values_t cmsm_state;
    uint32_t cmsm_timer;
 
@@ -2806,8 +2810,6 @@ struct pnet
    int cmrpc_rpcreq_socket; /* Main socket for incoming requests */
    uint8_t cmrpc_dcerpc_input_frame[PF_FRAME_BUFFER_SIZE];
    uint8_t cmrpc_dcerpc_output_frame[PF_FRAME_BUFFER_SIZE];
-   pf_cmsu_state_values_t cmsu_state;
-   pf_cmwrr_state_values_t cmwrr_state;
    const pnet_cfg_t * p_fspm_default_cfg; /* Default configuration from user.
                                              Used at factory reset */
    pnet_cfg_t fspm_cfg; /* Configuration from user. Might be updated by stack


### PR DESCRIPTION
CMSU and CMWRR should be per AR instead of per device.

Implement modulediff when another AR owns a submodule.

Verify that PPM data have been set for a submodule, regardless of owning AR.

The output data frame ID from the PLC should be unique per device, not per AR.

Adapt sample application to be able to handle multiple connections.

Future work is needed for same input subslot to be able to send data to multiple PLCs.

Closes #131
Closes #169
