### PR TITLE
Fix rt-kernel tests

### DIFF
--- a/src/ports/rt-kernel/pnal.c
+++ b/src/ports/rt-kernel/pnal.c
@@ -21,7 +21,6 @@
 
 #include <drivers/net.h>
 #include <drivers/eth/phy/phy.h>
-#include <gpio.h>
 #include <lwip/apps/snmp.h>
 #include <lwip/netif.h>
 #include <lwip/snmp.h>


### PR DESCRIPTION
Update cmake tools to fix problem building gtest. Remove unused header
from pnal.c to allow building pf_test for integrator BSP.