### PR TITLE
Clean up pf_block_writer.c

### DIFF
--- a/src/common/pf_snmp.c
+++ b/src/common/pf_snmp.c
@@ -29,6 +29,7 @@
 #define pf_file_save_if_modified     mock_pf_file_save_if_modified
 #define pf_fspm_get_im_location      mock_pf_fspm_get_im_location
 #define pf_fspm_save_im_location     mock_pf_fspm_save_im_location
+#define pnal_get_hostname            mock_pnal_get_hostname
 #endif
 
 #include "pf_includes.h"

--- a/src/device/pf_block_writer.h
+++ b/src/device/pf_block_writer.h
@@ -707,139 +707,190 @@ void pf_put_diag_data (
    uint16_t * p_pos);
 
 /**
- * Insert pd port data check block into a buffer.
+ * Insert PDport data check block into a buffer.
+ * @param is_big_endian    In:    Endianness of the destination buffer.
+ * @param slot             In:    Slot number
+ * @param subslot          In:    Subslot number
  * @param check_peer       In:    check_peer data. ToDo - add support for misc
  *                                port data checks
- * @param is_big_endian    In:    Endianness of the destination buffer.
- * @param p_res            In:    Read result
  * @param res_len          In:    Size of destination buffer.
  * @param p_bytes          Out:   Destination buffer.
  * @param p_pos            InOut: Position in destination buffer.
  */
 void pf_put_pdport_data_check (
-   const pf_check_peer_t * check_peer,
    bool is_big_endian,
-   const pf_iod_read_result_t * p_res,
+   uint16_t slot,
+   uint16_t subslot,
+   const pf_check_peer_t * check_peer,
    uint16_t res_len,
    uint8_t * p_bytes,
    uint16_t * p_pos);
 
 /**
- * Insert pd port data adjust block into a buffer.
- * @param p_peer_to_peer_boundary   In:    Peer to peer boundary ToDo - Add
- *                                         support for other adjust properties
- * @param subslot                   In:    DAP subslot identifying the port.
+ * Insert PDport data adjust block into a buffer.
+ *
+ * ToDo - Add support for other adjust properties
+ *
  * @param is_big_endian             In:    Endianness of the destination buffer.
- * @param p_res                     In:    Read result
+ * @param subslot                   In:    DAP subslot identifying the port.
+ * @param p_peer_to_peer_boundary   In:    Peer to peer boundary
  * @param res_len                   In:    Size of destination buffer.
  * @param p_bytes                   Out:   Destination buffer.
  * @param p_pos                     InOut: Position in destination buffer.
  */
 void pf_put_pdport_data_adj (
-   const pf_adjust_peer_to_peer_boundary_t * p_peer_to_peer_boundary,
-   uint16_t subslot,
    bool is_big_endian,
-   const pf_iod_read_result_t * p_res,
+   uint16_t subslot,
+   const pf_adjust_peer_to_peer_boundary_t * p_peer_to_peer_boundary,
    uint16_t res_len,
    uint8_t * p_bytes,
    uint16_t * p_pos);
 
 /**
  * Insert pd interface adjust block into a buffer.
+ *
+ * @param is_big_endian    In:    Endianness of the destination buffer.
+ * @param subslot          In:    DAP subslot identifying the interface
  * @param mode             In:    Multiple interface mode.
  *                                (name of device mode)
- * @param subslot          In:    DAP subslot identifying the interface
- * @param is_big_endian    In:    Endianness of the destination buffer.
- * @param p_res            In:    Read result
  * @param res_len          In:    Size of destination buffer.
  * @param p_bytes          Out:   Destination buffer.
  * @param p_pos            InOut: Position in destination buffer.
  */
 void pf_put_pd_interface_adj (
-   pf_lldp_name_of_device_mode_t name_of_device_mode,
-   uint16_t subslot,
    bool is_big_endian,
-   const pf_iod_read_result_t * p_res,
+   uint16_t subslot,
+   pf_lldp_name_of_device_mode_t name_of_device_mode,
    uint16_t res_len,
    uint8_t * p_bytes,
    uint16_t * p_pos);
 
 /**
- * Insert pd port real data block into a buffer.
+ * Insert PDport real data block into a buffer.
  *
  * Includes peer chassis ID, peer MAC address and peer MAU type.
  *
- * If the local port number is out of range this operation will assert.
- *
- * @param net              InOut: The p-net stack instance
- * @param loc_port_num     In:    Local port number.
- *                                Valid range: 1 .. num_physical_ports.
- * @param is_big_endian    In:    Endianness of the destination buffer.
- * @param p_res            In:    Read result
- * @param res_len          In:    Size of destination buffer.
- * @param p_bytes          Out:   Destination buffer.
- * @param p_pos            InOut: Position in destination buffer.
+ * @param is_big_endian       In:    Endianness of the destination buffer.
+ * @param subslot             In:    Subslot
+ * @param p_peer_station_name In:    Peer station name
+ * @param p_peer_port_name    In:    Peer port name
+ * @param p_port_data         In:    Port data
+ * @param media_type          In:    Media type
+ * @param p_eth_status        In:    Ethernet status
+ * @param res_len             In:    Size of destination buffer.
+ * @param p_bytes             Out:   Destination buffer.
+ * @param p_pos               InOut: Position in destination buffer.
  */
 void pf_put_pdport_data_real (
-   pnet_t * net,
-   int loc_port_num,
    bool is_big_endian,
-   const pf_iod_read_result_t * p_res,
+   uint16_t subslot,
+   const pf_lldp_station_name_t * p_peer_station_name,
+   const pf_lldp_port_name_t * p_peer_port_name,
+   const pf_port_t * p_port_data,
+   pf_mediatype_values_t media_type,
+   const pnal_eth_status_t * p_eth_status,
    uint16_t res_len,
    uint8_t * p_bytes,
    uint16_t * p_pos);
 
 /**
- * Insert pd port statistics block into a buffer.
- * @param p_port_stats     In:    Port statistics
+ * Insert PD port statistics block into a buffer.
+ *
  * @param is_big_endian    In:    Endianness of the destination buffer.
- * @param p_res            In:    Read result
+ * @param p_port_stats     In:    Port statistics
  * @param res_len          In:    Size of destination buffer.
  * @param p_bytes          Out:   Destination buffer.
  * @param p_pos            InOut: Position in destination buffer.
  */
-
 void pf_put_pdport_statistics (
-   const pnal_port_stats_t * p_port_stats,
    bool is_big_endian,
-   const pf_iod_read_result_t * p_res,
+   const pnal_port_stats_t * p_port_stats,
    uint16_t res_len,
    uint8_t * p_bytes,
    uint16_t * p_pos);
 
 /**
- * Insert dp interface real data block into a buffer.
+ * Insert PD interface real data block into a buffer.
  *
  * This includes chassis ID, MAC address, IP address, subnet and gateway.
  *
- * @param net              InOut: The p-net stack instance
  * @param is_big_endian    In:    Endianness of the destination buffer.
- * @param p_res            In:    Read result
+ * @param mac_address      In:    MAC address for DAP
+ * @param ip_address       In:    IP address
+ * @param netmask          In:    Netmask
+ * @param gateway          In:    Gateway address
+ * @param station_name     In:    Station name, terminated string, buffer
+ *                                size PNET_STATION_NAME_MAX_SIZE
  * @param res_len          In:    Size of destination buffer.
  * @param p_bytes          Out:   Destination buffer.
  * @param p_pos            InOut: Position in destination buffer.
  */
 void pf_put_pdinterface_data_real (
-   pnet_t * net,
    bool is_big_endian,
-   const pf_iod_read_result_t * p_res,
+   const pnet_ethaddr_t * mac_address,
+   pnal_ipaddr_t ip_address,
+   pnal_ipaddr_t netmask,
+   pnal_ipaddr_t gateway,
+   const char * station_name,
    uint16_t res_len,
    uint8_t * p_bytes,
    uint16_t * p_pos);
 
 /**
- * Insert dp real data block into a buffer.
- * @param net              InOut: The p-net stack instance
- * @param is_big_endian    In:    Endianness of the destination buffer.
- * @param p_res            In:    Read result
- * @param res_len          In:    Size of destination buffer.
- * @param p_bytes          Out:   Destination buffer.
- * @param p_pos            InOut: Position in destination buffer.
+ * Insert multiblock port and statistics for one port
+ *
+ * @param is_big_endian       In:    Endianness of the destination buffer.
+ * @param api                 In:    API number
+ * @param subslot             In:    DAP subslot for port
+ * @param p_peer_station_name In:    Peer station name
+ * @param p_peer_port_name    In:    Peer port name
+ * @param p_port_data         In:    Port data
+ * @param media_type          In:    Media type
+ * @param p_eth_status        In:    Ethernet status
+ * @param p_port_statistics   In:    Port statistics
+ * @param res_len             In:    Size of destination buffer.
+ * @param p_bytes             Out:   Destination buffer.
+ * @param p_pos               InOut: Position in destination buffer.
  */
-void pf_put_pd_real_data (
-   pnet_t * net,
+void pf_put_pd_multiblock_port_and_statistics (
    bool is_big_endian,
-   const pf_iod_read_result_t * p_res,
+   uint32_t api,
+   uint16_t subslot,
+   const pf_lldp_station_name_t * p_peer_station_name,
+   const pf_lldp_port_name_t * p_peer_port_name,
+   const pf_port_t * p_port_data,
+   pf_mediatype_values_t media_type,
+   const pnal_eth_status_t * p_eth_status,
+   const pnal_port_stats_t * p_port_statistics,
+   uint16_t res_len,
+   uint8_t * p_bytes,
+   uint16_t * p_pos);
+
+/**
+ * Insert multiblock interface and statistics
+ *
+ * @param is_big_endian     In:    Endianness of the destination buffer.
+ * @param api               In:    API number
+ * @param mac_address       In:    MAC address
+ * @param ip_address        In:    IP address
+ * @param netmask           In:    Netmask
+ * @param gateway           In:    Gateway address
+ * @param station_name      In:    Station name, terminated string, buffer
+ *                                 size PNET_STATION_NAME_MAX_SIZE
+ * @param p_port_statistics In:    Port statistics
+ * @param res_len           In:    Size of destination buffer.
+ * @param p_bytes           Out:   Destination buffer.
+ * @param p_pos             InOut: Position in destination buffer.
+ */
+void pf_put_pd_multiblock_interface_and_statistics (
+   bool is_big_endian,
+   uint32_t api,
+   const pnet_ethaddr_t * mac_address,
+   pnal_ipaddr_t ip_address,
+   pnal_ipaddr_t netmask,
+   pnal_ipaddr_t gateway,
+   const char * station_name,
+   const pnal_port_stats_t * p_port_statistics,
    uint16_t res_len,
    uint8_t * p_bytes,
    uint16_t * p_pos);

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -31,7 +31,8 @@
  */
 
 #ifdef UNIT_TEST
-#define pnal_set_ip_suite mock_pnal_set_ip_suite
+#define pnal_get_port_statistics mock_pnal_get_port_statistics
+#define pnal_set_ip_suite        mock_pnal_set_ip_suite
 #endif
 
 #include <string.h>

--- a/src/device/pf_cmrdr.c
+++ b/src/device/pf_cmrdr.c
@@ -57,6 +57,7 @@ int pf_cmrdr_rm_read_ind (
    uint8_t iops_len = 0;
    uint16_t data_len = 0;
    bool new_flag = false;
+   char station_name[PNET_STATION_NAME_MAX_SIZE]; /* Terminated*/
 
    if (
       (p_read_request->slot_number == PNET_SLOT_DAP_IDENT) &&
@@ -862,10 +863,15 @@ int pf_cmrdr_rm_read_ind (
             (p_read_request->subslot_number ==
              PNET_SUBSLOT_DAP_INTERFACE_1_IDENT))
          {
+            pf_cmina_get_station_name (net, station_name);
+
             pf_put_pdinterface_data_real (
-               net,
                true,
-               &read_result,
+               pf_cmina_get_device_macaddr (net),
+               pf_cmina_get_ipaddr (net),
+               pf_cmina_get_netmask (net),
+               pf_cmina_get_gateway (net),
+               station_name,
                res_size,
                p_res,
                p_pos);

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -13,6 +13,11 @@
  * full license information.
  ********************************************************************/
 
+#ifdef UNIT_TEST
+#define pnal_eth_get_status      mock_pnal_eth_get_status
+#define pnal_get_port_statistics mock_pnal_get_port_statistics
+#endif
+
 #include "pf_includes.h"
 #include "pf_block_writer.h"
 #include "pf_block_reader.h"
@@ -409,12 +414,17 @@ int pf_pdport_read_ind (
    int ret = -1;
    int loc_port_num;
    pf_port_iterator_t port_iterator;
-   pnal_port_stats_t port_stats;
+   pnal_port_stats_t port_statistics;
    pf_port_t * p_port_data;
    uint16_t slot = p_read_req->slot_number;
    uint16_t subslot = p_read_req->subslot_number;
    uint16_t index = p_read_req->index;
    const char * netif_name;
+   pf_lldp_station_name_t peer_station_name;
+   pf_lldp_port_name_t peer_port_name;
+   pnal_eth_status_t eth_status;
+   char station_name[PNET_STATION_NAME_MAX_SIZE]; /* Terminated*/
+   uint16_t subslot_for_port;
 
    switch (index)
    {
@@ -424,11 +434,28 @@ int pf_pdport_read_ind (
          (pf_port_subslot_is_dap_port_id (net, subslot)))
       {
          loc_port_num = pf_port_dap_subslot_to_local_port (net, subslot);
-         pf_put_pdport_data_real (
+
+         p_port_data = pf_port_get_state (net, loc_port_num);
+         if (pnal_eth_get_status (p_port_data->netif.name, &eth_status) != 0)
+         {
+            memset (&eth_status, 0, sizeof (eth_status));
+         }
+
+         /* Look up peer info. Subfields .len indicates whether peer is found */
+         (void)pf_lldp_get_peer_station_name (
             net,
             loc_port_num,
+            &peer_station_name);
+         (void)pf_lldp_get_peer_port_name (net, loc_port_num, &peer_port_name);
+
+         pf_put_pdport_data_real (
             true,
-            p_read_res,
+            subslot,
+            &peer_station_name,
+            &peer_port_name,
+            p_port_data,
+            pf_port_get_media_type (eth_status.operational_mau_type),
+            &eth_status,
             res_size,
             p_res,
             p_pos);
@@ -446,10 +473,9 @@ int pf_pdport_read_ind (
          if (p_port_data->pdport.adjust.active)
          {
             pf_put_pdport_data_adj (
-               &p_port_data->pdport.adjust.peer_to_peer_boundary,
-               subslot,
                true,
-               p_read_res,
+               subslot,
+               &p_port_data->pdport.adjust.peer_to_peer_boundary,
                res_size,
                p_res,
                p_pos);
@@ -468,9 +494,10 @@ int pf_pdport_read_ind (
             if (p_port_data->pdport.check.active)
             {
                pf_put_pdport_data_check (
-                  &p_port_data->pdport.check.peer,
                   true,
-                  p_read_res,
+                  p_read_res->slot_number,
+                  p_read_res->subslot_number,
+                  &p_port_data->pdport.check.peer,
                   res_size,
                   p_res,
                   p_pos);
@@ -487,9 +514,10 @@ int pf_pdport_read_ind (
                if (p_port_data->pdport.check.active)
                {
                   pf_put_pdport_data_check (
-                     &p_port_data->pdport.check.peer,
                      true,
-                     p_read_res,
+                     p_read_res->slot_number,
+                     p_read_res->subslot_number,
+                     &p_port_data->pdport.check.peer,
                      res_size,
                      p_res,
                      p_pos);
@@ -507,7 +535,74 @@ int pf_pdport_read_ind (
          ((subslot == PNET_SUBSLOT_DAP_WHOLE_MODULE) ||
           (subslot == PNET_SUBSLOT_DAP_IDENT)))
       {
-         pf_put_pd_real_data (net, true, p_read_res, res_size, p_res, p_pos);
+         pf_cmina_get_station_name (net, station_name);
+         if (
+            pnal_get_port_statistics (
+               net->pf_interface.main_port.name,
+               &port_statistics) != 0)
+         {
+            memset (&port_statistics, 0, sizeof (port_statistics));
+         }
+
+         pf_put_pd_multiblock_interface_and_statistics (
+            true,
+            p_read_res->api,
+            pf_cmina_get_device_macaddr (net),
+            pf_cmina_get_ipaddr (net),
+            pf_cmina_get_netmask (net),
+            pf_cmina_get_gateway (net),
+            station_name,
+            &port_statistics,
+            res_size,
+            p_res,
+            p_pos);
+
+         pf_port_init_iterator_over_ports (net, &port_iterator);
+         loc_port_num = pf_port_get_next (&port_iterator);
+         while (loc_port_num != 0)
+         {
+            subslot_for_port =
+               pf_port_loc_port_num_to_dap_subslot (net, loc_port_num);
+            p_port_data = pf_port_get_state (net, loc_port_num);
+
+            if (pnal_eth_get_status (p_port_data->netif.name, &eth_status) != 0)
+            {
+               memset (&eth_status, 0, sizeof (eth_status));
+            }
+            if (
+               pnal_get_port_statistics (
+                  p_port_data->netif.name,
+                  &port_statistics) != 0)
+            {
+               memset (&port_statistics, 0, sizeof (port_statistics));
+            }
+
+            /* Look up peer info. Subfields .len indicates whether peer is found
+             */
+            (void)pf_lldp_get_peer_station_name (
+               net,
+               loc_port_num,
+               &peer_station_name);
+            (void)
+               pf_lldp_get_peer_port_name (net, loc_port_num, &peer_port_name);
+
+            pf_put_pd_multiblock_port_and_statistics (
+               true,
+               p_read_res->api,
+               subslot_for_port,
+               &peer_station_name,
+               &peer_port_name,
+               p_port_data,
+               pf_port_get_media_type (eth_status.operational_mau_type),
+               &eth_status,
+               &port_statistics,
+               res_size,
+               p_res,
+               p_pos);
+
+            loc_port_num = pf_port_get_next (&port_iterator);
+         }
+
          ret = 0;
       }
       break;
@@ -551,12 +646,11 @@ int pf_pdport_read_ind (
             netif_name = p_port_data->netif.name;
          }
 
-         if (pnal_get_port_statistics (netif_name, &port_stats) == 0)
+         if (pnal_get_port_statistics (netif_name, &port_statistics) == 0)
          {
             pf_put_pdport_statistics (
-               &port_stats,
                true,
-               p_read_res,
+               &port_statistics,
                res_size,
                p_res,
                p_pos);
@@ -573,10 +667,9 @@ int pf_pdport_read_ind (
          if (net->pf_interface.name_of_device_mode.active == true)
          {
             pf_put_pd_interface_adj (
-               net->pf_interface.name_of_device_mode.mode,
-               PNET_SUBSLOT_DAP_INTERFACE_1_IDENT,
                true,
-               p_read_res,
+               PNET_SUBSLOT_DAP_INTERFACE_1_IDENT,
+               net->pf_interface.name_of_device_mode.mode,
                res_size,
                p_res,
                p_pos);

--- a/src/ports/rt-kernel/pnal_config.h
+++ b/src/ports/rt-kernel/pnal_config.h
@@ -30,6 +30,9 @@ extern "C" {
 
 typedef struct pnal_cfg
 {
+   /* This is not used for rt-kernel, however an empty struct is
+      undefined behaviour in C and has a size of 1 byte in C++. */
+   char dummy;
 } pnal_cfg_t;
 
 #ifdef __cplusplus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,7 @@ target_sources(pf_test PRIVATE
   ${PROFINET_SOURCE_DIR}/src/device/pf_cmsm.c
   ${PROFINET_SOURCE_DIR}/src/device/pf_cmsu.c
   ${PROFINET_SOURCE_DIR}/src/device/pf_cmwrr.c
+  ${PROFINET_SOURCE_DIR}/src/device/pf_pdport.c
   ${PROFINET_SOURCE_DIR}/src/device/pnet_api.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_alarm.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_cpm.c

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -90,6 +90,24 @@ int mock_pnal_eth_get_status (
    return 0;
 }
 
+int mock_pnal_get_port_statistics (
+   const char * interface_name,
+   pnal_port_stats_t * port_stats)
+{
+   /* TODO get loc_port_num from interface_name */
+   *port_stats = mock_os_data.port_statistics[1];
+
+   return 0;
+}
+
+int mock_pnal_get_hostname (char * hostname)
+{
+   hostname[0] = 'A';
+   hostname[1] = '\0';
+
+   return 0;
+}
+
 int mock_pnal_get_ip_suite (
    const char * interface_name,
    pnal_ipaddr_t * p_ipaddr,

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -38,6 +38,7 @@ typedef struct mock_os_data_obj
     * dummy array element at index 0.
     */
    pnal_eth_status_t eth_status[PNET_MAX_PHYSICAL_PORTS + 1];
+   pnal_port_stats_t port_statistics[PNET_MAX_PHYSICAL_PORTS + 1];
 
    uint16_t udp_sendto_len;
    uint16_t udp_sendto_count;
@@ -109,6 +110,10 @@ int mock_pnal_get_macaddress (
 int mock_pnal_eth_get_status (
    const char * interface_name,
    pnal_eth_status_t * status);
+int mock_pnal_get_port_statistics (
+   const char * interface_name,
+   pnal_port_stats_t * port_stats);
+int mock_pnal_get_hostname (char * hostname);
 void mock_os_cpy_mac_addr (uint8_t * mac_addr);
 int mock_pnal_udp_open (pnal_ipaddr_t addr, pnal_ipport_t port);
 int mock_pnal_udp_sendto (


### PR DESCRIPTION
Mock more pnal_xxx functions

Homogenize function prototypes

Make sure that the writer functions are cleaner, and accepting just whe data that should be written.
    
Avoid calls to other files from the block writer functions.
