### PR TITLE
Reintroduce delayed transmission of application ready

### DIFF
--- a/sample_app/sampleapp_common.h
+++ b/sample_app/sampleapp_common.h
@@ -36,6 +36,7 @@ extern "C" {
 
 #define APP_DATA_LED_ID            1
 #define APP_PROFINET_SIGNAL_LED_ID 2
+#define APP_EVENT_READY_FOR_DATA   BIT (0)
 #define APP_EVENT_TIMER            BIT (1)
 #define APP_EVENT_ALARM            BIT (2)
 #define APP_EVENT_ABORT            BIT (15)
@@ -244,6 +245,7 @@ typedef struct app_data_obj
    uint32_t app_param_1;
    uint32_t app_param_2;
    uint8_t inputdata[APP_DATASIZE_INPUT];
+   uint32_t arep_for_appl_ready;
 } app_data_t;
 
 typedef struct app_data_and_stack_obj

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -1461,6 +1461,14 @@ int pf_cmdev_state_ind (pnet_t * net, pf_ar_t * p_ar, pnet_event_values_t state)
 {
    if (p_ar != NULL)
    {
+      /* If we move pf_fspm_state_ind(), which triggers a user callback, last in
+         this list then it would be possible for users to invoke
+         pnet_application_ready() directly in the callback and not to use
+         some delay mechanism.
+
+         However then the users could not use pnet_get_ar_error_codes() at
+         ABORT, as the AR would already be gone when the callback is triggered.
+       */
       pf_fspm_state_ind (net, p_ar, state);
       pf_cmsu_cmdev_state_ind (net, p_ar, state);
       pf_cmio_cmdev_state_ind (net, p_ar, state);


### PR DESCRIPTION
Commit 9857aba made each AR have its own CMSU and CMWRR instance, and thus allow
multiple simultaneous connections. To support that the sample app needs to be able
to call pnet_application_ready() for each connection. A (premature) simplification
was made by calling the pnet_application_ready() already in the user callback
for state change, instead of doing a delayed transmission. It did work fine
when testing with connections.

It was later noticed however that it was not possible to do any write after the
connection had been established (normally writes are done during connection setup),
as the CMWRR was left in wrong state.

Reintroduce the delayed transmission of application_ready to solve the problem.

From an end-user point of view it would be nice to be able to call
pnet_application_ready() already from the callback (without using any delay mechanism).
It proved possible to do that by changing the order of how things are done in
the pf_cmdev_state_ind() function. If triggering the user callback last when a state
change occurs, it would be possible as the stack has been properly updated to the
new state. The drawback would instead be that at ABORT conditions, the AR
would already be gone when the user callback is triggered.
Then no error information on what caused the ABORT is available.

One future alternative could be to add an additional argument to the user callback
with error information, instead of asking the AR for error information.