### PR TITLE
Close EPM session after each request

### DIFF
--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -4361,6 +4361,11 @@ static int pf_cmrpc_dce_packet (
                   p_sess->out_buffer,
                   &p_sess->out_buf_len);
                *p_is_release = true;
+
+               /* Close session after each EPM request
+                  If future more advanced EPM usage is required, implement a
+                  timeout for closing the session */
+               p_sess->kill_session = true;
             }
             else
             {


### PR DESCRIPTION
TIA portal uses EPM requests for identifying devices on the network.

Previously the sessions were not closed, resulting in "Out of session resources"
when a number of requests have been done.

Profinet uses EPM in a limited way. If we for some reason we need more advanced
EPM handling in the future, implement a timeout for each EPM session.

Closes #396