### PR TITLE
Trigger peer-not-detected diagnosis immediately at startup

### DIFF
--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -1036,9 +1036,7 @@ typedef struct pf_alarm_receive_queue
 #define PF_CMINA_FS_HELLO_INTERVAL                                             \
    (3 * 1000)                            /* milliseconds. Default is 30 ms */
 #define PF_LLDP_SEND_INTERVAL (5 * 1000) /* milliseconds */
-#define PF_LLDP_INITIAL_PEER_TIMEOUT                                           \
-   ((2 * PF_LLDP_SEND_INTERVAL) / 1000) /* seconds */
-#define PF_LLDP_TTL 20                  /* seconds */
+#define PF_LLDP_TTL           20         /* seconds */
 
 typedef enum pf_cmina_state_values
 {


### PR DESCRIPTION
If we should verify that a peer is connected, the no-peer-detected
diagnosis should be set already at startup. If the peer shows up,
the diagnosis is removed.

The previous method of setting the diagnosis after some arbitrary time
was prone to intermittent problems, as the boot time varies a lot
on Linux (for example if file system repairs are done at startup).
Dependent on the arbitrary time had timed out or not at the
diagnosis question from the ART Tester, different results appeared.

Found with the test case "Pdev_Check_onePort".