### PR TITLE
No support for device-access AR

### DIFF
--- a/sample_app/GSDML-V2.4-RT-Labs-P-Net-Sample-App-20210415.xml
+++ b/sample_app/GSDML-V2.4-RT-Labs-P-Net-Sample-App-20210415.xml
@@ -23,7 +23,7 @@
       </DeviceFunction>
       <ApplicationProcess>
          <DeviceAccessPointList>
-            <DeviceAccessPointItem ID="IDD_1" PNIO_Version="V2.4" PhysicalSlots="0..4" ModuleIdentNumber="0x00000001" MinDeviceInterval="32" DNS_CompatibleName="rt-labs-dev" FixedInSlots="0" ObjectUUID_LocalIndex="1" DeviceAccessSupported="true" NumberOfDeviceAccessAR="1" MultipleWriteSupported="true" CheckDeviceID_Allowed="true" NameOfStationNotTransferable="false" LLDP_NoD_Supported="true" ResetToFactoryModes="1..2">
+            <DeviceAccessPointItem ID="IDD_1" PNIO_Version="V2.4" PhysicalSlots="0..4" ModuleIdentNumber="0x00000001" MinDeviceInterval="32" DNS_CompatibleName="rt-labs-dev" FixedInSlots="0" ObjectUUID_LocalIndex="1" DeviceAccessSupported="false"  MultipleWriteSupported="true" CheckDeviceID_Allowed="true" NameOfStationNotTransferable="false" LLDP_NoD_Supported="true" ResetToFactoryModes="1..2">
                <ModuleInfo>
                   <Name TextId="IDT_MODULE_NAME_DAP1"/>
                   <InfoText TextId="IDT_INFO_DAP1"/>

--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -1702,7 +1702,6 @@ int pf_cmdev_check_visible_string (const char * s)
  * @internal
  * Check if the Specified AR type is supported.
  *
- * ToDo: Currently only IOCAR_SINGLE and PF_ART_IOSAR is supported.
  * @param ar_type          In:    The AR type to check.
  * @return  0  if the AR type is supported.
  *          -1 if the AR type is not supported.
@@ -1711,7 +1710,7 @@ int pf_cmdev_check_ar_type (uint16_t ar_type)
 {
    int ret = -1;
 
-   if ((ar_type == PF_ART_IOCAR_SINGLE) || (ar_type == PF_ART_IOSAR))
+   if (ar_type == PF_ART_IOCAR_SINGLE)
    {
       ret = 0;
    }

--- a/test/test_cmdev.cpp
+++ b/test/test_cmdev.cpp
@@ -393,7 +393,7 @@ TEST_F (CmdevUnitTest, CmdevCheckArType)
    {
       ret = pf_cmdev_check_ar_type (ar_type);
 
-      if (ar_type == PF_ART_IOCAR_SINGLE || ar_type == PF_ART_IOSAR)
+      if (ar_type == PF_ART_IOCAR_SINGLE)
       {
          EXPECT_EQ (0, ret);
       }

--- a/test/test_cmrpc.cpp
+++ b/test/test_cmrpc.cpp
@@ -651,22 +651,23 @@ TEST_F (CmrpcTest, CmrpcConnectFragmentTest)
 
 TEST_F (CmrpcTest, CmrpcConnectReleaseIOSAR_DA)
 {
+   // Device-access AR is not yet supported
    TEST_TRACE ("\nGenerating mock connection request IOSAR_DA\n");
    mock_set_pnal_udp_recvfrom_buffer (
       connect_req_iosar_da,
       sizeof (connect_req_iosar_da));
    run_stack (TEST_UDP_DELAY);
-   EXPECT_EQ (appdata.call_counters.state_calls, 1);
-   EXPECT_EQ (appdata.cmdev_state, PNET_EVENT_STARTUP);
-   EXPECT_EQ (appdata.call_counters.connect_calls, 1);
-   EXPECT_EQ (mock_os_data.eth_send_count, PNET_MAX_PHYSICAL_PORTS);
+   EXPECT_EQ (appdata.call_counters.state_calls, 0);
+   EXPECT_EQ (appdata.cmdev_state, PNET_EVENT_ABORT);
+   EXPECT_EQ (appdata.call_counters.connect_calls, 0);
+   EXPECT_EQ (mock_os_data.eth_send_count, 0);
 
    TEST_TRACE ("\nGenerating mock release request IOSAR_DA\n");
    mock_set_pnal_udp_recvfrom_buffer (
       release_req_iosar_da,
       sizeof (release_req_iosar_da));
    run_stack (TEST_UDP_DELAY);
-   EXPECT_EQ (appdata.call_counters.state_calls, 2);
+   EXPECT_EQ (appdata.call_counters.state_calls, 0);
    EXPECT_EQ (appdata.call_counters.release_calls, 0);
    EXPECT_EQ (appdata.cmdev_state, PNET_EVENT_ABORT);
 }


### PR DESCRIPTION
Device-access AR is a limited version of connection as a supervisor can do.
We do not support that.

Update GSDML file to reflect that we support only one concurrent (standard) AR.

In order to support more than one AR in the future, we need to implement
ownership control of different modules in slots.

Found with ART Tester, test case "AR-ASE"