### PR TITLE
Keep UDP socket open at session release

### DIFF
--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -4884,11 +4884,8 @@ void pf_cmrpc_periodic (pnet_t * net)
       {
          LOG_DEBUG (
             PF_RPC_LOG,
-            "CMRPC(%d): Closing and reopening socket used for incoming DCE RPC "
-            "requests.\n",
+            "CMRPC(%d): Release is requested by incoming DCE RPC request.\n",
             __LINE__);
-         pf_udp_close (net, net->cmrpc_rpcreq_socket);
-         net->cmrpc_rpcreq_socket = pf_udp_open (net, PF_RPC_SERVER_PORT);
       }
    }
 }
@@ -4955,15 +4952,6 @@ int pf_cmrpc_cmdev_state_ind (
             if (p_ar->p_sess->release_in_progress == false)
             {
                pf_session_release (net, p_ar->p_sess);
-
-               /* Re-open the global RPC socket. */
-               LOG_DEBUG (
-                  PF_RPC_LOG,
-                  "CMRPC(%d): Closing and reopening socket used for incoming "
-                  "DCE RPC requests.\n",
-                  __LINE__);
-               pf_udp_close (net, net->cmrpc_rpcreq_socket);
-               net->cmrpc_rpcreq_socket = pf_udp_open (net, PF_RPC_SERVER_PORT);
             }
          }
          else


### PR DESCRIPTION
 We are missing incoming UDP packets when closing and reopening the UDP socket.
 This was found with the ART Tester, test case Alarm.
 
 The bug is time sensitive, and is triggered when running XMC4800 with debug logging over serial cable at 460800 bit/s.
