### PR TITLE
Increase default number of alarms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,8 @@ set(PNET_MAX_PHYSICAL_PORTS          1
   CACHE STRING "Max number of physical ports")
 set(PNET_MAX_LOG_BOOK_ENTRIES   16
   CACHE STRING "")
-set(PNET_MAX_ALARMS             3
-  CACHE STRING "Per AR and queue. One queue for high and one for low priority alarms. 'Automated RT Tester' uses 2.")
+set(PNET_MAX_ALARMS             6
+  CACHE STRING "Per AR and queue. One queue for high and one for low priority alarms. 'Automated RT Tester' uses 6.")
 set(PNET_MAX_ALARM_PAYLOAD_DATA_SIZE 28
   CACHE STRING "Min 24 or PNET_MAX_DIAG_MANUF_DATA_SIZE + 12. Max is 1408")
 set(PNET_MAX_DIAG_ITEMS         200


### PR DESCRIPTION
In the ART Tester test case "APMS" a burst of 6 alarm frames is sent to the device.
Adapt the default compile time settings so all these incoming frames will fit in the
alarm input queue.
