### PR TITLE
Change name of a FSPM function

### DIFF
--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -3267,7 +3267,7 @@ static int pf_cmdev_check_iocr_param (
            (p_iocr->send_clock_factor > 64)) ||
           ((p_iocr->reduction_ratio == 512) &&
            (p_iocr->send_clock_factor > 32)) ||
-          (pf_cmina_get_min_device_interval (net) >
+          (pf_fspm_get_min_device_interval (net) >
            p_iocr->send_clock_factor * p_iocr->reduction_ratio)))
       {
          pf_set_error (

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -564,7 +564,7 @@ void pf_fspm_get_default_cfg (pnet_t * net, const pnet_cfg_t ** pp_cfg)
    }
 }
 
-int16_t pf_cmina_get_min_device_interval (const pnet_t * net)
+int16_t pf_fspm_get_min_device_interval (const pnet_t * net)
 {
    return net->fspm_cfg.min_device_interval;
 }

--- a/src/device/pf_fspm.h
+++ b/src/device/pf_fspm.h
@@ -49,7 +49,7 @@ int pf_fspm_init (pnet_t * net, const pnet_cfg_t * p_cfg);
  * @param net              InOut: The p-net stack instance
  * @return the minimum device interval.
  */
-int16_t pf_cmina_get_min_device_interval (const pnet_t * net);
+int16_t pf_fspm_get_min_device_interval (const pnet_t * net);
 
 /**
  * Create a LogBook entry.


### PR DESCRIPTION
The function `pf_cmina_get_min_device_interval()` is located in `pf_fspm.c` so
it should be named `pf_fspm_get_min_device_interval()`