### PR TITLE
Check number of incoming IOCR blocks

### DIFF
--- a/options.h.in
+++ b/options.h.in
@@ -88,8 +88,8 @@
  * These values directly affect the memory usage of the
  * implementation. Sometimes in complicated ways.
  *
- * Please note that some defines have minimum requirements. These
- * values are used as is by the stack. No validation is performed.
+ * Please note that some defines have minimum requirements.
+ * Only a few of the defines are validated.
  */
 
 #if !defined (PNET_MAX_AR)

--- a/src/device/pf_diag.c
+++ b/src/device/pf_diag.c
@@ -47,6 +47,10 @@
 #include "pf_block_reader.h"
 #include "pf_block_writer.h"
 
+#if PNET_MAX_DIAG_ITEMS > 65534
+#error "PNET_MAX_DIAG_ITEMS is too large"
+#endif
+
 int pf_diag_init (void)
 {
    return 0;

--- a/src/device/pf_port.c
+++ b/src/device/pf_port.c
@@ -21,6 +21,10 @@
 #error "PNET_MAX_PHYSICAL_PORTS needs to be at least 1"
 #endif
 
+#if PNET_MAX_SLOTS < 1
+#error "At least one slot must be available for DAP. Increase PNET_MAX_SLOTS."
+#endif
+
 #if PNET_MAX_SUBSLOTS < (2 + PNET_MAX_PHYSICAL_PORTS)
 #error                                                                         \
    "DAP requires 2 + PNET_MAX_PHYSICAL_PORTS subslots. Increase PNET_MAX_SUBSLOTS."

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -24,6 +24,14 @@
 #include "pf_includes.h"
 #include "pf_block_reader.h"
 
+#if PNET_MAX_AR < 1
+#error "PNET_MAX_AR needs to be at least 1"
+#endif
+
+#if PNET_MAX_API < 1
+#error "PNET_MAX_API needs to be at least 1"
+#endif
+
 int pnet_init_only (pnet_t * net, const pnet_cfg_t * p_cfg)
 {
    memset (net, 0, sizeof (*net));


### PR DESCRIPTION
The max number of CR information block we can store is PNET_MAX_CR.
Make sure we do not exceed this.
    
Also do some rudimentary validation of some of the compile time settings.


NOTE: Use the setting "Hide whitespace changes" while reviewing.