### PR TITLE
Add log message if cycle time is violated

### DIFF
--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -1274,6 +1274,15 @@ int pf_cmina_remove_all_data_files (const char * file_directory)
    return 0;
 }
 
+bool pf_cmina_has_timed_out (
+   uint32_t now_us,
+   uint32_t previous_us,
+   uint16_t period,
+   uint16_t factor)
+{
+   return (now_us - previous_us) >= ((uint32_t) (period * factor) * 1000 / 32);
+}
+
 /*************** Diagnostic strings *****************************************/
 
 void pf_cmina_ip_to_string (pnal_ipaddr_t ip, char * outputstring)

--- a/src/device/pf_cmina.h
+++ b/src/device/pf_cmina.h
@@ -192,6 +192,27 @@ int pf_cmina_dcp_get_req (
    uint8_t ** pp_value,
    uint8_t * p_block_error);
 
+/**
+ * Check if a time interval has passed
+ *
+ * @param now_us           In:    Interval end in microseconds
+ * @param previous_us      In:    Interval start in microseconds
+ * @param period           In:    Time interval length in 1/32 of millisecond.
+ *                                For 1 millisecond use 32
+ *                                    2 milliseconds use 64 etc
+ * @param factor           In:    Multiplication factor for the timeout.
+ *                                Use 1 if the given time interval length should
+ *                                be used, or 3 if we should return true after
+ *                                3 time interval lengths etc
+ * @return  true if the measured time interval is longer than period*factor
+ *          false if it not has passed
+ */
+bool pf_cmina_has_timed_out (
+   uint32_t now_us,
+   uint32_t previous_us,
+   uint16_t period,
+   uint16_t factor);
+
 /************ Internal functions, made available for unit testing ************/
 
 bool pf_cmina_is_stationname_valid (const char * station_name, uint16_t len);

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -32,6 +32,8 @@
 #error "PNET_MAX_API needs to be at least 1"
 #endif
 
+#define PNET_PERIODIC_WARNING_FACTOR 3
+
 int pnet_init_only (pnet_t * net, const pnet_cfg_t * p_cfg)
 {
    memset (net, 0, sizeof (*net));
@@ -51,7 +53,10 @@ int pnet_init_only (pnet_t * net, const pnet_cfg_t * p_cfg)
 
    if (pf_eth_init (net, p_cfg) != 0)
    {
-      LOG_ERROR (PNET_LOG, "Failed to initialise network interfaces\n");
+      LOG_ERROR (
+         PNET_LOG,
+         "API(%d): Failed to initialise network interfaces\n",
+         __LINE__);
       return -1;
    }
 
@@ -70,7 +75,7 @@ int pnet_init_only (pnet_t * net, const pnet_cfg_t * p_cfg)
    pf_snmp_data_init (net);
    if (pnal_snmp_init (net, &p_cfg->pnal_cfg) != 0)
    {
-      LOG_ERROR (PNET_LOG, "Failed to configure SNMP\n");
+      LOG_ERROR (PNET_LOG, "API(%d): Failed to configure SNMP\n", __LINE__);
       return -1;
    }
 #endif
@@ -79,6 +84,8 @@ int pnet_init_only (pnet_t * net, const pnet_cfg_t * p_cfg)
    pf_cmdev_init (net);
 
    pf_cmrpc_init (net);
+
+   net->timestamp_handle_periodic_us = os_get_current_time_us();
 
    return 0;
 }
@@ -94,7 +101,8 @@ pnet_t * pnet_init (const pnet_cfg_t * p_cfg)
    {
       LOG_ERROR (
          PNET_LOG,
-         "Failed to allocate memory for pnet_t (%zu bytes)\n",
+         "API(%d): Failed to allocate memory for pnet_t (%zu bytes)\n",
+         __LINE__,
          sizeof (*net));
       return NULL;
    }
@@ -110,6 +118,25 @@ pnet_t * pnet_init (const pnet_cfg_t * p_cfg)
 
 void pnet_handle_periodic (pnet_t * net)
 {
+#if LOG_DEBUG_ENABLED(PNET_LOG)
+   uint32_t start_time_us = os_get_current_time_us();
+   uint32_t end_time_us = 0;
+
+   if (pf_cmina_has_timed_out (
+          start_time_us,
+          net->timestamp_handle_periodic_us,
+          net->fspm_cfg.min_device_interval,
+          PNET_PERIODIC_WARNING_FACTOR))
+   {
+      LOG_DEBUG (
+         PNET_LOG,
+         "API(%d): Too long since pnet_handle_periodic() was called: %u "
+         "microseconds\n",
+         __LINE__,
+         start_time_us - net->timestamp_handle_periodic_us);
+   }
+#endif
+
    pf_cmrpc_periodic (net);
    pf_alarm_periodic (net);
 
@@ -117,6 +144,23 @@ void pnet_handle_periodic (pnet_t * net)
    pf_scheduler_tick (net);
 
    pf_pdport_periodic (net);
+
+#if LOG_DEBUG_ENABLED(PNET_LOG)
+   end_time_us = os_get_current_time_us();
+   if (pf_cmina_has_timed_out (
+          end_time_us,
+          start_time_us,
+          net->fspm_cfg.min_device_interval,
+          1))
+   {
+      LOG_DEBUG (
+         PNET_LOG,
+         "API(%d): pnet_handle_periodic() took too long: %u microseconds\n",
+         __LINE__,
+         end_time_us - start_time_us);
+   }
+   net->timestamp_handle_periodic_us = end_time_us;
+#endif
 }
 
 void pnet_show (pnet_t * net, unsigned level)

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -2639,6 +2639,9 @@ struct pnet
    pf_log_book_t fspm_log_book;
    os_mutex_t * fspm_log_book_mutex;
 
+   /* Last time pnet_handle_periodic() was invoked */
+   uint32_t timestamp_handle_periodic_us;
+
    /* Mutex for protecting access to writable I&M data.
     *
     * Note I&M may be both read and written by SNMP, which executes from


### PR DESCRIPTION
This is a debug feature, so we use the DEBUG log level right now.
We can easily adjust the log level to maybe WARNING later on if we find it useful for end users.
