### PR TITLE
Fix USE_SCHED_FIFO option

### DIFF
--- a/cmake/Linux.cmake
+++ b/cmake/Linux.cmake
@@ -13,14 +13,6 @@
 # full license information.
 #*******************************************************************/
 
-option (USE_SCHED_FIFO
-  "Use SCHED_FIFO policy. May require extra privileges to run"
-  OFF)
-
-if (USE_SCHED_FIFO)
-  add_compile_definitions(USE_SCHED_FIFO)
-endif()
-
 if (PNET_OPTION_SNMP)
   find_package(NetSNMP REQUIRED)
   find_package(NetSNMPAgent REQUIRED)


### PR DESCRIPTION
USE_SCHED_FIFO was not propagated to the OSAL subproject as
intended. Bump cmake-tools for newer OSAL which sets USE_SCHED_FIFO
option locally. Remove local setting of USE_SCHED_FIFO option.