### PR TITLE
Fix assignment of data for led_state in sample application

### DIFF
--- a/sample_app/app_data.c
+++ b/sample_app/app_data.c
@@ -115,6 +115,7 @@ int app_data_set_output_data (
          submodule_id == APP_GSDML_SUBMOD_ID_DIGITAL_OUT ||
          submodule_id == APP_GSDML_SUBMOD_ID_DIGITAL_IN_OUT)
       {
+         memcpy (outputdata, data, size);
          led_state = (outputdata[0] & 0x80) > 0;
          app_handle_data_led_state (led_state);
          return 0;


### PR DESCRIPTION
Found with "PLC tests" in conformance testing