### PR TITLE
Add data length checks for all RT classes in IOCRBlockReq PDU

### DIFF
--- a/src/device/pf_cmdev.c
+++ b/src/device/pf_cmdev.c
@@ -3186,7 +3186,10 @@ static int pf_cmdev_check_iocr_param (
       else if (
          ((p_iocr->iocr_properties.rt_class == PF_RT_CLASS_UDP) &&
           ((p_iocr->c_sdu_length < 12) || (p_iocr->c_sdu_length > 1440))) ||
-         ((p_iocr->iocr_properties.rt_class == PF_RT_CLASS_1) &&
+         (((p_iocr->iocr_properties.rt_class == PF_RT_CLASS_1) ||
+           (p_iocr->iocr_properties.rt_class == PF_RT_CLASS_2) ||
+           (p_iocr->iocr_properties.rt_class == PF_RT_CLASS_3) ||
+           (p_iocr->iocr_properties.rt_class == PF_RT_CLASS_STREAM)) &&
           ((p_iocr->c_sdu_length < 40) || (p_iocr->c_sdu_length > 1440))))
       {
          pf_set_error (


### PR DESCRIPTION
There are missing data length checks for RT_Class = 0x02,0x03,0x05.
The Standard says these classes must have a data length of 40-1440.