### PR TITLE
Run codespell over code to correct spelling errors

### DIFF
--- a/codespell_ignore.txt
+++ b/codespell_ignore.txt
@@ -1,0 +1,3 @@
+inout
+cconfiguration
+

--- a/doc/compliancetest.rst
+++ b/doc/compliancetest.rst
@@ -704,7 +704,7 @@ reading out of parameter values, but you need instead to force the corresponding
 PLC program variable to a high level. In the left side menu use "Watch and
 force tables" (below the PLC), and add a new entry by clicking an empty row
 in the "Name" column, and select "Ix_Req". When later in online mode, click
-the small "Show/hide all modify colmns" to show the column. Enter "TRUE" in
+the small "Show/hide all modify columns" to show the column. Enter "TRUE" in
 the "Modify value" on the line for "Ix_Req". Select that line by enabling
 the corresponding check box. Press the "Modify all selected values once
 and now".

--- a/doc/prepare_raspberrypi.rst
+++ b/doc/prepare_raspberrypi.rst
@@ -64,7 +64,7 @@ Unmount the SD-card, and plug it in into your Raspberry Pi. Power up the
 Raspberry Pi. Log in to it via a serial cable (see below).
 Use the username ``pi`` and the default password ``raspberry``.
 
-If you do not have any serial cable (and not have disabled DCHP), connect
+If you do not have any serial cable (and not have disabled DHCP), connect
 the Raspberry Pi to your local network.
 Find the IP address of it by running this on a Linux machine on the network
 (replace the hostname if you have changed it)::

--- a/doc/use_with_siematic.rst
+++ b/doc/use_with_siematic.rst
@@ -455,7 +455,7 @@ instead of in SCL.
 
 In order to flash the LED we use an available clock bit. In the "Device view"
 for the PLC, use the "Properties" tab and "General" sub-tab. Select "System
-and clock memory", and enable the checkbox "Enabe the use of clock memory
+and clock memory", and enable the checkbox "Enable the use of clock memory
 byte". Enter the value 100 in the "Address of clock memory byte" text box.
 This results in the "Clock_1.25Hz" having the address ``%M100.4``.
 For this change to take effect in the PLC, you need to compile the hardware
@@ -523,7 +523,7 @@ Connect the outputs RECORD to ``"data".param_value``.
 
 To study the result, compile and download the program to the PLC. Go online,
 and enable monitoring by clicking the small glasses-icon. The parameter value
-will be seen in the ladder logic diagram. The PLC wll read out the parameter
+will be seen in the ladder logic diagram. The PLC will read out the parameter
 value many times per second. The VALID and BUSY outputs are switching on
 and off rapidly.
 

--- a/sample_app/app_data.h
+++ b/sample_app/app_data.h
@@ -22,7 +22,7 @@
  *
  * Functions for:
  * - Getting input data (Button 1 and counter value)
- * - Setting ouput data (LED 1)
+ * - Setting output data (LED 1)
  * - Setting default output state. This should be
  *   part of all device implementations for setting
  *   defined state when device is not connected to PLC
@@ -106,7 +106,7 @@ int app_data_write_parameter (
  * Read parameter index.
  * @param submodule_id  In:  Submodule id
  * @param index         In:  Parameter index
- * @param data          In:  Refernce to parameter data
+ * @param data          In:  Reference to parameter data
  * @param size          In:  Length of parameter data
  * @return 0 on success, -1 on error
  */

--- a/sample_app/app_utils.h
+++ b/sample_app/app_utils.h
@@ -234,7 +234,7 @@ void app_utils_print_network_config (
 /**
  * Print iocs warning message if ioxs is changed.
  * @param subslot          In: Subslot
- * @param ioxs_str         In: String decription Producer or Consumer
+ * @param ioxs_str         In: String description Producer or Consumer
  * @param ioxs_current     In: Current status
  * @param ioxs_new         In: New status
  */
@@ -289,7 +289,7 @@ int app_utils_pull_module (app_api_t * p_api, uint16_t slot_nbr);
  * @param submodule_name   In:    Submodule name
  * @param cyclic_callback  In:    Submodule data callback
  * @param tag              In:    Tag passed in cyclic callback
- *                                Typicall application or
+ *                                Typically application or
  *                                submodule handle
  *
  * @return Reference to allocated subslot,

--- a/src/common/pf_alarm.c
+++ b/src/common/pf_alarm.c
@@ -747,7 +747,7 @@ static int pf_alarm_apmr_frame_handler (
    }
    else
    {
-      /* No need for the frame hander to free p_buf as it is NULL */
+      /* No need for the frame handler to free p_buf as it is NULL */
       LOG_ERROR (
          PF_ALARM_LOG,
          "Alarm(%d): Did not put incoming %s prio alarm frame in queue, "

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -1215,7 +1215,7 @@ void pf_lldp_get_org_header_from_packet (
  * 1-255 Chassis ID
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param chassis_id       Out:   Parsed Chassis ID.
  */
@@ -1266,7 +1266,7 @@ static void pf_lldp_get_chassis_id_from_packet (
  * 1-255 Port ID
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param port_id          Out:   Parsed Port ID.
  */
@@ -1316,7 +1316,7 @@ static void pf_lldp_get_port_id_from_packet (
  * 2     Time to live (TTL)
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param ttl              Out:   Parsed TTL.
  */
@@ -1348,7 +1348,7 @@ static void pf_lldp_get_ttl_from_packet (
  * 0-255 Port description
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param port_description Out:   Parsed port description.
  */
@@ -1392,7 +1392,7 @@ static void pf_lldp_get_port_description_from_packet (
  * 0-128 Object identifier
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param management_address Out: Parsed management address.
  */
@@ -1450,7 +1450,7 @@ static void pf_lldp_get_management_address_from_packet (
  * 4     CableDelayLocal
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param delay            Out:   Parsed delay values.
  */
@@ -1485,7 +1485,7 @@ static void pf_lldp_get_signal_delay_from_packet (
  * 2     RTClass3_PortStatus
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param status           Out:   Parsed port status.
  */
@@ -1515,7 +1515,7 @@ static void pf_lldp_get_port_status_from_packet (
  * 6     Chassis MAC address
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param chassis_mac      Out:   Parsed Chassis MAC address.
  */
@@ -1551,7 +1551,7 @@ static void pf_lldp_get_chassis_mac_from_packet (
  * 2     Operational MAU typ
  *
  * @param parse_info       InOut: Parsing information.
- * @param offet            InOut: Byte offset in buffer.
+ * @param offset            InOut: Byte offset in buffer.
  * @param tlv_len          In:    Length of TLV in bytes.
  * @param link_status      Out:   Parsed link status.
  */

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -49,7 +49,7 @@ typedef struct pf_lldp_link_status
 /**
  * Port description
  *
- * "The port description field shall contain an alpha-numeric string
+ * "The port description field shall contain an alphanumeric string
  * that indicates the port's description. If RFC 2863
  * is implemented, the ifDescr object should be used for this field."
  * - IEEE 802.1AB (LLDP) ch. 9.5.5.2 "port description".

--- a/src/common/pf_ppm.c
+++ b/src/common/pf_ppm.c
@@ -17,7 +17,7 @@
  * @file
  * @brief Implements the Cyclic Provider Protocol Machine (PPM)
  *
- * This handles cyclic sending of data (and IOPS). Initalizes transmit buffers.
+ * This handles cyclic sending of data (and IOPS). Initializes transmit buffers.
  *
  * One instance of PPM exist per CR (together with a CPM).
  *

--- a/src/common/pf_ppm.h
+++ b/src/common/pf_ppm.h
@@ -224,7 +224,7 @@ int pf_ppm_set_data_status_provider (pf_ar_t * p_ar, uint32_t crep, bool run);
 int pf_ppm_get_data_status (const pf_ppm_t * p_ppm, uint8_t * p_data_status);
 
 /**
- * Set/Reset the station problem indicator which is inclued in all data
+ * Set/Reset the station problem indicator which is included in all data
  * messages.
  *
  * @param p_ar                InOut: The AR instance.

--- a/src/common/pf_scheduler.c
+++ b/src/common/pf_scheduler.c
@@ -591,7 +591,7 @@ void pf_scheduler_show (pnet_t * net)
  *
  * This function calculates the delay time required to make the
  * scheduler fire at a specific stack tick. However the time jitter in the
- * firing is largely dependent on the underlaying operating system's ablitity to
+ * firing is largely dependent on the underlying operating system's ablitity to
  * trigger the stack execution with a high time precision.
  *
  * @param wanted_delay                    In:    Delay in microseconds.

--- a/src/device/pf_block_reader.h
+++ b/src/device/pf_block_reader.h
@@ -210,7 +210,7 @@ void pf_get_ir_info_request (
  * @param p_info           InOut: The parser information. Sets
  *                                p_info->is_big_endian
  * @param p_pos            InOut: The current parsing position.
- * @param p_rpc            Out:   Destination struture.
+ * @param p_rpc            Out:   Destination structure.
  */
 void pf_get_dce_rpc_header (
    pf_get_info_t * p_info,

--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -3225,7 +3225,7 @@ void pf_put_alarm_fixed (
  * Insert maint_status into a buffer
  *
  * @param is_big_endian    In:    true if buffer is big-endian.
- * @param maint_status     In:    Maintainance status.
+ * @param maint_status     In:    Maintenance status.
  * @param res_len          In:    Size of destination buffer.
  * @param p_bytes          Out:   Destination buffer.
  * @param p_pos            InOut: Position in destination buffer.

--- a/src/device/pf_block_writer.h
+++ b/src/device/pf_block_writer.h
@@ -293,7 +293,7 @@ void pf_put_read_result (
 
 /**
  * Insert read data (from the application) into a buffer.
- * Use a block header with the specificied block_type.
+ * Use a block header with the specified block_type.
  * @param is_big_endian    In:   Endianness of the destination buffer.
  * @param block_type       In:   The block type to use for the data.
  * @param raw_length       In:   The length in bytes of the user data.

--- a/src/device/pf_cmdev.h
+++ b/src/device/pf_cmdev.h
@@ -343,7 +343,7 @@ void pf_cmdev_diag_show (const pnet_t * net);
  *
  * @param net              InOut: The p-net stack instance
  * @param p_ar             InOut: The AR instance.
- * @param state            In:    The CMDEV state transision event. Use
+ * @param state            In:    The CMDEV state transition event. Use
  *                                PNET_EVENT_xxx, not PF_CMDEV_STATE_xxx
  * @return  0  if operation succeeded.
  *          -1 if an error occurred.

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -1182,7 +1182,7 @@ int pf_cmina_dcp_get_req (
          ret = -1;
          break;
       case PF_DCP_SUB_DHCP_CONTROL:
-         /* Cant get this */
+         /* Can't get this */
          *p_block_error = PF_DCP_BLOCK_ERROR_SUBOPTION_NOT_SUPPORTED;
          ret = -1;
          break;
@@ -1193,7 +1193,7 @@ int pf_cmina_dcp_get_req (
       }
       break;
    case PF_DCP_OPT_CONTROL:
-      /* Cant get control */
+      /* Can't get control */
       *p_block_error = PF_DCP_BLOCK_ERROR_OPTION_NOT_SUPPORTED;
       ret = -1;
       break;
@@ -1259,7 +1259,7 @@ const pnet_ethaddr_t * pf_cmina_get_device_macaddr (const pnet_t * net)
    return &net->pf_interface.main_port.mac_address;
 }
 
-/************************* Utilites ******************************************/
+/************************* Utilities ******************************************/
 
 int pf_cmina_remove_all_data_files (const char * file_directory)
 {
@@ -1653,7 +1653,7 @@ bool pf_cmina_is_ipsuite_valid (const pf_ip_suite_t * p_ipsuite)
  * Defined in Profinet 2.4, section
  *
  * @param full_ipsuite     In: IP suite with IP, netmask, gateway and DNS
- * adresses
+ * addresses
  * @return  0  if the IP suite is valid
  *          -1 if the IP suite is invalid
  */

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -3344,7 +3344,7 @@ static int pf_cmrpc_rm_write_ind (
                {
                   req_pos++;
                }
-               /* Prepare for next bloc */
+               /* Prepare for next block */
                memset (&write_stat_multi, 0, sizeof (write_stat_multi));
             }
             if (req_pos != p_sess->get_info.len)

--- a/src/device/pf_diag.c
+++ b/src/device/pf_diag.c
@@ -970,7 +970,7 @@ int pf_diag_remove (
 
 /**
  * @internal
- * Get the prefered diagnosis USI, for use with standard format.
+ * Get the preferred diagnosis USI, for use with standard format.
  *
  * @param net              InOut: The p-net stack instance.
  * @return the USI

--- a/src/device/pf_fspm.h
+++ b/src/device/pf_fspm.h
@@ -57,7 +57,7 @@ int16_t pf_fspm_get_min_device_interval (const pnet_t * net);
  * Logbooks are described in Profinet 2.4 Services, section 7.3.6 "LogBook ASE"
  *
  * @param net              InOut: The p-net stack instance
- * @param arep             In:   The AREP, indentifying the AR.
+ * @param arep             In:   The AREP, identifying the AR.
  * @param p_pnio_status    In:   The PNIO status.
  * @param entry_detail     In:   Additional application information.
  */

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -980,7 +980,7 @@ static void pf_pdport_handle_link_up (pnet_t * net, int loc_port_num)
  * @internal
  * Monitor the Ethernet link status
  *
- * Set approprite diagnosis, if check is enabled.
+ * Set appropriate diagnosis, if check is enabled.
  *
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
@@ -1007,7 +1007,7 @@ static void pf_pdport_monitor_link (pnet_t * net, int loc_port_num)
  * @internal
  * Trigger monitoring the state of one Ethernet link.
  *
- * Set approprite diagnosis, if check is enabled.
+ * Set appropriate diagnosis, if check is enabled.
  * Will loop through all Ethernet links, one per call.
  *
  * This is a callback for the scheduler. Arguments should fulfill

--- a/src/device/pf_pdport.h
+++ b/src/device/pf_pdport.h
@@ -51,7 +51,7 @@ int pf_pdport_reset_all (pnet_t * net);
 void pf_pdport_remove_data_files (const char * file_directory);
 
 /**
- * Notity PDPort that a new AR has been set up.
+ * Notify PDPort that a new AR has been set up.
  * @param net              InOut: The p-net stack instance
  * @param p_ar             In:    The AR instance.
  */
@@ -179,7 +179,7 @@ void pf_pdport_update_eth_status (pnet_t * net);
  * @param net              InOut: The p-net stack instance
  * @param loc_port_num     In:    Local port number.
  *                                Valid range: 1 .. num_physical_ports
- * @return The ethernet staus for local port
+ * @return The ethernet status for local port
  */
 pnal_eth_status_t pf_pdport_get_eth_status (pnet_t * net, int loc_port_num);
 

--- a/src/pf_types.h
+++ b/src/pf_types.h
@@ -144,7 +144,7 @@ static inline uint32_t atomic_fetch_sub (atomic_int * p, uint32_t v)
       (x) |= (v) << PF_DIAG_CH_PROP_MAINT_POS;                                 \
    } while (0)
 
-/* ch_properties appears or disappers */
+/* ch_properties appears or disappears */
 #define PF_DIAG_CH_PROP_SPEC_MASK 0x1800
 #define PF_DIAG_CH_PROP_SPEC_POS  11
 #define PF_DIAG_CH_PROP_SPEC_GET(x)                                            \
@@ -2123,7 +2123,7 @@ typedef struct pf_ar
 } pf_ar_t;
 
 /*
- * ============= Plugable typedefs ==================
+ * ============= Pluggable typedefs ==================
  */
 
 typedef enum pf_submod_plug_state
@@ -2619,7 +2619,7 @@ struct pnet
    pf_cmina_dcp_ase_t cmina_nonvolatile_dcp_ase; /* Reflects what is/should be
                                                     stored in nvm */
    pf_cmina_dcp_ase_t cmina_current_dcp_ase;     /* Reflects current settings
-                                                    (possibly not yet commited) */
+                                                    (possibly not yet committed) */
    os_mutex_t * cmina_mutex;
    pf_cmina_state_values_t cmina_state;
    uint8_t cmina_error_decode;

--- a/src/pnal.h
+++ b/src/pnal.h
@@ -515,7 +515,7 @@ int pnal_get_hostname (char * hostname);
  * @param p_netmask        In:    Netmask
  * @param p_gw             In:    Default gateway
  * @param hostname         In:    Host name, for example my_laptop_4
- * @param permanent        In:    1 if changes are permanent, or 0 if temportary
+ * @param permanent        In:    1 if changes are permanent, or 0 if temporary
  * @return  0  if the operation succeeded.
  *          -1 if an error occurred.
  */

--- a/src/ports/linux/pnal.c
+++ b/src/ports/linux/pnal.c
@@ -316,10 +316,10 @@ static pnal_eth_mau_t calculate_mau_type (uint32_t speed, uint8_t duplex)
 }
 
 /**
- * Calculate advertised capabilites
+ * Calculate advertised capabilities
  *
- * @param advertised       In:    Linux advertised capabilites as a bitfield
- * @return Profinet advertised capabilites as a bitfield
+ * @param advertised       In:    Linux advertised capabilities as a bitfield
+ * @return Profinet advertised capabilities as a bitfield
  */
 static uint16_t calculate_capabilities (uint32_t advertised)
 {

--- a/src/ports/linux/pnal_filetools.c
+++ b/src/ports/linux/pnal_filetools.c
@@ -48,7 +48,7 @@ bool pnal_does_file_exist (const char * filepath)
  *                                enough for the full path to the binary.
  *
  * @return 0 on success.
- *         -1 if an error occured.
+ *         -1 if an error occurred.
  */
 static int pnal_get_directory_of_binary (
    char * tempstring,
@@ -91,7 +91,7 @@ static int pnal_get_directory_of_binary (
  *                                sizeof(PNAL_DEFAULT_SEARCHPATH) +
  *                                PNET_MAX_DIRECTORYPATH_SIZE
  * @return 0 on success.
- *         -1 if an error occured.
+ *         -1 if an error occurred.
  */
 int pnal_create_searchpath (char * path, size_t size)
 {

--- a/src/ports/linux/pnal_filetools.h
+++ b/src/ports/linux/pnal_filetools.h
@@ -46,7 +46,7 @@ bool pnal_does_file_exist (const char * filepath);
  *                                the script.
  *                                The last element should be NULL.
  * @return 0 on success
- *         -1 if an error occured
+ *         -1 if an error occurred
  */
 int pnal_execute_script (const char * argv[]);
 

--- a/src/ports/rt-kernel/0001-rtkernel-for-Profinet.patch
+++ b/src/ports/rt-kernel/0001-rtkernel-for-Profinet.patch
@@ -1084,7 +1084,7 @@ index 2f4a6893..1df6bb0d 100644
  #define SNMP_SYSSERVICES ((1 << 6) | (1 << 3) | ((IP_FORWARD) << 2))
  #endif
  
--void snmp_mib2_set_sysdescr(const u8_t* str, const u16_t* len); /* read-only be defintion */
+-void snmp_mib2_set_sysdescr(const u8_t* str, const u16_t* len); /* read-only be definition */
 -void snmp_mib2_set_syscontact(u8_t *ocstr, u16_t *ocstrlen, u16_t bufsize);
 -void snmp_mib2_set_syscontact_readonly(const u8_t *ocstr, const u16_t *ocstrlen);
 -void snmp_mib2_set_sysname(u8_t *ocstr, u16_t *ocstrlen, u16_t bufsize);

--- a/src/ports/rt-kernel/pnal.c
+++ b/src/ports/rt-kernel/pnal.c
@@ -160,11 +160,11 @@ static pnal_eth_mau_t calculate_mau_type (uint8_t link_state)
 }
 
 /**
- * Calculate advertised capabilites
+ * Calculate advertised capabilities
  *
  * @param capabilities     In:    rt-kernel advertised capabilities as a
  *                                bitfield.
- * @return Profinet advertised capabilites as a bitfield.
+ * @return Profinet advertised capabilities as a bitfield.
  */
 static uint16_t calculate_capabilities (uint16_t capabilities)
 {

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -280,7 +280,7 @@ TEST_F (FileUnitTest, FileCheckMagicAndVersion)
    mock_os_data.file_content[4] = temporary_byte; /* Reset to initial value */
 
    /* Verify that mock does not delete file for other name */
-   pf_file_clear (TEST_FILE_DIRECTORY, "nonexistant file");
+   pf_file_clear (TEST_FILE_DIRECTORY, "nonexistent file");
    EXPECT_GT (mock_os_data.file_size, 1);
 
    /* Clear: Invalid directory */

--- a/test/test_scheduler.cpp
+++ b/test/test_scheduler.cpp
@@ -470,7 +470,7 @@ TEST_F (SchedulerTest, SchedulerAddRemove)
    is_scheduled = pf_scheduler_is_running (p_b);
    EXPECT_FALSE (is_scheduled);
 
-   /* Shedule and restart */
+   /* Schedule and restart */
    ret = pf_scheduler_add (
       net,
       TEST_SCHEDULER_CALLBACK_DELAY,


### PR DESCRIPTION
Running codespell to correct spelling mistakes.

Also adding codespell ignore file also for some code related words
that can be safely ignored.

Could split this patch if needed into API documentation / code related.