### PR TITLE
Feature/stm32cube

### DIFF
--- a/cmake/STM32Cube.cmake
+++ b/cmake/STM32Cube.cmake
@@ -1,0 +1,83 @@
+#********************************************************************
+#        _       _         _
+#  _ __ | |_  _ | |  __ _ | |__   ___
+# | '__|| __|(_)| | / _` || '_ \ / __|
+# | |   | |_  _ | || (_| || |_) |\__ \
+# |_|    \__|(_)|_| \__,_||_.__/ |___/
+#
+# www.rt-labs.com
+# Copyright 2021 rt-labs AB, Sweden.
+#
+# This software is dual-licensed under GPLv3 and a commercial
+# license. See the file LICENSE.md distributed with this software for
+# full license information.
+#*******************************************************************/
+
+target_include_directories(profinet
+  PRIVATE
+  src/ports/STM32Cube
+  )
+
+target_sources(profinet
+  PRIVATE
+  src/ports/STM32Cube/pnal.c
+  src/ports/STM32Cube/pnal_eth.c
+  src/ports/STM32Cube/pnal_udp.c
+  )
+
+target_compile_options(profinet
+  PRIVATE
+  -Wall
+  -Wextra
+  -Werror
+  -Wno-unused-parameter
+  )
+
+target_include_directories(pn_dev
+  PRIVATE
+  sample_app
+  src/ports/STM32Cube
+  )
+
+if (EXISTS ${PROFINET_SOURCE_DIR}/src/ports/STM32Cube/sampleapp_${BOARD}.c)
+  set(BOARD_SOURCE sampleapp_${BOARD}.c)
+else()
+  set(BOARD_SOURCE sampleapp_board.c)
+endif()
+
+target_sources(pn_dev
+  PRIVATE
+  sample_app/sampleapp_common.c
+  sample_app/app_utils.c
+  sample_app/app_log.c
+  sample_app/app_gsdml.c
+  sample_app/app_data.c
+  src/ports/STM32Cube/sampleapp_main.c
+  src/ports/STM32Cube/${BOARD_SOURCE}
+  )
+
+target_compile_options(pn_dev
+  PRIVATE
+  -Wall
+  -Wextra
+  -Werror
+  -Wno-unused-parameter
+  )
+
+target_link_libraries(pn_dev PRIVATE cube-bsp)
+
+install (FILES
+  src/ports/STM32Cube/pnal_config.h
+  DESTINATION include
+  )
+
+if (BUILD_TESTING)
+  target_include_directories(pf_test
+    PRIVATE
+    src/ports/STM32Cube
+    )
+  target_link_libraries(pf_test PRIVATE cube-bsp)
+endif()
+
+generate_bin(pn_dev)
+generate_bin(pf_test)

--- a/cmake/rt-kernel.cmake
+++ b/cmake/rt-kernel.cmake
@@ -45,6 +45,12 @@ target_include_directories(pn_dev
   src/ports/rt-kernel
   )
 
+if (EXISTS ${PROFINET_SOURCE_DIR}/src/ports/rt-kernel/sampleapp_${BSP}.c)
+  set(BSP_SOURCE sampleapp_${BSP}.c)
+else()
+  set(BSP_SOURCE sampleapp_bsp.c)
+endif()
+
 target_sources(pn_dev
   PRIVATE
   sample_app/sampleapp_common.c
@@ -53,6 +59,7 @@ target_sources(pn_dev
   sample_app/app_gsdml.c
   sample_app/app_data.c
   src/ports/rt-kernel/sampleapp_main.c
+  src/ports/rt-kernel/${BSP_SOURCE}
   )
 
 target_compile_options(pn_dev

--- a/doc/getting_started_freertos.rst
+++ b/doc/getting_started_freertos.rst
@@ -1,0 +1,36 @@
+Getting started using STM32Cube / FreeRTOS / lwIP
+=================================================
+
+Cloning STM32Cube firmware
+--------------------------
+
+First, clone the relevant STM32Cube repo for your platform. For
+instance, to build for STM32F7 (fetching a specific tag only)::
+
+    git clone https://github.com/STMicroelectronics/STM32CubeF7.git \
+        -b v1.16.1 --single-branch --depth 1
+
+Download and compile p-net
+--------------------------
+Clone the source::
+
+    git clone --recurse-submodules https://github.com/rtlabs-com/p-net.git
+
+This will clone the repository with submodules. If you already cloned
+the repository without the ``--recurse-submodules`` flag then run this
+in the ``p-net`` folder::
+
+    git submodule update --init --recursive
+
+Then, when configuring specify CPU, board and path to the cloned git
+repository::
+
+    CPU=cortex-m7fd BOARD=STM32F769I-DISCO CUBE_DIR=/path/to/cube cmake \
+        -B build.cube \
+        -DCMAKE_TOOLCHAIN_FILE=cmake/tools/toolchain/stm32cube.cmake \
+        -G "Unix Makefiles"
+    cmake --build build.cube
+
+When the build completes you can find the sample-app binary in
+``build.cube/pn_dev.bin``. Flash this binary to your board by
+uploading it to the USB disk as usual for STM32 boards.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,7 @@ documentation.
    tutorial.rst
    additional_linux_details.rst
    getting_started_rtkernel.rst
+   getting_started_freertos.rst
    using_codesys.rst
    codesys_details.rst
    use_with_siematic.rst

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -436,7 +436,7 @@ Later on kill the ``pn_dev`` process by using ``sudo pkill pn_dev``.
 
 Study the resulting communication
 ---------------------------------
-Press Button1 to see the LED1 start flashing. Press it again to stop the
+LED1 should be flashing by default. Press Button1 to toogle LED1
 flashing.
 
 By pressing Button2 you can trigger alarms, add diagnosis etc. See the

--- a/doc/using_codesys.rst
+++ b/doc/using_codesys.rst
@@ -105,7 +105,7 @@ Variables section::
         out_pin_LED: BOOL;
 
         in_pin_button_LED_previous: BOOL;
-        flashing: BOOL;
+        flashing: BOOL := TRUE;
         oscillator_state: BOOL := FALSE;
         oscillator_cycles: UINT := 0;
     END_VAR

--- a/sample_app/app_utils.c
+++ b/sample_app/app_utils.c
@@ -490,7 +490,7 @@ void app_utils_print_ioxs_change (
    {
       if (iocs_new == PNET_IOXS_BAD)
       {
-         APP_LOG_WARNING (
+         APP_LOG_DEBUG (
             "PLC reports %s BAD for slot %u subslot %u \"%s\"\n",
             ioxs_str,
             subslot->slot_nbr,
@@ -508,7 +508,7 @@ void app_utils_print_ioxs_change (
       }
       else if (iocs_new != PNET_IOXS_GOOD)
       {
-         APP_LOG_WARNING (
+         APP_LOG_DEBUG (
             "PLC reports %s %u for input slot %u subslot %u \"%s\".\n"
             "  Is it in STOP mode?\n",
             ioxs_str,

--- a/src/ports/STM32Cube/pnal.c
+++ b/src/ports/STM32Cube/pnal.c
@@ -1,0 +1,302 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2021 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include "pnal.h"
+
+#include "osal.h"
+#include "osal_log.h"
+#include "options.h"
+
+#include <fatfs.h>
+#include <lwip/apps/snmp.h>
+#include <lwip/netif.h>
+#include <lwip/snmp.h>
+#include <lwip/sys.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int pnal_set_ip_suite (
+   const char * interface_name,
+   const pnal_ipaddr_t * p_ipaddr,
+   const pnal_ipaddr_t * p_netmask,
+   const pnal_ipaddr_t * p_gw,
+   const char * hostname,
+   bool permanent)
+{
+   ip_addr_t ip_addr;
+   ip_addr_t ip_mask;
+   ip_addr_t ip_gw;
+
+   ip_addr.addr = htonl (*p_ipaddr);
+   ip_mask.addr = htonl (*p_netmask);
+   ip_gw.addr = htonl (*p_gw);
+   netif_set_addr (netif_default, &ip_addr, &ip_mask, &ip_gw);
+
+   return 0;
+}
+
+int pnal_get_macaddress (const char * interface_name, pnal_ethaddr_t * mac_addr)
+{
+   memcpy (mac_addr, netif_default->hwaddr, sizeof (pnal_ethaddr_t));
+   return 0;
+}
+
+pnal_ipaddr_t pnal_get_ip_address (const char * interface_name)
+{
+   return htonl (netif_default->ip_addr.addr);
+}
+
+pnal_ipaddr_t pnal_get_netmask (const char * interface_name)
+{
+   return htonl (netif_default->netmask.addr);
+}
+
+pnal_ipaddr_t pnal_get_gateway (const char * interface_name)
+{
+   /* TODO Read the actual default gateway */
+
+   pnal_ipaddr_t ip;
+   pnal_ipaddr_t gateway;
+
+   ip = pnal_get_ip_address (interface_name);
+   gateway = (ip & 0xFFFFFF00) | 0x00000001;
+
+   return gateway;
+}
+
+int pnal_get_hostname (char * hostname)
+{
+   strcpy (hostname, netif_default->hostname);
+   return 0;
+}
+
+int pnal_get_ip_suite (
+   const char * interface_name,
+   pnal_ipaddr_t * p_ipaddr,
+   pnal_ipaddr_t * p_netmask,
+   pnal_ipaddr_t * p_gw,
+   char * hostname)
+{
+   int ret = -1;
+
+   *p_ipaddr = pnal_get_ip_address (interface_name);
+   *p_netmask = pnal_get_netmask (interface_name);
+   *p_gw = pnal_get_gateway (interface_name);
+   ret = pnal_get_hostname (hostname);
+
+   return ret;
+}
+
+int pnal_get_port_statistics (
+   const char * interface_name,
+   pnal_port_stats_t * port_stats)
+{
+   port_stats->if_in_octets = netif_default->mib2_counters.ifinoctets;
+   port_stats->if_in_errors = netif_default->mib2_counters.ifinerrors;
+   port_stats->if_in_discards = netif_default->mib2_counters.ifindiscards;
+   port_stats->if_out_octets = netif_default->mib2_counters.ifoutoctets;
+   port_stats->if_out_errors = netif_default->mib2_counters.ifouterrors;
+   port_stats->if_out_discards = netif_default->mib2_counters.ifoutdiscards;
+
+   return 0;
+}
+
+int pnal_get_interface_index (const char * interface_name)
+{
+   return 0;
+}
+
+int pnal_eth_get_status (const char * interface_name, pnal_eth_status_t * status)
+{
+   status->is_autonegotiation_supported = false;
+   status->is_autonegotiation_enabled = false;
+   status->autonegotiation_advertised_capabilities = 0;
+
+   status->operational_mau_type = 0;
+   status->running = true;
+
+   return 0;
+}
+
+int pnal_save_file (
+   const char * fullpath,
+   const void * object_1,
+   size_t size_1,
+   const void * object_2,
+   size_t size_2)
+{
+   FIL fil;
+   FRESULT fres;
+   UINT count;
+   int ret = 0; /* Assume everything goes well */
+
+   if (!SDFatFSMounted)
+   {
+      LOG_ERROR (
+         PF_PNAL_LOG,
+         "PNAL(%d): SD-Card not mounted (%s)\n",
+         __LINE__,
+         fullpath);
+      return -1;
+   }
+
+   fres = f_open (&fil, fullpath, FA_WRITE | FA_OPEN_ALWAYS | FA_CREATE_ALWAYS);
+   if (fres != FR_OK)
+   {
+      LOG_ERROR (
+         PF_PNAL_LOG,
+         "PNAL(%d): Could not open file %s\n",
+         __LINE__,
+         fullpath);
+      return -1;
+   }
+
+   /* Write file contents */
+   if (size_1 > 0)
+   {
+      fres = f_write (&fil, object_1, size_1, &count);
+      if (fres != FR_OK || count != size_1)
+      {
+         ret = -1;
+         LOG_ERROR (
+            PF_PNAL_LOG,
+            "PNAL(%d): Failed to write file %s\n",
+            __LINE__,
+            fullpath);
+      }
+   }
+   if (size_2 > 0 && ret == 0)
+   {
+      fres = f_write (&fil, object_2, size_2, &count);
+      if (fres != FR_OK || count != size_2)
+      {
+         ret = -1;
+         LOG_ERROR (
+            PF_PNAL_LOG,
+            "PNAL(%d): Failed to write file %s (second buffer)\n",
+            __LINE__,
+            fullpath);
+      }
+   }
+
+   f_close (&fil);
+   return ret;
+}
+
+void pnal_clear_file (const char * fullpath)
+{
+   if (!SDFatFSMounted)
+   {
+      LOG_ERROR (
+         PF_PNAL_LOG,
+         "PNAL(%d): SD-Card not mounted (%s)\n",
+         __LINE__,
+         fullpath);
+      return;
+   }
+   LOG_DEBUG (PF_PNAL_LOG, "PNAL(%d): Clearing file %s\n", __LINE__, fullpath);
+   f_unlink (fullpath);
+}
+
+int pnal_load_file (
+   const char * fullpath,
+   void * object_1,
+   size_t size_1,
+   void * object_2,
+   size_t size_2)
+{
+   FIL fil;
+   FRESULT fres;
+   UINT count;
+   int ret = 0; /* Assume everything goes well */
+
+   if (!SDFatFSMounted)
+   {
+      LOG_ERROR (
+         PF_PNAL_LOG,
+         "PNAL(%d): SD-Card not mounted (%s)\n",
+         __LINE__,
+         fullpath);
+      return -1;
+   }
+
+   fres = f_open (&fil, fullpath, FA_READ);
+   if (fres != FR_OK)
+   {
+      LOG_ERROR (
+         PF_PNAL_LOG,
+         "PNAL(%d): Could not yet open file %s\n",
+         __LINE__,
+         fullpath);
+      return -1;
+   }
+
+   /* Write file contents */
+   if (size_1 > 0)
+   {
+      fres = f_read (&fil, object_1, size_1, &count);
+      if (fres != FR_OK || count != size_1)
+      {
+         ret = -1;
+         LOG_ERROR (
+            PF_PNAL_LOG,
+            "PNAL(%d): Failed to read file %s\n",
+            __LINE__,
+            fullpath);
+      }
+   }
+   if (size_2 > 0 && ret == 0)
+   {
+      fres = f_read (&fil, object_2, size_2, &count);
+      if (fres != FR_OK || count != size_2)
+      {
+         ret = -1;
+         LOG_ERROR (
+            PF_PNAL_LOG,
+            "PNAL(%d): Failed to read file %s (second buffer)\n",
+            __LINE__,
+            fullpath);
+      }
+   }
+
+   f_close (&fil);
+   return ret;
+}
+
+uint32_t pnal_get_system_uptime_10ms (void)
+{
+   uint32_t uptime = 0;
+
+   MIB2_COPY_SYSUPTIME_TO (&uptime);
+   return uptime;
+}
+
+pnal_buf_t * pnal_buf_alloc (uint16_t length)
+{
+   return pbuf_alloc (PBUF_RAW, length, PBUF_POOL);
+}
+
+void pnal_buf_free (pnal_buf_t * p)
+{
+   CC_ASSERT (pbuf_free (p) == 1);
+}
+
+uint8_t pnal_buf_header (pnal_buf_t * p, int16_t header_size_increment)
+{
+   return pbuf_header (p, header_size_increment);
+}

--- a/src/ports/STM32Cube/pnal.c
+++ b/src/ports/STM32Cube/pnal.c
@@ -15,9 +15,9 @@
 
 #include "pnal.h"
 
+#include "options.h"
 #include "osal.h"
 #include "osal_log.h"
-#include "options.h"
 
 #include <fatfs.h>
 #include <lwip/apps/snmp.h>

--- a/src/ports/STM32Cube/pnal_config.h
+++ b/src/ports/STM32Cube/pnal_config.h
@@ -1,0 +1,49 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2021 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+/**
+ * @file
+ * @brief PNAL-specific configuration
+ *
+ * This file contains definitions of configuration settings for the
+ * PNAL layer.
+ */
+
+#ifndef PNAL_CONFIG_H
+#define PNAL_CONFIG_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct pnal_thread_cfg
+{
+   uint32_t prio;
+   size_t stack_size;
+} pnal_thread_cfg_t;
+
+typedef struct pnal_cfg
+{
+   pnal_thread_cfg_t bg_worker_thread;
+} pnal_cfg_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PNAL_CONFIG_H */

--- a/src/ports/STM32Cube/pnal_eth.c
+++ b/src/ports/STM32Cube/pnal_eth.c
@@ -1,0 +1,179 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2021 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+/**
+ * @file
+ * @brief STM32Cube Ethernet related functions that use \a pnal_eth_handle_t
+ */
+
+#include "pnal.h"
+#include "osal_log.h"
+
+#include <lwip/netif.h>
+#include <lwip/apps/snmp_core.h>
+
+#define MAX_NUMBER_OF_IF 1
+
+struct pnal_eth_handle
+{
+   struct netif * netif;
+   pnal_eth_callback_t * eth_rx_callback;
+   void * arg;
+};
+
+static pnal_eth_handle_t interface[MAX_NUMBER_OF_IF];
+static int nic_index = 0;
+
+/**
+ * Find PNAL network interface handle
+ *
+ * @param netif            In:    lwip network interface.
+ * @return PNAL network interface handle corresponding to \a netif,
+ *         NULL otherwise.
+ */
+static pnal_eth_handle_t * pnal_eth_find_handle (struct netif * netif)
+{
+   pnal_eth_handle_t * handle;
+   int i;
+
+   for (i = 0; i < MAX_NUMBER_OF_IF; i++)
+   {
+      handle = &interface[i];
+      if (handle->netif == netif)
+      {
+         return handle;
+      }
+   }
+
+   return NULL;
+}
+
+/**
+ * Allocate PNAL network interface handle
+ *
+ * Handles are allocated from a static array and need never be freed.
+ *
+ * @return PNAL network interface handle if available,
+ *         NULL if too many handles were allocated.
+ */
+static pnal_eth_handle_t * pnal_eth_allocate_handle (void)
+{
+   pnal_eth_handle_t * handle;
+
+   if (nic_index < MAX_NUMBER_OF_IF)
+   {
+      handle = &interface[nic_index];
+      nic_index++;
+      return handle;
+   }
+   else
+   {
+      return NULL;
+   }
+}
+
+/**
+ * Process received Ethernet frame
+ *
+ * Called from lwip when an Ethernet frame is received with an EtherType
+ * lwip is not aware of (e.g. Profinet and LLDP).
+ *
+ * @param p_buf            InOut: Packet buffer containing Ethernet frame.
+ * @param netif            InOut: Network interface receiving the frame.
+ * @return ERR_OK if frame was processed and freed,
+ *         ERR_IF if it was ignored.
+ */
+static err_t pnal_eth_sys_recv (struct pbuf * p_buf, struct netif * netif)
+{
+   int processed;
+   pnal_eth_handle_t * handle;
+
+   handle = pnal_eth_find_handle (netif);
+   if (handle == NULL)
+   {
+      /* p-net not started yet, let lwIP handle frame */
+      return ERR_IF;
+   }
+
+   processed = handle->eth_rx_callback (handle, handle->arg, p_buf);
+   if (processed)
+   {
+      /* Frame handled and freed */
+      return ERR_OK;
+   }
+   else
+   {
+      /* Frame not handled */
+      return ERR_IF;
+   }
+}
+
+err_enum_t lwip_hook_unknown_eth_protocol (
+   struct pbuf * pbuf,
+   struct netif * netif)
+{
+   return pnal_eth_sys_recv (pbuf, netif);
+}
+
+pnal_eth_handle_t * pnal_eth_init (
+   const char * if_name,
+   pnal_ethertype_t receive_type,
+   const pnal_cfg_t * pnal_cfg,
+   pnal_eth_callback_t * callback,
+   void * arg)
+{
+   pnal_eth_handle_t * handle;
+   struct netif * netif;
+
+   (void)receive_type; /* Ignore, for now all frames will be received. */
+
+   netif = netif_find (if_name);
+   if (netif == NULL)
+   {
+      os_log (LOG_LEVEL_ERROR, "Network interface \"%s\" not found!\n", if_name);
+      return NULL;
+   }
+
+   handle = pnal_eth_allocate_handle();
+   if (handle == NULL)
+   {
+      os_log (LOG_LEVEL_ERROR, "Too many network interfaces\n");
+      return NULL;
+   }
+
+   handle->arg = arg;
+   handle->eth_rx_callback = callback;
+   handle->netif = netif;
+
+   return handle;
+}
+
+int pnal_eth_send (pnal_eth_handle_t * handle, pnal_buf_t * buf)
+{
+   int ret = -1;
+
+   CC_ASSERT (handle->netif->linkoutput != NULL);
+
+   /* TODO: Determine if buf could ever be NULL here */
+   if (buf != NULL)
+   {
+      /* TODO: remove tot_len from os_buff */
+      buf->tot_len = buf->len;
+
+      handle->netif->linkoutput (handle->netif, buf);
+      ret = buf->len;
+   }
+   return ret;
+}

--- a/src/ports/STM32Cube/pnal_sys.h
+++ b/src/ports/STM32Cube/pnal_sys.h
@@ -6,23 +6,30 @@
  * |_|    \__|(_)|_| \__,_||_.__/ |___/
  *
  * www.rt-labs.com
- * Copyright 2018 rt-labs AB, Sweden.
+ * Copyright 2021 rt-labs AB, Sweden.
  *
  * This software is dual-licensed under GPLv3 and a commercial
  * license. See the file LICENSE.md distributed with this software for
  * full license information.
  ********************************************************************/
 
-#include <gtest/gtest.h>
-#include "osal.h"
+#ifndef PNAL_SYS_H
+#define PNAL_SYS_H
 
-OS_MAIN (int argc, char * argv[])
-{
-   if (argc > 0)
-      ::testing::InitGoogleTest (&argc, argv);
-   else
-      ::testing::InitGoogleTest();
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-   int result = RUN_ALL_TESTS();
-   return result;
+#include <lwip/def.h> /* For htonl etc */
+#include <lwip/pbuf.h>
+
+#define PNAL_BUF_MAX_SIZE PBUF_POOL_BUFSIZE
+
+/* Re-use lwIP pbuf for rt-kernel */
+typedef struct pbuf pnal_buf_t;
+
+#ifdef __cplusplus
 }
+#endif
+
+#endif /* PNAL_SYS_H */

--- a/src/ports/STM32Cube/pnal_udp.c
+++ b/src/ports/STM32Cube/pnal_udp.c
@@ -1,0 +1,110 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2021 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include "pnal.h"
+#include "osal_log.h"
+
+#include <lwip/sockets.h>
+#include <string.h>
+
+int pnal_udp_open (pnal_ipaddr_t addr, pnal_ipport_t port)
+{
+   struct sockaddr_in local;
+   int id;
+   const int enable = 1;
+
+   id = socket (PF_INET, SOCK_DGRAM, IPPROTO_UDP);
+   if (id == -1)
+   {
+      return -1;
+   }
+
+   if (setsockopt (id, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof (enable)) != 0)
+   {
+      goto error;
+   }
+
+   /* set IP and port number */
+   local = (struct sockaddr_in){
+      .sin_family = AF_INET,
+      .sin_addr.s_addr = htonl (addr),
+      .sin_port = htons (port),
+   };
+
+   if (bind (id, (struct sockaddr *)&local, sizeof (local)) != 0)
+   {
+      goto error;
+   }
+
+   return id;
+
+error:
+   close (id);
+   return -1;
+}
+
+int pnal_udp_sendto (
+   uint32_t id,
+   pnal_ipaddr_t dst_addr,
+   pnal_ipport_t dst_port,
+   const uint8_t * data,
+   int size)
+{
+   struct sockaddr_in remote;
+   int len;
+
+   remote = (struct sockaddr_in){
+      .sin_family = AF_INET,
+      .sin_addr.s_addr = htonl (dst_addr),
+      .sin_port = htons (dst_port),
+   };
+   len =
+      sendto (id, data, size, 0, (struct sockaddr *)&remote, sizeof (remote));
+
+   return len;
+}
+
+int pnal_udp_recvfrom (
+   uint32_t id,
+   pnal_ipaddr_t * src_addr,
+   pnal_ipport_t * src_port,
+   uint8_t * data,
+   int size)
+{
+   struct sockaddr_in remote;
+   socklen_t addr_len = sizeof (remote);
+   int len;
+
+   memset (&remote, 0, sizeof (remote));
+   len = recvfrom (
+      id,
+      data,
+      size,
+      MSG_DONTWAIT,
+      (struct sockaddr *)&remote,
+      &addr_len);
+   if (len > 0)
+   {
+      *src_addr = ntohl (remote.sin_addr.s_addr);
+      *src_port = ntohs (remote.sin_port);
+   }
+
+   return len;
+}
+
+void pnal_udp_close (uint32_t id)
+{
+   close (id);
+}

--- a/src/ports/STM32Cube/sampleapp_STM32F769I-DISCO.c
+++ b/src/ports/STM32Cube/sampleapp_STM32F769I-DISCO.c
@@ -1,0 +1,43 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2021 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include "sampleapp_common.h"
+
+/************************* Utilities ******************************************/
+
+void app_set_led (uint16_t id, bool led_state)
+{
+   if (id == APP_DATA_LED_ID)
+   {
+      HAL_GPIO_WritePin (LD_USER1_GPIO_Port, LD_USER1_Pin, led_state ? 1 : 0);
+   }
+   else if (id == APP_PROFINET_SIGNAL_LED_ID)
+   {
+      HAL_GPIO_WritePin (LD_USER2_GPIO_Port, LD_USER2_Pin, led_state ? 1 : 0);
+   }
+}
+
+bool app_get_button (uint16_t id)
+{
+   if (id == 0)
+   {
+      return HAL_GPIO_ReadPin (B_USER_GPIO_Port, B_USER_Pin) == 1;
+   }
+   else if (id == 1)
+   {
+      /* No more buttons on STM32F769-Discovery */
+   }
+   return false;
+}

--- a/src/ports/STM32Cube/sampleapp_board.c
+++ b/src/ports/STM32Cube/sampleapp_board.c
@@ -6,23 +6,20 @@
  * |_|    \__|(_)|_| \__,_||_.__/ |___/
  *
  * www.rt-labs.com
- * Copyright 2018 rt-labs AB, Sweden.
+ * Copyright 2021 rt-labs AB, Sweden.
  *
  * This software is dual-licensed under GPLv3 and a commercial
  * license. See the file LICENSE.md distributed with this software for
  * full license information.
  ********************************************************************/
 
-#include <gtest/gtest.h>
-#include "osal.h"
+#include "sampleapp_common.h"
 
-OS_MAIN (int argc, char * argv[])
+void app_set_led (uint16_t id, bool led_state)
 {
-   if (argc > 0)
-      ::testing::InitGoogleTest (&argc, argv);
-   else
-      ::testing::InitGoogleTest();
+}
 
-   int result = RUN_ALL_TESTS();
-   return result;
+bool app_get_button (uint16_t id)
+{
+   return false;
 }

--- a/src/ports/STM32Cube/sampleapp_main.c
+++ b/src/ports/STM32Cube/sampleapp_main.c
@@ -1,0 +1,115 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2021 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include "sampleapp_common.h"
+#include "app_utils.h"
+#include "app_log.h"
+#include "app_gsdml.h"
+
+#include "osal_log.h"
+#include "osal.h"
+#include <pnet_api.h>
+
+#include <lwip/netif.h>
+
+#include <string.h>
+
+#define APP_DEFAULT_ETHERNET_INTERFACE "st"
+#define APP_DEFAULT_FILE_DIRECTORY     ""
+#define APP_LOG_LEVEL                  APP_LOG_LEVEL_INFO
+
+#define APP_BG_WORKER_THREAD_PRIORITY  2
+#define APP_BG_WORKER_THREAD_STACKSIZE 4096 /* bytes */
+
+/********************************** Globals ***********************************/
+
+static app_data_t * sample_app = NULL;
+static pnet_cfg_t pnet_cfg = {0};
+app_args_t app_args = {0};
+
+/****************************** Main ******************************************/
+
+int _main (void)
+{
+   int ret;
+   int32_t app_log_level = APP_LOG_LEVEL;
+   app_utils_netif_namelist_t netif_name_list;
+   pnet_if_cfg_t netif_cfg = {0};
+   uint16_t number_of_ports;
+
+   strcpy (app_args.eth_interfaces, APP_DEFAULT_ETHERNET_INTERFACE);
+   strcpy (app_args.station_name, APP_GSDML_DEFAULT_STATION_NAME);
+   app_log_set_log_level (app_log_level);
+
+   APP_LOG_INFO ("\n** Starting P-Net sample application " PNET_VERSION
+                 " **\n");
+   APP_LOG_INFO (
+      "Number of slots:      %u (incl slot for DAP module)\n",
+      PNET_MAX_SLOTS);
+   APP_LOG_INFO ("P-net log level:      %u (DEBUG=0, FATAL=4)\n", LOG_LEVEL);
+   APP_LOG_INFO ("App log level:        %u (DEBUG=0, FATAL=4)\n", app_log_level);
+   APP_LOG_INFO ("Max number of ports:  %u\n", PNET_MAX_PHYSICAL_PORTS);
+   APP_LOG_INFO ("Network interfaces:   %s\n", app_args.eth_interfaces);
+   APP_LOG_INFO ("Default station name: %s\n", app_args.station_name);
+
+   app_pnet_cfg_init_default (&pnet_cfg);
+
+   /* Note: station name is defined by app_gsdml.h */
+
+   strcpy (pnet_cfg.file_directory, APP_DEFAULT_FILE_DIRECTORY);
+
+   /* Note: pnal_cfg not is used for rt-kernel  */
+
+   ret = app_utils_pnet_cfg_init_netifs (
+      app_args.eth_interfaces,
+      &netif_name_list,
+      &number_of_ports,
+      &netif_cfg);
+   if (ret != 0)
+   {
+      return -1;
+   }
+
+   pnet_cfg.if_cfg = netif_cfg;
+   pnet_cfg.num_physical_ports = number_of_ports;
+
+   app_utils_print_network_config (&netif_cfg, number_of_ports);
+
+   pnet_cfg.pnal_cfg.bg_worker_thread.prio = APP_BG_WORKER_THREAD_PRIORITY;
+   pnet_cfg.pnal_cfg.bg_worker_thread.stack_size =
+      APP_BG_WORKER_THREAD_STACKSIZE;
+
+   /* Initialize profinet stack */
+   APP_LOG_INFO ("Init sample application\n");
+   sample_app = app_init (&pnet_cfg);
+   if (sample_app == NULL)
+   {
+      printf ("Failed to initialize P-Net.\n");
+      printf ("Aborting application\n");
+      return -1;
+   }
+
+   APP_LOG_INFO ("Start sample application\n");
+   if (app_start (sample_app, RUN_IN_MAIN_THREAD) != 0)
+   {
+      printf ("Failed to start\n");
+      printf ("Aborting application\n");
+      return -1;
+   }
+
+   app_loop_forever (sample_app);
+
+   return 0;
+}

--- a/src/ports/STM32Cube/sampleapp_main.c
+++ b/src/ports/STM32Cube/sampleapp_main.c
@@ -44,14 +44,13 @@ app_args_t app_args = {0};
 int _main (void)
 {
    int ret;
-   int32_t app_log_level = APP_LOG_LEVEL;
    app_utils_netif_namelist_t netif_name_list;
    pnet_if_cfg_t netif_cfg = {0};
    uint16_t number_of_ports;
 
    strcpy (app_args.eth_interfaces, APP_DEFAULT_ETHERNET_INTERFACE);
    strcpy (app_args.station_name, APP_GSDML_DEFAULT_STATION_NAME);
-   app_log_set_log_level (app_log_level);
+   app_log_set_log_level (APP_LOG_LEVEL);
 
    APP_LOG_INFO ("\n** Starting P-Net sample application " PNET_VERSION
                  " **\n");
@@ -59,7 +58,7 @@ int _main (void)
       "Number of slots:      %u (incl slot for DAP module)\n",
       PNET_MAX_SLOTS);
    APP_LOG_INFO ("P-net log level:      %u (DEBUG=0, FATAL=4)\n", LOG_LEVEL);
-   APP_LOG_INFO ("App log level:        %u (DEBUG=0, FATAL=4)\n", app_log_level);
+   APP_LOG_INFO ("App log level:        %u (DEBUG=0, FATAL=4)\n", APP_LOG_LEVEL);
    APP_LOG_INFO ("Max number of ports:  %u\n", PNET_MAX_PHYSICAL_PORTS);
    APP_LOG_INFO ("Network interfaces:   %s\n", app_args.eth_interfaces);
    APP_LOG_INFO ("Default station name: %s\n", app_args.station_name);
@@ -69,8 +68,6 @@ int _main (void)
    /* Note: station name is defined by app_gsdml.h */
 
    strcpy (pnet_cfg.file_directory, APP_DEFAULT_FILE_DIRECTORY);
-
-   /* Note: pnal_cfg not is used for rt-kernel  */
 
    ret = app_utils_pnet_cfg_init_netifs (
       app_args.eth_interfaces,

--- a/src/ports/linux/pnal.c
+++ b/src/ports/linux/pnal.c
@@ -17,8 +17,8 @@
 
 #include "pnal.h"
 
-#include "osal.h"
 #include "options.h"
+#include "osal.h"
 #include "osal_log.h"
 #include "pnal_filetools.h"
 

--- a/src/ports/rt-kernel/pnal.c
+++ b/src/ports/rt-kernel/pnal.c
@@ -15,9 +15,9 @@
 
 #include "pnal.h"
 
+#include "options.h"
 #include "osal.h"
 #include "osal_log.h"
-#include "options.h"
 
 #include <drivers/net.h>
 #include <drivers/eth/phy/phy.h>

--- a/src/ports/rt-kernel/sampleapp_bsp.c
+++ b/src/ports/rt-kernel/sampleapp_bsp.c
@@ -1,0 +1,25 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2018 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include "sampleapp_common.h"
+
+void app_set_led (uint16_t id, bool led_state)
+{
+}
+
+bool app_get_button (uint16_t id)
+{
+   return false;
+}

--- a/src/ports/rt-kernel/sampleapp_f769disco.c
+++ b/src/ports/rt-kernel/sampleapp_f769disco.c
@@ -1,0 +1,44 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2018 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include "sampleapp_common.h"
+#include <bsp.h>
+
+/************************* Utilities ******************************************/
+
+void app_set_led (uint16_t id, bool led_state)
+{
+   if (id == APP_DATA_LED_ID)
+   {
+      gpio_set (GPIO_LED_GREEN, led_state ? 1 : 0);
+   }
+   else if (id == APP_PROFINET_SIGNAL_LED_ID)
+   {
+      gpio_set (GPIO_LED_RED, led_state ? 1 : 0);
+   }
+}
+
+bool app_get_button (uint16_t id)
+{
+   if (id == 0)
+   {
+      return (gpio_get (GPIO_BUTTON) == 1);
+   }
+   else if (id == 1)
+   {
+      /* No more buttons on board */
+   }
+   return false;
+}

--- a/src/ports/rt-kernel/sampleapp_main.c
+++ b/src/ports/rt-kernel/sampleapp_main.c
@@ -22,17 +22,12 @@
 #include "osal.h"
 #include <pnet_api.h>
 
-#include <gpio.h>
 #include <kern/kern.h>
 #include <lwip/netif.h>
 #include <shell.h>
 
 #include <string.h>
 
-#define GPIO_LED1                      GPIO_P5_9
-#define GPIO_LED2                      GPIO_P5_8
-#define GPIO_BUTTON1                   GPIO_P15_13
-#define GPIO_BUTTON2                   GPIO_P15_12
 #define APP_DEFAULT_ETHERNET_INTERFACE "en1"
 #define APP_DEFAULT_FILE_DIRECTORY     "/disk1"
 #define APP_LOG_LEVEL                  APP_LOG_LEVEL_INFO
@@ -45,33 +40,6 @@
 static app_data_t * sample_app = NULL;
 static pnet_cfg_t pnet_cfg = {0};
 app_args_t app_args = {0};
-
-/************************* Utilities ******************************************/
-
-void app_set_led (uint16_t id, bool led_state)
-{
-   if (id == APP_DATA_LED_ID)
-   {
-      gpio_set (GPIO_LED1, led_state ? 1 : 0); /* "LED1" on circuit board */
-   }
-   else if (id == APP_PROFINET_SIGNAL_LED_ID)
-   {
-      gpio_set (GPIO_LED2, led_state ? 1 : 0); /* "LED2" on circuit board */
-   }
-}
-
-bool app_get_button (uint16_t id)
-{
-   if (id == 0)
-   {
-      return (gpio_get (GPIO_BUTTON1) == 0);
-   }
-   else if (id == 1)
-   {
-      return (gpio_get (GPIO_BUTTON2) == 0);
-   }
-   return false;
-}
 
 /************************* Shell commands *************************************/
 /*  Press enter in the terminal to get to the built-in shell.                 */

--- a/src/ports/rt-kernel/sampleapp_main.c
+++ b/src/ports/rt-kernel/sampleapp_main.c
@@ -130,14 +130,13 @@ void shell_banner (void)
 int main (void)
 {
    int ret;
-   int32_t app_log_level = APP_LOG_LEVEL;
    app_utils_netif_namelist_t netif_name_list;
    pnet_if_cfg_t netif_cfg = {0};
    uint16_t number_of_ports;
 
    strcpy (app_args.eth_interfaces, APP_DEFAULT_ETHERNET_INTERFACE);
    strcpy (app_args.station_name, APP_GSDML_DEFAULT_STATION_NAME);
-   app_log_set_log_level (app_log_level);
+   app_log_set_log_level (APP_LOG_LEVEL);
 
    APP_LOG_INFO ("\n** Starting P-Net sample application " PNET_VERSION
                  " **\n");
@@ -148,7 +147,7 @@ int main (void)
       "Number of slots:      %u (incl slot for DAP module)\n",
       PNET_MAX_SLOTS);
    APP_LOG_INFO ("P-net log level:      %u (DEBUG=0, FATAL=4)\n", LOG_LEVEL);
-   APP_LOG_INFO ("App log level:        %u (DEBUG=0, FATAL=4)\n", app_log_level);
+   APP_LOG_INFO ("App log level:        %u (DEBUG=0, FATAL=4)\n", APP_LOG_LEVEL);
    APP_LOG_INFO ("Max number of ports:  %u\n", PNET_MAX_PHYSICAL_PORTS);
    APP_LOG_INFO ("Network interfaces:   %s\n", app_args.eth_interfaces);
    APP_LOG_INFO ("Default station name: %s\n", app_args.station_name);
@@ -158,8 +157,6 @@ int main (void)
    /* Note: station name is defined by app_gsdml.h */
 
    strcpy (pnet_cfg.file_directory, APP_DEFAULT_FILE_DIRECTORY);
-
-   /* Note: pnal_cfg not is used for rt-kernel  */
 
    ret = app_utils_pnet_cfg_init_netifs (
       app_args.eth_interfaces,

--- a/src/ports/rt-kernel/sampleapp_xmc48relax.c
+++ b/src/ports/rt-kernel/sampleapp_xmc48relax.c
@@ -1,0 +1,45 @@
+/*********************************************************************
+ *        _       _         _
+ *  _ __ | |_  _ | |  __ _ | |__   ___
+ * | '__|| __|(_)| | / _` || '_ \ / __|
+ * | |   | |_  _ | || (_| || |_) |\__ \
+ * |_|    \__|(_)|_| \__,_||_.__/ |___/
+ *
+ * www.rt-labs.com
+ * Copyright 2018 rt-labs AB, Sweden.
+ *
+ * This software is dual-licensed under GPLv3 and a commercial
+ * license. See the file LICENSE.md distributed with this software for
+ * full license information.
+ ********************************************************************/
+
+#include "sampleapp_common.h"
+#include <gpio.h>
+#include <bsp.h>
+
+/************************* Utilities ******************************************/
+
+void app_set_led (uint16_t id, bool led_state)
+{
+   if (id == APP_DATA_LED_ID)
+   {
+      gpio_set (GPIO_LED1, led_state ? 1 : 0); /* "LED1" on circuit board */
+   }
+   else if (id == APP_PROFINET_SIGNAL_LED_ID)
+   {
+      gpio_set (GPIO_LED2, led_state ? 1 : 0); /* "LED2" on circuit board */
+   }
+}
+
+bool app_get_button (uint16_t id)
+{
+   if (id == 0)
+   {
+      return (gpio_get (GPIO_BUTTON1) == 0);
+   }
+   else if (id == 1)
+   {
+      return (gpio_get (GPIO_BUTTON2) == 0);
+   }
+   return false;
+}


### PR DESCRIPTION
Add support for STM32F769I-DISCO board, running STM32Cube firmware including FreeRTOS and lwIP. SNMP is currently not supported.

This PR also splits both rt-kernel and stm32cube sample apps so that board-specific support is in a separate file.

Finally, this PR changes the tutorial to enable flashing of LED1 by default, so that one can easily see if the tutorial is working.
