### PR TITLE
Use correct argument order for pf_put_padding_align()

### DIFF
--- a/src/device/pf_block_writer.c
+++ b/src/device/pf_block_writer.c
@@ -4638,7 +4638,7 @@ void pf_put_lookup_response_data (
       p_bytes,
       p_pos);
 
-   pf_put_padding_align (2, block_position, res_len, p_bytes, p_pos);
+   pf_put_padding_align (block_position, 2, res_len, p_bytes, p_pos);
 
    pf_put_uint32 (
       is_big_endian,


### PR DESCRIPTION
According to the documentation for the pf_put_padding_align() function,
the first argument should be the start_position, and the next argument should be the alignment size.

Change the usage to be according to the documentation.

Error reported by user.