### PR TITLE
Use a separate script to enable GPIOs on Raspberry Pi

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 # Do not perform LF normalization on bash scripts
 *.service text eol=lf
 *.raspberrypi text eol=lf
+*.sh text eol=lf
 src/ports/linux/set_network_parameters text eol=lf
 src/ports/linux/set_profinet_leds text eol=lf
 

--- a/doc/prepare_raspberrypi.rst
+++ b/doc/prepare_raspberrypi.rst
@@ -284,9 +284,11 @@ Place a systemd unit file here: ``/lib/systemd/system/pnet-sampleapp.service``
 An example file is available in the ``sample_app/`` directory of this
 repository. It assumes that the code is checked out into
 ``/home/pi/profinet/p-net/`` on your Raspberry Pi.
-Install the file::
+Install the files::
 
     sudo cp /home/pi/profinet/p-net/src/ports/linux/pnet-sampleapp.service /lib/systemd/system/
+    sudo cp /home/pi/profinet/p-net/src/ports/linux/enable-rpi-gpio-pins.sh /usr/bin/
+    sudo chmod +x /usr/bin/enable-rpi-gpio-pins.sh
 
 Adapt the contents to your paths and hardware.
 

--- a/src/ports/linux/enable-rpi-gpio-pins.sh
+++ b/src/ports/linux/enable-rpi-gpio-pins.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Enable GPIO pins for digital inputs (buttons) on Raspberry Pi
+echo 22 > /sys/class/gpio/export
+echo 27 > /sys/class/gpio/export
+
+# GPIO pins for digital outputs (LEDs) are enabled in another script

--- a/src/ports/linux/pnet-sampleapp.service
+++ b/src/ports/linux/pnet-sampleapp.service
@@ -11,8 +11,7 @@ After=network.target
 Type=simple
 ExecStartPre=/sbin/ifconfig eth0 up
 ExecStartPre=/bin/sh -c '/bin/echo "49152 60999" > /proc/sys/net/ipv4/ip_local_port_range'
-ExecStartPre=/usr/bin/gpio export 22 in
-ExecStartPre=/usr/bin/gpio export 27 in
+ExecStartPre=/usr/bin/enable-rpi-gpio-pins.sh
 # Enable this line if waiting for snmpd to start
 #ExecStartPre=/usr/bin/sleep 0.3
 WorkingDirectory=/home/pi/profinet/build/


### PR DESCRIPTION
The /usr/bin/gpio utility from the wiringpi package is no longer available.
Use a bash script instead.