### PR TITLE
Logging of incoming non-Profinet LLDP frames

### DIFF
--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -1876,39 +1876,61 @@ void pf_lldp_update_peer (
       /* No changes */
       return;
    }
+
    if (p_port_data->lldp.is_peer_info_received)
+   {
+      if (
+         p_port_data->lldp.peer_info.chassis_id.subtype ==
+            PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED &&
+         p_port_data->lldp.peer_info.port_id.subtype ==
+            PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED)
+      {
+         LOG_INFO (
+            PF_LLDP_LOG,
+            "LLDP(%d): Peer info changed on port %d. Old peer info - MAC: "
+            "%02X:%02X:%02X:%02X:%02X:%02X "
+            "Chassis ID: %s Port ID: %s\n",
+            __LINE__,
+            loc_port_num,
+            p_port_data->lldp.peer_info.mac_address.addr[0],
+            p_port_data->lldp.peer_info.mac_address.addr[1],
+            p_port_data->lldp.peer_info.mac_address.addr[2],
+            p_port_data->lldp.peer_info.mac_address.addr[3],
+            p_port_data->lldp.peer_info.mac_address.addr[4],
+            p_port_data->lldp.peer_info.mac_address.addr[5],
+            p_port_data->lldp.peer_info.chassis_id.string,
+            p_port_data->lldp.peer_info.port_id.string);
+      }
+      else
+      {
+         LOG_INFO (
+            PF_LLDP_LOG,
+            "LLDP(%d): Peer info changed on port %d.\n",
+            __LINE__,
+            loc_port_num);
+      }
+   }
+
+   if (
+      lldp_peer_info->chassis_id.subtype == PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED &&
+      lldp_peer_info->port_id.subtype == PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED)
    {
       LOG_INFO (
          PF_LLDP_LOG,
-         "LLDP(%d): Peer info changed on port %d. Old peer info - MAC: "
+         "LLDP(%d): New peer info on port %d - MAC: "
          "%02X:%02X:%02X:%02X:%02X:%02X "
          "Chassis ID: %s Port ID: %s\n",
          __LINE__,
          loc_port_num,
-         p_port_data->lldp.peer_info.mac_address.addr[0],
-         p_port_data->lldp.peer_info.mac_address.addr[1],
-         p_port_data->lldp.peer_info.mac_address.addr[2],
-         p_port_data->lldp.peer_info.mac_address.addr[3],
-         p_port_data->lldp.peer_info.mac_address.addr[4],
-         p_port_data->lldp.peer_info.mac_address.addr[5],
-         p_port_data->lldp.peer_info.chassis_id.string,
-         p_port_data->lldp.peer_info.port_id.string);
+         lldp_peer_info->mac_address.addr[0],
+         lldp_peer_info->mac_address.addr[1],
+         lldp_peer_info->mac_address.addr[2],
+         lldp_peer_info->mac_address.addr[3],
+         lldp_peer_info->mac_address.addr[4],
+         lldp_peer_info->mac_address.addr[5],
+         lldp_peer_info->chassis_id.string,
+         lldp_peer_info->port_id.string);
    }
-
-   LOG_INFO (
-      PF_LLDP_LOG,
-      "LLDP(%d): New peer info on port %d - MAC: %02X:%02X:%02X:%02X:%02X:%02X "
-      "Chassis ID: %s Port ID: %s\n",
-      __LINE__,
-      loc_port_num,
-      lldp_peer_info->mac_address.addr[0],
-      lldp_peer_info->mac_address.addr[1],
-      lldp_peer_info->mac_address.addr[2],
-      lldp_peer_info->mac_address.addr[3],
-      lldp_peer_info->mac_address.addr[4],
-      lldp_peer_info->mac_address.addr[5],
-      lldp_peer_info->chassis_id.string,
-      lldp_peer_info->port_id.string);
 
    pf_lldp_store_peer_info (net, loc_port_num, lldp_peer_info);
    pf_pdport_peer_indication (net, loc_port_num);
@@ -1930,21 +1952,49 @@ int pf_lldp_recv (
 
    if (!err)
    {
-      LOG_DEBUG (
-         PF_LLDP_LOG,
-         "LLDP(%d): Receive port %u MAC: %02X:%02X:%02X:%02X:%02X:%02X "
-         "Len: %d Chassis ID: %s Port ID: %s\n",
-         __LINE__,
-         loc_port_num,
-         peer_data.mac_address.addr[0],
-         peer_data.mac_address.addr[1],
-         peer_data.mac_address.addr[2],
-         peer_data.mac_address.addr[3],
-         peer_data.mac_address.addr[4],
-         peer_data.mac_address.addr[5],
-         p_frame_buf->len,
-         peer_data.chassis_id.string,
-         peer_data.port_id.string);
+      if (
+         peer_data.chassis_id.subtype == PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED &&
+         peer_data.port_id.subtype == PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED)
+      {
+         LOG_DEBUG (
+            PF_LLDP_LOG,
+            "LLDP(%d): Receive port %u MAC: "
+            "%02X:%02X:%02X:%02X:%02X:%02X "
+            "Len: %d Chassis ID: %s Port ID: %s\n",
+            __LINE__,
+            loc_port_num,
+            peer_data.mac_address.addr[0],
+            peer_data.mac_address.addr[1],
+            peer_data.mac_address.addr[2],
+            peer_data.mac_address.addr[3],
+            peer_data.mac_address.addr[4],
+            peer_data.mac_address.addr[5],
+            p_frame_buf->len,
+            peer_data.chassis_id.string,
+            peer_data.port_id.string);
+      }
+      else if (peer_data.port_id.subtype == PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED)
+      {
+         LOG_DEBUG (
+            PF_LLDP_LOG,
+            "LLDP(%d): LLDP frame received on port %u Len: %d Port "
+            "ID: %s\n",
+            __LINE__,
+            loc_port_num,
+            p_frame_buf->len,
+            peer_data.port_id.string);
+      }
+      else
+      {
+         LOG_DEBUG (
+            PF_LLDP_LOG,
+            "LLDP(%d): Non-profinet LLDP frame received on port %u "
+            "Len: "
+            "%d\n",
+            __LINE__,
+            loc_port_num,
+            p_frame_buf->len);
+      }
 
       if (pf_port_is_valid (net, loc_port_num))
       {

--- a/src/common/pf_lldp.h
+++ b/src/common/pf_lldp.h
@@ -28,7 +28,7 @@ extern "C" {
 
 #include "pnal.h"
 
-#define PF_LLDP_SUBTYPE_MAC              4
+#define PF_LLDP_SUBTYPE_MAC              4 /** Valid for ChassisID */
 #define PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED 7
 
 /**
@@ -105,9 +105,18 @@ typedef struct pf_port_iterator
  */
 typedef struct pf_lldp_chassis_id
 {
-   char string[PNET_LLDP_CHASSIS_ID_MAX_SIZE]; /**< Terminated string */
-   uint8_t subtype;                            /* PF_LLDP_SUBTYPE_xxx */
+   /** Terminated string
+       Typically this field is a string (PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED)
+       If the subtype indicates a MAC address, the content is the
+       raw MAC address bytes (and trailing null termination).
+       Similarly for other subtypes */
+   char string[PNET_LLDP_CHASSIS_ID_MAX_SIZE];
+
+   /** PF_LLDP_SUBTYPE_xxx */
+   uint8_t subtype;
+
    bool is_valid;
+
    size_t len;
 } pf_lldp_chassis_id_t;
 
@@ -118,9 +127,18 @@ typedef struct pf_lldp_chassis_id
  */
 typedef struct pf_lldp_port_id
 {
-   char string[PNET_LLDP_PORT_ID_MAX_SIZE]; /**< Terminated string */
-   uint8_t subtype;                         /* PF_LLDP_SUBTYPE_xxx */
+   /** Terminated string
+       Typically this field is a string (PF_LLDP_SUBTYPE_LOCALLY_ASSIGNED)
+       If the subtype indicates a MAC address, the content is the
+       raw MAC address bytes (and trailing null termination).
+       Similarly for other subtypes */
+   char string[PNET_LLDP_PORT_ID_MAX_SIZE];
+
+   /** PF_LLDP_SUBTYPE_xxx */
+   uint8_t subtype;
+
    bool is_valid;
+
    size_t len;
 } pf_lldp_port_id_t;
 


### PR DESCRIPTION
Handle logging of LLDP frames where ChassisID and PortID not are strings.