### PR TITLE
Better handling of Ethernet MAU types

### DIFF
--- a/include/pnet_api.h
+++ b/include/pnet_api.h
@@ -1155,17 +1155,17 @@ typedef struct pnet_ethaddr
 
 /**
  * Physical Port Configuration
- *
- * The port_name field has the format port-xyz or port-abcde-xyz regardless of
- * the format used for LLDP ChassisID and PortID.
- * See section 7.3.3.3.4 "Attributes" in Profinet 2.4 Services.
- * TODO: Move this field to runtime data instead, and rename the field to
- * name_of_port
- * Automatically populate it with port-00x where x is local_port_number
  */
 typedef struct pnet_port_cfg
 {
    const char * netif_name;
+
+   /** Ethernet MAU type to use when it not can be read from hardware.
+    *  For example
+    *     0x0010 = Copper 100 Mbit/s Full duplex.
+    *     0x001E = Copper 1000 Mbit/s Full duplex.
+    *  See \a pnal_eth_mau_t for more examples. */
+   uint16_t default_mau_type;
 } pnet_port_cfg_t;
 
 /**

--- a/sample_app/app_gsdml.h
+++ b/sample_app/app_gsdml.h
@@ -97,6 +97,8 @@ extern "C" {
 #define APP_GSDM_PARAMETER_2_IDX  124
 #define APP_GSDM_PARAMETER_LENGTH 4
 
+#define APP_GSDML_DEFAULT_MAUTYPE 0x10 /* Copper 100 Mbit/s Full duplex */
+
 typedef struct app_gsdml_module
 {
    uint32_t id;

--- a/sample_app/app_utils.c
+++ b/sample_app/app_utils.c
@@ -436,6 +436,8 @@ int app_utils_pnet_cfg_init_netifs (
    for (i = 1; i <= *number_of_ports; i++)
    {
       if_cfg->physical_ports[i - 1].netif_name = if_list->netif[i].name;
+      if_cfg->physical_ports[i - 1].default_mau_type =
+         APP_GSDML_DEFAULT_MAUTYPE;
    }
 
    /* Read IP, netmask, gateway from operating system */

--- a/src/common/pf_lldp.c
+++ b/src/common/pf_lldp.c
@@ -893,7 +893,8 @@ void pf_lldp_get_link_status (
    int loc_port_num,
    pf_lldp_link_status_t * p_link_status)
 {
-   pnal_eth_status_t status = pf_pdport_get_eth_status (net, loc_port_num);
+   pnal_eth_status_t status =
+      pf_pdport_get_eth_status_filtered_mau (net, loc_port_num);
 
    p_link_status->is_autonegotiation_supported =
       status.is_autonegotiation_supported;

--- a/src/device/pf_pdport.h
+++ b/src/device/pf_pdport.h
@@ -199,6 +199,26 @@ void pf_pdport_update_eth_status (pnet_t * net);
  */
 pnal_eth_status_t pf_pdport_get_eth_status (pnet_t * net, int loc_port_num);
 
+/**
+ * Get current ethernet status for local port.
+ * This is a non-blocking function reading from mutex-protected memory.
+ * The status values are updated by the background worker task
+ * in a periodic job executing the pf_pdport_update_eth_status() function.
+ *
+ * The MAU type value in the resulting \a pnal_eth_status_t struct
+ * will be replaced by the default MAU type from the configuration
+ * when the link is down (and the actual MAU type not can be read from
+ * hardware).
+ *
+ * @param net              InOut: The p-net stack instance
+ * @param loc_port_num     In:    Local port number.
+ *                                Valid range: 1 .. num_physical_ports
+ * @return The ethernet status for local port
+ */
+pnal_eth_status_t pf_pdport_get_eth_status_filtered_mau (
+   pnet_t * net,
+   int loc_port_num);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/device/pf_port.h
+++ b/src/device/pf_port.h
@@ -184,6 +184,13 @@ int pf_port_get_port_number (const pnet_t * net, pnal_eth_handle_t * eth_handle)
 /**
  * Decode media type from Ethernet MAU type.
  * Media types listed in PN-AL-protocol (Mar20) Table 727.
+ *
+ * The MAU type 0 represents "unknown" when the link is down.
+ * When the link is up a MAU type 0 represents "Radio".
+ *
+ * This function assumes that the link is up. Make sure you use
+ * some default MAU type if the link is down, before using this function.
+ *
  * @param mau_type         In:   Ethernet MAU type
  * @return media type
  */

--- a/src/pnal.h
+++ b/src/pnal.h
@@ -78,11 +78,12 @@ extern "C" {
  * IEEE 802.3 Medium Attachment Units (MAUs)", objects
  * "IANAifMauTypeListBits" and "dot3MauType".
  *
- * See Profinet 2.4, section 5.2.13.12.
+ * See Profinet "5.2.12.3.12 Coding of the field MAUType"
  */
 typedef enum pnal_eth_mau
 {
-   PNAL_ETH_MAU_RADIO = 0x00,
+   PNAL_ETH_MAU_UNKNOWN = 0x00, /* When link is down */
+   PNAL_ETH_MAU_RADIO = 0x00,   /* When link is up */
    PNAL_ETH_MAU_COPPER_10BaseT = 0x05,
    PNAL_ETH_MAU_COPPER_100BaseTX_HALF_DUPLEX = 0x0F,
    PNAL_ETH_MAU_COPPER_100BaseTX_FULL_DUPLEX = 0x10,

--- a/src/ports/rt-kernel/pnal.c
+++ b/src/ports/rt-kernel/pnal.c
@@ -155,7 +155,7 @@ static pnal_eth_mau_t calculate_mau_type (uint8_t link_state)
    case PHY_LINK_OK | PHY_LINK_1000MBIT | PHY_LINK_FULL_DUPLEX:
       return PNAL_ETH_MAU_COPPER_1000BaseT_FULL_DUPLEX;
    default:
-      return PNAL_ETH_MAU_RADIO;
+      return PNAL_ETH_MAU_UNKNOWN;
    }
 }
 


### PR DESCRIPTION
When the link is down the MAU type can not be read from
hardware, for Linux and possibly other operating systems.

Add a configuration value for default MAU type value, to be used
when the actual value not is available.