### PR TITLE
Disable background worker during unit test

### DIFF
--- a/src/common/pf_bg_worker.c
+++ b/src/common/pf_bg_worker.c
@@ -18,6 +18,16 @@
 
 #include <inttypes.h>
 
+#ifdef UNIT_TEST
+/* Background worker is disabled during unit tests.
+ * Stack reinitialization during test recreates
+ * the background task which cause problems.
+ * Disabling is implemented using mock functions
+ * - mock_pf_bg_worker_init
+ * - mock_pf_bg_worker_start_job
+ */
+#endif
+
 /* Events handled by bg worker task */
 
 #define BG_JOB_EVENT_UPDATE_PORTS_STATUS  BIT (0)

--- a/src/device/pf_cmina.c
+++ b/src/device/pf_cmina.c
@@ -33,6 +33,7 @@
 #ifdef UNIT_TEST
 #define pnal_get_port_statistics mock_pnal_get_port_statistics
 #define pnal_set_ip_suite        mock_pnal_set_ip_suite
+#define pf_bg_worker_start_job   mock_pf_bg_worker_start_job
 #endif
 
 #include <string.h>

--- a/src/device/pf_fspm.c
+++ b/src/device/pf_fspm.c
@@ -28,6 +28,7 @@
 #define pf_file_clear            mock_pf_file_clear
 #define pf_file_load             mock_pf_file_load
 #define pf_file_save_if_modified mock_pf_file_save_if_modified
+#define pf_bg_worker_start_job   mock_pf_bg_worker_start_job
 #endif
 
 #include <string.h>

--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -16,6 +16,7 @@
 #ifdef UNIT_TEST
 #define pnal_eth_get_status      mock_pnal_eth_get_status
 #define pnal_get_port_statistics mock_pnal_get_port_statistics
+#define pf_bg_worker_start_job   mock_pf_bg_worker_start_job
 #endif
 
 #include "pf_includes.h"

--- a/src/device/pnet_api.c
+++ b/src/device/pnet_api.c
@@ -14,7 +14,8 @@
  ********************************************************************/
 
 #ifdef UNIT_TEST
-#define pnal_snmp_init mock_pnal_snmp_init
+#define pnal_snmp_init    mock_pnal_snmp_init
+#define pf_bg_worker_init mock_pf_bg_worker_init
 #endif
 
 #include <inttypes.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,7 @@ target_sources(pf_test PRIVATE
   ${PROFINET_SOURCE_DIR}/src/device/pf_pdport.c
   ${PROFINET_SOURCE_DIR}/src/device/pnet_api.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_alarm.c
+  ${PROFINET_SOURCE_DIR}/src/common/pf_bg_worker.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_cpm.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_dcp.c
   ${PROFINET_SOURCE_DIR}/src/common/pf_eth.c

--- a/test/mocks.cpp
+++ b/test/mocks.cpp
@@ -500,3 +500,13 @@ void mock_pf_fspm_save_im_location (pnet_t * net, const char * location)
       "%-22s",
       location);
 }
+
+void mock_pf_bg_worker_init (pnet_t * net)
+{
+   return;
+}
+
+int mock_pf_bg_worker_start_job (pnet_t * net, pf_bg_job_t job_id)
+{
+   return 0;
+}

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -213,6 +213,10 @@ void mock_pf_fspm_get_im_location (pnet_t * net, char * location);
 
 void mock_pf_fspm_save_im_location (pnet_t * net, const char * location);
 
+void mock_pf_bg_worker_init (pnet_t * net);
+
+int mock_pf_bg_worker_start_job (pnet_t * net, pf_bg_job_t job_id);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This fixes problem with several background worker threads are created during tests. 