### PR TITLE
Validate DCP request length

### DIFF
--- a/src/common/pf_dcp.c
+++ b/src/common/pf_dcp.c
@@ -966,6 +966,11 @@ static int pf_dcp_get_set (
    src_pos += sizeof (pf_dcp_header_t);
    src_dcplen = (src_pos + ntohs (p_src_dcphdr->data_length));
 
+   if (src_dcplen > p_buf->len)
+   {
+      goto out;
+   }
+
    p_rsp = pnal_buf_alloc (PF_FRAME_BUFFER_SIZE); /* Get a transmit buffer
                                                    for the response */
    if (p_rsp == NULL)
@@ -1505,6 +1510,11 @@ static int pf_dcp_identify_req (
    p_src_dcphdr = (pf_dcp_header_t *)&p_src[src_pos];
    src_pos += sizeof (pf_dcp_header_t);
    src_dcplen = (src_pos + ntohs (p_src_dcphdr->data_length));
+
+   if (src_dcplen > p_buf->len)
+   {
+      goto out1;
+   }
 
    p_rsp = pnal_buf_alloc (PF_FRAME_BUFFER_SIZE); /* Get a transmit buffer
                                                    for the response */


### PR DESCRIPTION
Previously there was no validation of the length field in DCP requests, so if
the number of bytes to read in the request was larger than the buffer size
the resulting response would contain data from memory outside the buffer.

Fixes CVE-2022-26849

Closes #490