### PR TITLE
Fix build error for rt-kernel and FreeRTOS ports

### DIFF
--- a/src/ports/STM32Cube/sampleapp_main.c
+++ b/src/ports/STM32Cube/sampleapp_main.c
@@ -89,7 +89,7 @@ int _main (void)
       APP_BG_WORKER_THREAD_STACKSIZE;
 
    /* Initialize profinet stack */
-   sample_app = app_init (&pnet_cfg);
+   sample_app = app_init (&pnet_cfg, &app_args);
    if (sample_app == NULL)
    {
       printf ("Failed to initialize P-Net.\n");

--- a/src/ports/rt-kernel/sampleapp_main.c
+++ b/src/ports/rt-kernel/sampleapp_main.c
@@ -178,7 +178,7 @@ int main (void)
       APP_BG_WORKER_THREAD_STACKSIZE;
 
    /* Initialize profinet stack */
-   sample_app = app_init (&pnet_cfg);
+   sample_app = app_init (&pnet_cfg, &app_args);
    if (sample_app == NULL)
    {
       printf ("Failed to initialize P-Net.\n");


### PR DESCRIPTION
Checked that rt-kernel sample starts up on xmc board and that it can be configured using Proneta tool.