### PR TITLE
Fix reported media type when eth link is down

### DIFF
--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -525,7 +525,9 @@ int pf_pdport_read_ind (
             &peer_station_name,
             &peer_port_name,
             p_port_data,
-            pf_port_get_media_type (eth_status.operational_mau_type),
+            eth_status.running
+               ? pf_port_get_media_type (eth_status.operational_mau_type)
+               : PF_PD_MEDIATYPE_COPPER,
             &eth_status,
             res_size,
             p_res,
@@ -662,7 +664,9 @@ int pf_pdport_read_ind (
                &peer_station_name,
                &peer_port_name,
                p_port_data,
-               pf_port_get_media_type (eth_status.operational_mau_type),
+               eth_status.running
+                  ? pf_port_get_media_type (eth_status.operational_mau_type)
+                  : PF_PD_MEDIATYPE_COPPER,
                &eth_status,
                &port_statistics,
                res_size,


### PR DESCRIPTION
Use correct default media type for unconnected
port. Problem seen in test case Different Access
Ways Port 2 Port when run with LAN9962 setup.