### PR TITLE
Fix problem in PDPortDataCheck

### DIFF
--- a/src/device/pf_pdport.c
+++ b/src/device/pf_pdport.c
@@ -910,8 +910,8 @@ static void pf_pdport_check_peer_port_name (pnet_t * net, int loc_port_num)
       if (
          strncmp (
             lldp_port_id.string,
-            (char *)p_wanted_peer->peer_port_name,
-            lldp_port_id.len) == 0)
+         (char *)p_wanted_peer->peer_port_name,
+         p_wanted_peer->length_peer_port_name) == 0)
       {
          peer_portname_is_correct = true;
       }


### PR DESCRIPTION
Fixes problem detected in ART Tester Diagnosis test. In a setup with two ports,  a port name mismatch diagnosis was set even if device "D" reported the expected LLDP information.

Original problem reproduced on master branch. 
Test passes with this fix added.