### PR TITLE
Correct the accounting of outgoing RPC fragment sizes

### DIFF
--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -4740,6 +4740,13 @@ static int pf_cmrpc_dce_packet (
 
             /* Update how much the controller has received (ack'ed) */
             p_sess->out_buf_sent_pos += p_sess->out_buf_send_len;
+            if (p_sess->out_fragment_nbr > 0)
+            {
+               /* For all but the first fragment, we have accounted for
+                * the header size an additional time. Correct that here.
+                */
+               p_sess->out_buf_sent_pos -= PF_CMRPC_PDU_HEADER_SIZE;
+            }
             p_sess->out_fragment_nbr++;
 
             /* The fragment acknowledgment is valid (expected) */

--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -4422,7 +4422,8 @@ static int pf_cmrpc_dce_packet (
          {
             LOG_ERROR (
                PF_RPC_LOG,
-               "CMRPC(%d): Incoming fragments exceed max buffer\n",
+               "CMRPC(%d): Incoming RPC message exceeds buffer size."
+               " If possible, increase PNET_MAX_SESSION_BUFFER_SIZE.\n",
                __LINE__);
             pf_set_error (
                &p_sess->rpc_result,


### PR DESCRIPTION
For outgoing fragmented RPC messages, the header size was accounted for an extra time for each fragment except the first one. This change corrects that.