### PR TITLE
Fix pnal_buf_free does nothing on non debug builds

### DIFF
--- a/src/ports/STM32Cube/pnal.c
+++ b/src/ports/STM32Cube/pnal.c
@@ -299,7 +299,9 @@ pnal_buf_t * pnal_buf_alloc (uint16_t length)
 
 void pnal_buf_free (pnal_buf_t * p)
 {
-   CC_ASSERT (pbuf_free (p) == 1);
+   int ret = pbuf_free (p);
+   CC_UNUSED (ret);
+   CC_ASSERT (ret == 1);
 }
 
 uint8_t pnal_buf_header (pnal_buf_t * p, int16_t header_size_increment)

--- a/src/ports/STM32Cube/pnal.c
+++ b/src/ports/STM32Cube/pnal.c
@@ -299,7 +299,7 @@ pnal_buf_t * pnal_buf_alloc (uint16_t length)
 
 void pnal_buf_free (pnal_buf_t * p)
 {
-   int ret = pbuf_free (p);
+   u8_t ret = pbuf_free (p);
    CC_UNUSED (ret);
    CC_ASSERT (ret == 1);
 }

--- a/src/ports/iMX8M/pnal.c
+++ b/src/ports/iMX8M/pnal.c
@@ -176,7 +176,9 @@ pnal_buf_t * pnal_buf_alloc (uint16_t length)
 
 void pnal_buf_free (pnal_buf_t * p)
 {
-   CC_ASSERT (pbuf_free (p) == 1);
+   int ret = pbuf_free (p);
+   CC_UNUSED (ret);
+   CC_ASSERT (ret == 1);
 }
 
 uint8_t pnal_buf_header (pnal_buf_t * p, int16_t header_size_increment)

--- a/src/ports/iMX8M/pnal.c
+++ b/src/ports/iMX8M/pnal.c
@@ -176,7 +176,7 @@ pnal_buf_t * pnal_buf_alloc (uint16_t length)
 
 void pnal_buf_free (pnal_buf_t * p)
 {
-   int ret = pbuf_free (p);
+   u8_t ret = pbuf_free (p);
    CC_UNUSED (ret);
    CC_ASSERT (ret == 1);
 }

--- a/src/ports/rt-kernel/pnal.c
+++ b/src/ports/rt-kernel/pnal.c
@@ -368,8 +368,10 @@ pnal_buf_t * pnal_buf_alloc (uint16_t length)
 }
 
 void pnal_buf_free (pnal_buf_t * p)
-{
-   ASSERT (pbuf_free (p) == 1);
+{ 
+   int ret = pbuf_free (p);
+   (void)ret;
+   ASSERT (ret == 1);
 }
 
 uint8_t pnal_buf_header (pnal_buf_t * p, int16_t header_size_increment)

--- a/src/ports/rt-kernel/pnal.c
+++ b/src/ports/rt-kernel/pnal.c
@@ -369,7 +369,7 @@ pnal_buf_t * pnal_buf_alloc (uint16_t length)
 
 void pnal_buf_free (pnal_buf_t * p)
 { 
-   int ret = pbuf_free (p);
+   u8_t ret = pbuf_free (p);
    (void)ret;
    ASSERT (ret == 1);
 }


### PR DESCRIPTION
As asserts only are evaluated on debug builds their calls need to be free of side effects. In this case we leak all pbufs as they were never freed.