### PR TITLE
fix(cmrpc): release session when resend exhaustion aborts the AR

### DIFF
--- a/src/device/pf_cmrpc.c
+++ b/src/device/pf_cmrpc.c
@@ -1135,6 +1135,12 @@ static void pf_cmrpc_send_with_timeout (
                pf_udp_close (p_net, p_sess->socket);
                p_sess->socket = -1;
             }
+            /* Release the session, or it stays in_use forever. With
+             * PF_MAX_SESSION = 2*PNET_MAX_AR + 1 sessions in total, a few
+             * unanswered CControl requests otherwise exhaust the pool and
+             * the device permanently logs "Out of session resources" for
+             * every subsequent incoming frame. */
+            pf_session_release (p_net, p_sess);
          }
          else
          {
@@ -1148,6 +1154,8 @@ static void pf_cmrpc_send_with_timeout (
             p_sess->p_ar->err_code =
                PNET_ERROR_CODE_2_ABORT_AR_RPC_CONTROL_ERROR;
             (void)pf_cmdev_cm_abort (p_net, p_sess->p_ar);
+            /* Same leak as the CControl branch above: release the session. */
+            pf_session_release (p_net, p_sess);
          }
       }
    }


### PR DESCRIPTION
## Symptom

After a few AR churn cycles (controller connects, then aborts or disappears without answering the device's CControl/ApplicationReady request), a p-net device starts logging

```
CMRPC(4331): Out of session resources for incoming frame.
```

for every incoming RPC frame and never recovers. New Connects are still accepted, but record writes and PrmEnd stall until the controller's RPC timeout, and the AR then aborts with `CMSM: Timeout for communication start up` (0xFD/0x06). The device is effectively wedged until restart. A stale scheduler handle from the leaked session also produces `SCHEDULER: Invalid value 0 for timeout "(null)". No removal.`

## Root cause

In `pf_cmrpc_send_with_timeout`, when `resend_counter` is exhausted:

- the `from_me == true` branch (CControl request, no response) aborts the AR and closes the socket, **but never calls `pf_session_release`**;
- the fragment-timeout branch aborts the AR and releases nothing at all.

The session stays `in_use` forever. With `PF_MAX_SESSION = 2 * PNET_MAX_AR + 1` — three sessions in the default single-AR configuration — a handful of unanswered CControls exhausts the pool permanently.

## Fix

Call `pf_session_release` in both exhaustion branches, after the AR abort (mirroring the release the normal completion paths perform).

## Testing

Reproduced with a PROFINET controller performing repeated connect/abort cycles against 32 p-net-based simulated devices (Linux, default options):

- **Before:** each device wedged after ~3 unanswered CControls; subsequent establish attempts crawled (30 s RPC recv timeouts per step) and a 32-device reconnect train that normally takes ~45 s blew past 480 s.
- **After:** three consecutive full 32-device reconnect cycles completed with flat establish times (40/41/40 s) and zero session-exhaustion log lines on sampled devices.

Happy to sign a CLA or rework the patch to your conventions if needed — this is also offered under the project's GPLv3 terms for the dual-license arrangement at your discretion.